### PR TITLE
Moving MParticle-specific messaging logic into a router for reusability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,117 +2,89 @@
 
 ## Android SDK
 
-Hello! This is the public repo of the mParticle Android SDK. Right now, it contains the "kit" implementations and maintains a dependency on the mParticle Core library. 
-
-We originally built the [mParticle platform](https://www.mparticle.com) to help simplify the approach to SDKs and improve app performance. We've found that having a bunch of SDKs in an app bloats its size and is no-good for your users' battery. So, we built client-side APIs for you to collect all of your data, and a server platform that lets you send your data where you want it to go.
-
-From that original goal the platform has grown to support 50+ services and SDKs, including developer tools, analytics, attribution, messaging, and advertising services. mParticle is designed to serve as the connector between all of these services - check out [our site](https://www.mparticle.com), or hit us at dev@mparticle.com to learn more.
-
-## Get the SDK
-
-The SDK is composed of the Core library and a series of "kit" libraries that depend on Core. Though most of mParticle's integrations are on the server-side, some of these services need to be integrated on the client side - and that's where *kits* come in. The Core SDK takes care of initializing the kits depending on what you've configured in [your app's dashboard](https://app.mparticle.com), so you just have to decide which kits you *may* use prior to submission to Google Play. You can easily include all of the kits, none of the kits, or individual kits - the choice is yours.
-
-### Gradle Setup
-
 [![Maven Central Status](https://maven-badges.herokuapp.com/maven-central/com.mparticle/android-core/badge.svg?style=flat-square)](https://search.maven.org/#search%7Cga%7C1%7Cmparticle)
 
-mParticle deploys all artifacts to Maven Central - determine the correct artifact(s) to include in your project from the following options:
+Hello! This is the public repo of the mParticle Android SDK. mParticle's mission is straightforward: make it really easy to use all of the great services in the app ecosystem. Our SDKs and platform are designed to be your abstraction layer and data hub, and we do the work of integrating with each individual app service so you don't have to.
 
-**Option 1:** Include *only* the Core library (`com.mparticle:android-core`). This means that you'll only be using *server-based* integrations.  
-**Option 2:** Pick the Kits (`com.mparticle:android-XXX-kit`) that you'd like to use, and include only those. A Kit will only be instantiated if you configure it in the mParticle services dashboard.  
-**Option 3:** Include all the Kits with the `com.mparticle:android-sdk` artifact.  
+The platform has grown to support 80+ partners in the ecosystem, including developer tools, analytics, attribution, marketing automation, and advertising services. We also have a powerful audience engine that sits atop our platform to let you action on all of your data - [learn more here](https://www.mparticle.com)!
+
+### Core SDK
+
+mParticle's Android integration is powered by a Core library, which supports mParticle's server-side integrations and audience platform.
+
+You can grab the Core SDK via Maven Central. Please reference the badge above and follow the [releases page](https://github.com/mParticle/mparticle-android-sdk/releases) to stay up to date with the latest version.
 
 ```groovy
 dependencies {
-    // Option 1: 
-    // Just the Core library - only use server-side integrations
     compile 'com.mparticle:android-core:4.+'
-    
-    // Option 2: 
-    // Pick the individual kits you want
-    // This will automatically incorporate android-core
-    compile (
-        'com.mparticle:android-adjust-kit:4.+',
-        'com.mparticle:android-appboy-kit:4.+',
-        'com.mparticle:android-branch-kit:4.+'
-    )
-    
-    // Option 3: 
-    // Use this to include ALL kits
-    // This will automatically incorporate android-core
-    compile "com.mparticle:android-sdk:4.+"
-    
-    //Required for many attribution services
-    compile "com.google.android.gms:play-services-ads:7.8.0"
-    
-    //Optional - for Push notification support
-    compile "com.google.android.gms:play-services-gcm:7.8.0"
 }
 ```
 
-Here's the full list of currently supported kits:
+### Kits
 
-- `com.mparticle:android-adjust-kit:4.+`
-- `com.mparticle:android-appsflyer-kit:4.+`
-- `com.mparticle:android-appboy-kit:4.+`
-- `com.mparticle:android-branch-kit:4.+`
-- `com.mparticle:android-comscore-kit:4.+`
-- `com.mparticle:android-crittercism-kit:4.+`
-- `com.mparticle:android-flurry-kit:4.+`
-- `com.mparticle:android-foresee-kit:4.+`
-- `com.mparticle:android-kahuna-kit:4.+`
-- `com.mparticle:android-kochava-kit:4.+`
-- `com.mparticle:android-localytics-kit:4.+`
-- `com.mparticle:android-wootric-kit:4.+`
-- `com.mparticle:android-tune-kit:4.+`
+Several integrations require additional client-side add-on libraries called "kits." Some kits embed other SDKs, others just contain a bit of additional functionality. Kits are designed to feel just like server-side integrations; you enable, disable, filter, sample, and otherwise tweak kits completely from the mParticle platform UI. The Core SDK will detect kits at runtime, but you need to add them as dependencies to your build:
 
-## Proguard
-
-Proguard is a minification/optimization/obfuscation tool that's extremely useful, and it can also cause some sticky bugs. The mParticle SDK is already minified so there's no need to...double-minify it. With Proguard you can specify a set of exclusion rules - reference the sample below and edit your app's rules file to avoid processing mParticle, Google Play Services, and the various Kit SDK classes.
-
-```ini
-# mParticle (required)
--keep class com.mparticle.** { *; }
-
-# Google Play Services (required)
--keep class com.google.android.gms.common.** { *; }
--keep class com.google.android.gms.ads.identifier.** { *; }
-
-# Appboy Kit
--dontwarn com.amazon.device.messaging.**
--dontwarn bo.app.**
--keep class bo.app.** { *; } 
--keep class com.appboy.** { *; }
-
-# Kahuna Kit
--keep class kahuna.sdk.** { *; } 
-
-# Kochava Kit
--keep class kochava.android.** { *; } 
-
-# Comscore Kit
--keep class com.comscore.** { *; } 
--dontwarn com.comscore.**
-
-# Flurry Kit
--keep class com.flurry.** { *; }
--dontwarn com.flurry.**
-
-# Localytics Kit
--keep class com.localytics.android.** { *; }
--keepattributes JavascriptInterface
-
-# Wootric Kit
--keep class com.wootric.** { *; }
--keep class retrofit.** { *; }
--keepclassmembernames interface * {
-    @retrofit.http.* <methods>;
+```groovy
+dependencies {
+    compile (
+        'com.mparticle:android-example-kit:4.+',
+        'com.mparticle:android-another-kit:4.+',
+    )
 }
+```
+
+Kits are deployed as individual artifacts in Maven Central, and each has a dedicated repository if you'd like to view the source code. Review the table below to see if you need to include any kits:
+
+Kit | Maven Artifact 
+----|---------
+[Adjust](https://github.com/mparticle-integrations/mparticle-android-integration-adjust)                |  [`android-adjust-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-adjust-kit%22)
+[Appboy](https://github.com/mparticle-integrations/mparticle-android-integration-appboy)                |  [`android-appboy-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-appboy-kit%22) 
+[AppsFlyer](https://github.com/mparticle-integrations/mparticle-android-integration-appsflyer)          |  [`android-appsflyer-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-appsflyer-kit%22)
+[Apptentive](https://github.com/mparticle-integrations/mparticle-android-integration-apptentive)          |  [`android-apptentive-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-apptentive-kit%22)
+[Apteligent](https://github.com/mparticle-integrations/mparticle-android-integration-apteligent)        |  [`android-apteligent-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-apteligent-kit%22)
+[Branch Metrics](https://github.com/mparticle-integrations/mparticle-android-integration-branchmetrics) |  [`android-branch-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-branch-kit%22)
+[comScore](https://github.com/mparticle-integrations/mparticle-android-integration-comscore)            |  [`android-comscore-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-comscore-kit%22)
+[Flurry](https://github.com/mparticle-integrations/mparticle-android-integration-flurry)                |  [`android-flurry-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-flurry-kit%22)
+[Kahuna](https://github.com/mparticle-integrations/mparticle-android-integration-kahuna)                |  [`android-kahuna-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-kahuna-kit%22)
+[Kochava](https://github.com/mparticle-integrations/mparticle-android-integration-kochava)              |  [`android-kochava-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-kochava-kit%22)
+[Localytics](https://github.com/mparticle-integrations/mparticle-android-integration-localytics)        |  [`android-localytics-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-localytics-kit%22)
+[Tune](https://github.com/mparticle-integrations/mparticle-android-integration-tune)                    |  [`android-tune-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-tune-kit%22)
+[Wootric](https://github.com/mparticle-integrations/mparticle-android-integration-wootric)              |  [`android-wootric-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-wootric-kit%22)
+
+
+### Optional Dependencies
+
+##### Google Play Services Ads
+
+The Google Play Services Ads framework is necessary to collect the Android Advertisting ID. AAID collection is required by all attribution and audience integrations, and many other integrations. Include the `-ads` artifact, a subset of [Google Play Services](https://developers.google.com/android/guides/setup):
+
+```groovy
+    compile 'com.google.android.gms:play-services-ads:9.0.0'
+```
+
+##### Google Cloud Messaging
+
+mParticle supports several marketing automation and push messaging integrations. These require that mParticle register for an instance id (formely known as a push registration token) using the Google Play Services Cloud Messaging framework. Include the `-gcm` artifact, a subset of [Google Play Services](https://developers.google.com/android/guides/setup):
+
+```groovy
+    compile 'com.google.android.gms:play-services-gcm:9.0.0'
+```
+
+### Install Referrer
+
+In order for attribution, deep linking, and many other integrations to work properly, add the mParticle `ReferrerReceiver` to your manifest file within the `<application>` tag:
+
+```xml
+<receiver android:name="com.mparticle.ReferrerReceiver" android:exported="true">
+    <intent-filter>
+        <action android:name="com.android.vending.INSTALL_REFERRER"/>
+    </intent-filter>
+</receiver>
 ```
 
 ## Show me the code
 
-OK OK, slow down. Grab your mParticle key and secret from [your app's dashboard](https://app.mparticle.com/apps) and add them as `string` resources in your app:
+Grab your mParticle key and secret from [your app's dashboard](https://app.mparticle.com/apps) and add them as `string` resources in your app:
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -122,10 +94,11 @@ OK OK, slow down. Grab your mParticle key and secret from [your app's dashboard]
     <string name="mp_secret">APP SECRET</string>
 </resources>
 ```
+> You can also pass your key/secret programmatically in the method below.
 
 #### Initialize the SDK
 
-Call `start` from the `onCreate` method of your app's `Application` class. If you don't already have an `Application` class, create it and then specify its fully-qualified name in the `<application>` tag of your app's `AndroidManifest.xml`.
+Call `start` from the `onCreate` method of your app's `Application` class. It's crucial that the SDK be started here for proper session management. If you don't already have an `Application` class, create it and then specify its fully-qualified name in the `<application>` tag of your app's `AndroidManifest.xml`.
 
 ```java
 package com.example.myapp;
@@ -142,7 +115,11 @@ public class MyApplication extends Application {
 }
 ```
 
-**Note:** It's not advisable to log events in your `Application.onCreate()`. Android may instantiate your `Application` class for a lot of reasons, in the background, while the user isn't even using their device. 
+> **Warning:** It's generally not a good idea to log events in your `Application.onCreate()`. Android may instantiate your `Application` class for a lot of reasons, in the background, while the user isn't even using their device. 
+
+#### Proguard
+
+Proguard is a minification/optimization/obfuscation tool that's extremely useful, and it can also cause some sticky bugs. The mParticle SDK is already minified so there's no need to...double-minify it. If you're using Gradle there's nothing to do - we include a `consumer-proguard` rules file inside our `AAR` which Gradle will automatically include in your build. If you're not using Gradle, please add those same rules manually - [see here for the latest](https://github.com/mParticle/mparticle-android-sdk/blob/master/android-core/consumer-proguard.pro). 
 
 ## Read More
 
@@ -154,4 +131,3 @@ Just by initializing the SDK you'll be set up to track user installs, engagement
 ## License
 
 [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
-

--- a/android-core/src/main/java/com/mparticle/internal/MParticleApiClientImpl.java
+++ b/android-core/src/main/java/com/mparticle/internal/MParticleApiClientImpl.java
@@ -36,6 +36,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
@@ -289,10 +290,10 @@ public class MParticleApiClientImpl implements MParticleApiClient {
         }
     }
 
-    private void addMessageSignature(HttpURLConnection request, String message) {
+    void addMessageSignature(HttpURLConnection request, String message) {
         try {
             String method = request.getRequestMethod();
-            SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+            SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
             String dateHeader = format.format(new Date());
             String path = request.getURL().getFile();
             StringBuilder hashString = new StringBuilder()

--- a/android-core/src/main/java/com/mparticle/messaging/MPMessagingRouter.java
+++ b/android-core/src/main/java/com/mparticle/messaging/MPMessagingRouter.java
@@ -1,0 +1,40 @@
+package com.mparticle.messaging;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.mparticle.MPService;
+
+public class MPMessagingRouter {
+    /**
+     * Parses the incoming intent and delegates functionality to the given {@code callback} if appropriate. This implementation checks for
+     * MParticle-specific actions and will not handle messages outside of that scope. MParticle actions can be found in
+     * {@link MPMessagingAPI} {@code BROADCAST_*} constants
+     *
+     * @param context
+     * @param intent
+     * @param callback
+     * @return {@code true} if the {@link Intent} was handled by MParticle
+     */
+    public static boolean onReceive(Context context, Intent intent, PushAnalyticsReceiverCallback callback) {
+        if (MPMessagingAPI.BROADCAST_NOTIFICATION_TAPPED.equalsIgnoreCase(intent.getAction())) {
+            AbstractCloudMessage message = intent.getParcelableExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA);
+            CloudAction action = intent.getParcelableExtra(MPMessagingAPI.CLOUD_ACTION_EXTRA);
+            if (!callback.onNotificationTapped(message, action)) {
+                intent.putExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA, message);
+                intent.putExtra(MPMessagingAPI.CLOUD_ACTION_EXTRA, action);
+                MPService.runIntentInService(context, intent);
+            }
+            return true;
+        } else if (MPMessagingAPI.BROADCAST_NOTIFICATION_RECEIVED.equalsIgnoreCase(intent.getAction())) {
+            AbstractCloudMessage message = intent.getParcelableExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA);
+            if (!callback.onNotificationReceived(message)) {
+                intent.putExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA, message);
+                MPService.runIntentInService(context, intent);
+            }
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/android-core/src/main/java/com/mparticle/messaging/PushAnalyticsReceiver.java
+++ b/android-core/src/main/java/com/mparticle/messaging/PushAnalyticsReceiver.java
@@ -4,8 +4,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-import com.mparticle.MPService;
-
 /**
  * <code>BroadcastReceiver</code> to be used to listen for, manipulate, and react to GCM notifications.
  *
@@ -26,63 +24,20 @@ import com.mparticle.MPService;
  * @see #onNotificationTapped(AbstractCloudMessage, CloudAction)
  *
  */
-public class PushAnalyticsReceiver extends BroadcastReceiver {
-    private Context mContext = null;
-
+public class PushAnalyticsReceiver extends BroadcastReceiver implements PushAnalyticsReceiverCallback {
 
     @Override
     public final void onReceive(Context context, Intent intent) {
-        mContext = context;
-        if (MPMessagingAPI.BROADCAST_NOTIFICATION_TAPPED.equalsIgnoreCase(intent.getAction())){
-            AbstractCloudMessage message = intent.getParcelableExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA);
-            CloudAction action = intent.getParcelableExtra(MPMessagingAPI.CLOUD_ACTION_EXTRA);
-            if (!onNotificationTapped(message, action)){
-                intent.putExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA, message);
-                intent.putExtra(MPMessagingAPI.CLOUD_ACTION_EXTRA, action);
-                MPService.runIntentInService(context, intent);
-            }
-            return;
-        } else if (MPMessagingAPI.BROADCAST_NOTIFICATION_RECEIVED.equalsIgnoreCase(intent.getAction())){
-            AbstractCloudMessage message = intent.getParcelableExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA);
-            if (!onNotificationReceived(message)){
-                intent.putExtra(MPMessagingAPI.CLOUD_MESSAGE_EXTRA, message);
-                MPService.runIntentInService(context, intent);
-            }
-            return;
-        }
-
+        MPMessagingRouter.onReceive(context, intent, this);
     }
 
-    /**
-     * Helper method to retrieve the Context that was passed into this <code>BroadcastReceiver</code>
-     *
-     * @return Context object
-     */
-    protected final Context getContext(){
-        return mContext;
-    }
-
-    /**
-     * Override this method to listen for when a notification has been received.
-     *
-     *
-     * @param message The message that was received. Depending on the push provider, could be either a {@link com.mparticle.messaging.MPCloudNotificationMessage} or a {@link com.mparticle.messaging.ProviderCloudMessage}
-     * @return True if you would like to handle this notification, False if you would like the mParticle to generate and show a {@link android.app.Notification}.
-     */
-    protected boolean onNotificationReceived(AbstractCloudMessage message){
+    @Override
+    public boolean onNotificationReceived(AbstractCloudMessage message) {
         return false;
     }
 
-    /**
-     * Override this method to listen for when a notification has been tapped or acted on.
-     *
-     *
-     * @param message The message that was tapped. Depending on the push provider, could be either a {@link com.mparticle.messaging.MPCloudNotificationMessage} or a {@link com.mparticle.messaging.ProviderCloudMessage}
-     * @param action The action that the user acted on.
-     * @return True if you would like to consume this tap/action, False if the mParticle SDK should attempt to handle it.
-     */
-    protected boolean onNotificationTapped(AbstractCloudMessage message, CloudAction action){
+    @Override
+    public boolean onNotificationTapped(AbstractCloudMessage message, CloudAction action) {
         return false;
     }
-
 }

--- a/android-core/src/main/java/com/mparticle/messaging/PushAnalyticsReceiverCallback.java
+++ b/android-core/src/main/java/com/mparticle/messaging/PushAnalyticsReceiverCallback.java
@@ -1,0 +1,22 @@
+package com.mparticle.messaging;
+
+public interface PushAnalyticsReceiverCallback {
+    /**
+     * Override this method to listen for when a notification has been received.
+     *
+     *
+     * @param message The message that was received. Depending on the push provider, could be either a {@link com.mparticle.messaging.MPCloudNotificationMessage} or a {@link com.mparticle.messaging.ProviderCloudMessage}
+     * @return True if you would like to handle this notification, False if you would like the mParticle to generate and show a {@link android.app.Notification}.
+     */
+    boolean onNotificationReceived(AbstractCloudMessage message);
+
+    /**
+     * Override this method to listen for when a notification has been tapped or acted on.
+     *
+     *
+     * @param message The message that was tapped. Depending on the push provider, could be either a {@link com.mparticle.messaging.MPCloudNotificationMessage} or a {@link com.mparticle.messaging.ProviderCloudMessage}
+     * @param action The action that the user acted on.
+     * @return True if you would like to consume this tap/action, False if the mParticle SDK should attempt to handle it.
+     */
+    boolean onNotificationTapped(AbstractCloudMessage message, CloudAction action);
+}

--- a/android-core/src/test/java/com/mparticle/internal/KitFrameworkWrapperTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/KitFrameworkWrapperTest.java
@@ -1,0 +1,331 @@
+package com.mparticle.internal;
+
+import android.content.Context;
+
+import com.mparticle.MPEvent;
+import com.mparticle.commerce.CommerceEvent;
+import com.mparticle.messaging.PushAnalyticsReceiver;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+public class KitFrameworkWrapperTest {
+
+    @Test
+    public void testLoadKitLibrary() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+
+        assertFalse(wrapper.getKitsLoaded());
+        assertFalse(wrapper.getFrameworkLoadAttempted());
+
+        wrapper.loadKitLibrary();
+
+        assertTrue(wrapper.getFrameworkLoadAttempted());
+        assertTrue(wrapper.getKitsLoaded());
+
+    }
+
+    @Test
+    public void testDisableQueuing() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertFalse(wrapper.getKitsLoaded());
+        wrapper.setKitsLoaded(false);
+        MPEvent event = new MPEvent.Builder("example").build();
+
+        wrapper.logEvent(event);
+        assertEquals(event, wrapper.getEventQueue().peek());
+        wrapper.disableQueuing();
+        assertTrue(wrapper.getKitsLoaded());
+        assertNull(wrapper.getEventQueue());
+    }
+
+    @Test
+    @PrepareForTest({PushRegistrationHelper.class, CommerceEvent.class})
+    public void testReplayEvents() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        wrapper.replayEvents();
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+        PowerMockito.mockStatic(PushRegistrationHelper.class);
+        PushRegistrationHelper.PushRegistration registration = new PushRegistrationHelper.PushRegistration();
+        registration.instanceId = "instance id";
+        registration.senderId = "1234545";
+        Mockito.when(
+                PushRegistrationHelper.getLatestPushRegistration(Mockito.any(Context.class))
+        ).thenReturn(registration);
+
+        wrapper.replayEvents();
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).onPushRegistration(Mockito.anyString(), Mockito.anyString());
+
+        wrapper.onPushRegistration("whatever", "whatever");
+        wrapper.replayEvents();
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).onPushRegistration(Mockito.anyString(), Mockito.anyString());
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).checkForDeepLink();
+
+        wrapper.checkForDeepLink();
+        wrapper.replayEvents();
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).checkForDeepLink();
+
+        wrapper.setKitsLoaded(false);
+        MPEvent event = new MPEvent.Builder("example").build();
+        MPEvent screenEvent = Mockito.mock(MPEvent.class);
+        CommerceEvent commerceEvent = PowerMockito.mock(CommerceEvent.class);
+        Mockito.when(screenEvent.isScreenEvent()).thenReturn(true);
+        wrapper.logEvent(event);
+        wrapper.logEvent(screenEvent);
+        wrapper.logCommerceEvent(commerceEvent);
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).logEvent(Mockito.any(MPEvent.class));
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).logScreen(Mockito.any(MPEvent.class));
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).logCommerceEvent(Mockito.any(CommerceEvent.class));
+
+        wrapper.replayEvents();
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).logEvent(Mockito.any(MPEvent.class));
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).logScreen(Mockito.any(MPEvent.class));
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).logCommerceEvent(Mockito.any(CommerceEvent.class));
+
+
+
+    }
+
+    @Test
+    public void testReplayAndDisableQueue() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        wrapper.setKitsLoaded(false);
+        wrapper.replayAndDisableQueue();
+        assertTrue(wrapper.getKitsLoaded());
+    }
+
+    @Test
+    public void testQueueEvent() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertNull(wrapper.getEventQueue());
+        wrapper.setKitsLoaded(false);
+        MPEvent event = Mockito.mock(MPEvent.class);
+        wrapper.queueEvent(event);
+        assertEquals(wrapper.getEventQueue().peek(), event);
+
+        for (int i = 0 ; i < 50; i++) {
+            wrapper.queueEvent(event);
+        }
+        assertEquals(10, wrapper.getEventQueue().size());
+    }
+
+    @Test
+    public void testLogEvent() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertNull(wrapper.getEventQueue());
+        wrapper.setKitsLoaded(false);
+        MPEvent event = Mockito.mock(MPEvent.class);
+        wrapper.logEvent(event);
+        assertEquals(wrapper.getEventQueue().peek(), event);
+
+        for (int i = 0 ; i < 50; i++) {
+            wrapper.logEvent(event);
+        }
+        assertEquals(10, wrapper.getEventQueue().size());
+
+        wrapper.setKitsLoaded(true);
+
+        wrapper.logEvent(event);
+
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).logEvent(Mockito.any(MPEvent.class));
+
+        wrapper.logEvent(event);
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).logEvent(Mockito.any(MPEvent.class));
+    }
+
+    @Test
+    @PrepareForTest({CommerceEvent.class})
+    public void testLogCommerceEvent() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertNull(wrapper.getEventQueue());
+        wrapper.setKitsLoaded(false);
+        CommerceEvent event = Mockito.mock(CommerceEvent.class);
+        wrapper.logCommerceEvent(event);
+        assertEquals(wrapper.getEventQueue().peek(), event);
+
+        for (int i = 0 ; i < 50; i++) {
+            wrapper.logCommerceEvent(event);
+        }
+        assertEquals(10, wrapper.getEventQueue().size());
+
+        wrapper.setKitsLoaded(true);
+
+        wrapper.logCommerceEvent(event);
+
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).logCommerceEvent(Mockito.any(CommerceEvent.class));
+
+        wrapper.logCommerceEvent(event);
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).logCommerceEvent(Mockito.any(CommerceEvent.class));
+    }
+
+    @Test
+    public void testLogScreen() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertNull(wrapper.getEventQueue());
+        wrapper.setKitsLoaded(false);
+        MPEvent event = Mockito.mock(MPEvent.class);
+        Mockito.when(event.isScreenEvent()).thenReturn(true);
+        wrapper.logScreen(event);
+        assertEquals(wrapper.getEventQueue().peek(), event);
+
+        for (int i = 0 ; i < 50; i++) {
+            wrapper.logScreen(event);
+        }
+        assertEquals(10, wrapper.getEventQueue().size());
+
+        wrapper.setKitsLoaded(true);
+
+        wrapper.logScreen(event);
+
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).logScreen(Mockito.any(MPEvent.class));
+
+        wrapper.logScreen(event);
+
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).logScreen(Mockito.any(MPEvent.class));
+    }
+
+    @Test
+    public void testCheckForDeepLink() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertFalse(wrapper.getShouldCheckForDeepLink());
+        wrapper.setKitsLoaded(false);
+        wrapper.checkForDeepLink();
+        assertTrue(wrapper.getShouldCheckForDeepLink());
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+        wrapper.checkForDeepLink();
+        Mockito.verify(
+                mockKitManager, Mockito.times(0)
+        ).checkForDeepLink();
+
+        wrapper.setKitsLoaded(true);
+
+        wrapper.checkForDeepLink();
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).checkForDeepLink();
+
+    }
+
+    @Test
+    public void testIsKitActive() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertFalse(wrapper.isKitActive(0));
+
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+        assertFalse(wrapper.isKitActive(0));
+        Mockito.verify(
+                mockKitManager, Mockito.times(1)
+        ).isKitActive(Mockito.anyInt());
+
+        Mockito.when(mockKitManager.isKitActive(Mockito.anyInt())).thenReturn(true);
+        assertTrue(wrapper.isKitActive(0));
+    }
+
+    @Test
+    public void testGetSupportedKits() throws Exception {
+        KitFrameworkWrapper wrapper = new KitFrameworkWrapper(Mockito.mock(Context.class),
+                Mockito.mock(ReportingManager.class),
+                Mockito.mock(ConfigManager.class),
+                Mockito.mock(AppStateManager.class));
+        assertNull(wrapper.getSupportedKits());
+
+        KitManager mockKitManager = Mockito.mock(KitManager.class);
+        wrapper.setKitManager(mockKitManager);
+        Set<Integer> supportedKits = new HashSet<Integer>();
+        supportedKits.add(3);
+        Mockito.when(mockKitManager.getSupportedKits()).thenReturn(supportedKits);
+        assertEquals(wrapper.getSupportedKits(), supportedKits);
+    }
+}

--- a/android-core/src/test/java/com/mparticle/internal/MParticleApiClientImplTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/MParticleApiClientImplTest.java
@@ -18,7 +18,6 @@ import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
-import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -162,7 +161,13 @@ public class MParticleApiClientImplTest {
         setup();
         PowerMockito.mockStatic(MPUtility.class);
         Mockito.when(MPUtility.hmacSha256Encode(Mockito.anyString(), Mockito.anyString())).thenReturn("encoded");
-        client.sendMessageBatch("");
+        try {
+            client.sendMessageBatch("");
+        }catch (Exception e) {
+            if (e instanceof MParticleApiClientImpl.MPThrottleException) {
+                throw e;
+            }
+        }
         client.setNextRequestTime(System.currentTimeMillis() + 1000);
         Exception e = null;
         try {

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -453,7 +453,7 @@ public class KitConfiguration {
             }
             if (attributes.getRevenue() != null &&
                     !mCommerceAttributeFilters.get(MPUtility.mpHash(eventType + Constants.Commerce.ATT_TOTAL), true)) {
-                attributes.setRevenue(null);
+                attributes.setRevenue(0.0);
             }
             if (attributes.getId() != null &&
                     !mCommerceAttributeFilters.get(MPUtility.mpHash(eventType + Constants.Commerce.ATT_TRANSACTION_ID), true)) {


### PR DESCRIPTION
Core changes:

 - `PushAnalyticsReceiver#onNotification*` methods are now part of an interface (`PushAnalyticsReceiverCallback`)
 - `PushAnalyticsReceiver` now delegates processing of the intent and calling of callbacks into `MPMessagingRouter`
 - `MPMessagingRouter` abides by a contract of only consuming what it should, and lets the caller know if the given `Intent` was consumed