### PR TITLE
Add consumer proguard rule to guard reflective access

### DIFF
--- a/android-core/consumer-proguard.pro
+++ b/android-core/consumer-proguard.pro
@@ -1,3 +1,4 @@
 #these are the rules that are packaged with the Core SDK .aar to be used in consuming apps.
 -keep class com.mparticle.** { *; }
 -dontwarn com.mparticle.**
+-keep class com.google.android.gms.ads.identifier.** { *; }


### PR DESCRIPTION
[MParticleUtility.getGoogleAdIdInfo()](https://github.com/mParticle/mparticle-android-sdk/blob/master/android-core/src/main/java/com/mparticle/internal/MPUtility.java#L113) attempts to reference com.google.android.gms.ads.identifier.AdvertisingIdClient using reflection

Guarding the package with a proguard rule increases the likelihood of success for the library code
