### PR TITLE
Update Proguard config

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ public class MyApplication extends Application {
 
 #### Proguard
 
-Proguard is a minification/optimization/obfuscation tool that's extremely useful, and it can also cause some sticky bugs. The mParticle SDK is already minified so there's no need to...double-minify it. If you're using Gradle there's nothing to do - we include a `consumer-proguard` rules file inside our `AAR` which Gradle will automatically include in your build. If you're not using Gradle, please add those same rules manually - [see here for the latest](https://github.com/mParticle/mparticle-android-sdk/blob/master/android-core/consumer-proguard.pro). 
+Proguard is a minification/optimization/obfuscation tool that's extremely useful, and it can also cause some sticky bugs. The mParticle SDK is already minified. If you're using Gradle there's nothing to do - we include a `consumer-proguard` rules file inside our `AAR` which Gradle will automatically include in your build. If you're not using Gradle, please add those same rules manually - [see here for the latest](https://github.com/mParticle/mparticle-android-sdk/blob/master/android-core/consumer-proguard.pro). 
 
 ## Read More
 

--- a/android-core/consumer-proguard.pro
+++ b/android-core/consumer-proguard.pro
@@ -1,3 +1,12 @@
-#these are the rules that are packaged with the Core SDK .aar to be used in consuming apps.
--keep class com.mparticle.** { *; }
--dontwarn com.mparticle.**
+# These are the rules that are packaged with the Core SDK .aar to be used in consuming apps.
+
+# The mParticle SDK is reading the Android Advertisment ID via reflection so it can get arround depending on
+# com.google.android.gms:play-services-ads-identifier.
+
+-keep public class com.google.android.gms.ads.identifier.AdvertisingIdClient {
+    public static com.google.android.gms.ads.identifier.AdvertisingIdClient$Info getAdvertisingIdInfo(android.content.Context);
+}
+-keep public final class com.google.android.gms.ads.identifier.AdvertisingIdClient$Info {
+    java.lang.String getId();
+    boolean isLimitAdTrackingEnabled();
+}


### PR DESCRIPTION
## Summary

It's not a good idea to keep `com.mparticle.** { *; }` because even though the SDK is already proguarded there are still parts of it that might not be used by an app implementing it and those need to be removed.

Added rule to keep the Advertisment Id code as it is accessed via reflection from mParticle SDK and needs to be kept in order access it.

## Testing Plan

Still needs to be tested, this is just a suggestion.

## Master Issue

