### PR TITLE
OneTrust Kit updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -91,3 +91,6 @@
 [submodule "kits/googleanalyticsfirebase-kit"]
 	path = kits/googleanalyticsfirebase-kit
 	url = git@github.com:mparticle-integrations/mparticle-android-integration-google-analytics-firebase.git
+[submodule "kits/onetrust-kit"]
+	path = kits/onetrust-kit
+	url = git@github.com:Zentrust/mparticle-android-integration-example.git

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -1498,6 +1498,7 @@ public class MParticle {
         int OPTIMIZELY = 54;
         int RESPONSYS = 102;
         int CLEVERTAP = 135;
+        int ONETRUST = 134;
         int GOOGLE_ANALYTICS_FIREBASE = 136;
         @NonNull String BROADCAST_ACTIVE = "MPARTICLE_SERVICE_PROVIDER_ACTIVE_";
         @NonNull String BROADCAST_DISABLED = "MPARTICLE_SERVICE_PROVIDER_DISABLED_";

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
@@ -56,6 +56,7 @@ public class KitIntegrationFactory {
         kits.put(MParticle.ServiceProviders.RESPONSYS,                  "com.mparticle.kits.ResponsysKit");
         kits.put(MParticle.ServiceProviders.CLEVERTAP,                  "com.mparticle.kits.CleverTapKit");
         kits.put(MParticle.ServiceProviders.GOOGLE_ANALYTICS_FIREBASE,  "com.mparticle.kits.GoogleAnalyticsFirebaseKit");
+        kits.put(MParticle.ServiceProviders.ONETRUST,                   "com.mparticle.kits.OneTrustKit");
         return kits;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        mavenLocal()
         jcenter()
         google()
     }

--- a/settings-kits.gradle
+++ b/settings-kits.gradle
@@ -30,6 +30,7 @@ include (
         ':kits:responsys-kit',
         ':kits:clevertap-kit',
         ':kits:googleanalyticsfirebase-kit',
+        ':kits:onetrust-kit',
 	    ':testutils',
         ':android-core',
         ':android-kit-base'


### PR DESCRIPTION
## Summary
Only changes made outside of Android kit setup instructions was to add our functional code in the kit. Functional code is saving mParticle mapping JSON to device so OneTrust SDK can retrieve when needed. 

## Testing Plan
Testing has included the following:
- mParticle mapping JSON is saved correctly
- OneTrust SDK can correctly retrieve the mapping JSON

## Master Issue
Closes mParticle/issues#
