### PR TITLE
fix: Update Semantic release configurations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       - name: "Commit Kit Updates"
         run: |
           git add .
-          git diff-index --quiet HEAD || git commit -m 'feat: Update Submodules'
+          git diff-index --quiet HEAD || git commit -m 'ci: Update Submodules'
       - name: "Push kit updates to release branch"
         run: git push origin release/${{ github.run_number }}
 

--- a/release.config.js
+++ b/release.config.js
@@ -7,6 +7,18 @@ module.exports = {
       {
         preset: "angular",
       },
+      "releaseRules": [
+        {type: 'feat', release: 'minor'},
+        {type: 'ci', release: 'patch'},
+        {type: 'fix', scope: 'patch'},
+        {type: 'docs', release: 'patch'},
+        {type: 'test', release: 'patch'},
+        {type: 'refactor', release: 'patch'},
+        {type: 'style', release: 'patch'},
+        {type: 'build', release: 'patch'},
+        {type: 'chore', release: 'patch'},
+        {type: 'revert', release: 'patch'}
+       ]
     ],
     [
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Summary
Add explicit versioning rules for all the valid commit prefixes we use

Reword kit update commit message to be prefixed with `"ci:` so that semantic release only does a patch update

## Testing Plan
Run release job

## Master Issue
Closes https://go.mparticle.com/work/75621
