### PR TITLE
fix: change localbroadcastmanager back to compile in pom.xml

### DIFF
--- a/android-core/build.gradle
+++ b/android-core/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     compileOnly 'androidx.annotation:annotation:[1.0.0,)'
     compileOnly 'androidx.core:core:[1.3.2, )'
 
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:[1.0.0, )'
+    api 'androidx.localbroadcastmanager:localbroadcastmanager:[1.0.0, )'
 
     lintPublish project( path: ':tooling:custom-lint-rules', configuration: 'lintBuild')
 


### PR DESCRIPTION
## Summary
- Change `localbroadcastmanager` from `implementation` to `api` to output `compile` instead of `runtime` in `pom.xml` file.  Our previous AGP 7 upgrade changed some behavior.

## Testing Plan
- normal regression tests should pass
