### PR TITLE
feat: Add configMaxAge to MParticleOptions

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
@@ -425,4 +425,35 @@ public class MParticleOptionsTest extends BaseAbstractTest {
         assertTrue(com.mparticle.networking.AccessUtils.equals(options.getNetworkOptions(), com.mparticle.networking.AccessUtils.getDefaultNetworkOptions()));
     }
 
+    @Test
+    public void testConfigStaleness() {
+        //nothing set, should return null
+        MParticleOptions options = MParticleOptions.builder(mContext)
+                .credentials("key", "secret")
+                .build();
+        assertNull(options.getConfigMaxAge());
+
+        //0 should return 0
+        options = MParticleOptions.builder(mContext)
+                .credentials("key", "secret")
+                .configMaxAgeSeconds(0)
+                .build();
+        assertEquals(0, options.getConfigMaxAge().intValue());
+
+        //positive number should return positive number
+        int testValue = Math.abs(ran.nextInt());
+        options = MParticleOptions.builder(mContext)
+                .credentials("key", "secret")
+                .configMaxAgeSeconds(testValue)
+                .build();
+        assertEquals(testValue, options.getConfigMaxAge().intValue());
+
+        //negative number should get thrown out and return null
+        options = MParticleOptions.builder(mContext)
+                .credentials("key", "secret")
+                .configMaxAgeSeconds(-5)
+                .build();
+        assertNull(options.getConfigMaxAge());
+    }
+
 }

--- a/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
@@ -436,22 +436,22 @@ public class MParticleOptionsTest extends BaseAbstractTest {
         //0 should return 0
         options = MParticleOptions.builder(mContext)
                 .credentials("key", "secret")
-                .configMaxAgeSeconds(0)
+                .configMaxAgeSeconds(0L)
                 .build();
         assertEquals(0, options.getConfigMaxAge().intValue());
 
         //positive number should return positive number
-        int testValue = Math.abs(ran.nextInt());
+        Long testValue = Math.abs(ran.nextLong());
         options = MParticleOptions.builder(mContext)
                 .credentials("key", "secret")
                 .configMaxAgeSeconds(testValue)
                 .build();
-        assertEquals(testValue, options.getConfigMaxAge().intValue());
+        assertEquals(testValue, options.getConfigMaxAge());
 
         //negative number should get thrown out and return null
         options = MParticleOptions.builder(mContext)
                 .credentials("key", "secret")
-                .configMaxAgeSeconds(-5)
+                .configMaxAgeSeconds(-5L)
                 .build();
         assertNull(options.getConfigMaxAge());
     }

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
@@ -1,0 +1,199 @@
+package com.mparticle.internal
+
+import com.mparticle.MParticle
+import com.mparticle.MParticleOptions
+import com.mparticle.testutils.BaseCleanInstallEachTest
+import com.mparticle.testutils.MPLatch
+import org.json.JSONObject
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
+    val configManager: ConfigManager
+        get() = MParticle.getInstance()?.Internal()?.configManager.assertNotNull()
+
+    @Test
+    fun testNeverStale() {
+        val config1 = randomJson(4)
+        val config2 = randomJson(4);
+        var latch = MPLatch(1);
+        val options = MParticleOptions.builder(mContext)
+            .addCredentials()
+            .build()
+
+        mServer.setupConfigResponse(config1.toString())
+
+        MParticle.start(options)
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        assertEquals(config1.toString(), configManager.config)
+        val etag = configManager.etag
+        val lastModified = configManager.ifModified
+        val timestamp = configManager.configTimestamp
+
+        MParticle.setInstance(null)
+        mServer.setupConfigResponse(config2.toString())
+
+        MParticle.start(options)
+        latch = MPLatch(1)
+        configManager.onNewConfig { latch.countDown() }
+
+        //after restart, we should still have config1
+        assertEquals(config1.toString(), configManager.config)
+        assertEquals(etag, configManager.etag)
+        assertEquals(lastModified, configManager.ifModified)
+        assertEquals(timestamp, configManager.configTimestamp)
+
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        assertEquals(config2.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+    }
+
+
+
+    @Test
+    fun testExceedStalenessThreshold() {
+        val config1 = randomJson(4)
+        val config2 = randomJson(4);
+        var latch = MPLatch(1);
+        val options = MParticleOptions.builder(mContext)
+            .addCredentials()
+            .configMaxAgeSeconds(1)
+            .build()
+
+        mServer.setupConfigResponse(config1.toString())
+
+        MParticle.start(options)
+
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        assertEquals(config1.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+
+        MParticle.setInstance(null)
+
+        Thread.sleep(1010);
+
+        mServer.setupConfigResponse(config2.toString())
+
+        MParticle.start(options)
+        latch = MPLatch(1)
+
+        //after configMaxAge time has elapsed, config should be cleared after restart
+        assertNull(configManager.config)
+        assertNull(configManager.etag)
+        assertNull(configManager.ifModified)
+        assertNull(configManager.configTimestamp)
+
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        //after config has been fetched, we should see config2
+        assertEquals(config2.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+    }
+
+    @Test
+    fun testDoesntExceedStalenessThreshold() {
+        val config1 = randomJson(4)
+        val config2 = randomJson(4);
+        var latch = MPLatch(1);
+        val options = MParticleOptions.builder(mContext)
+            .addCredentials()
+            .configMaxAgeSeconds(100)
+            .build()
+
+        mServer.setupConfigResponse(config1.toString())
+
+        MParticle.start(options)
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        assertEquals(config1.toString(), configManager.config)
+        val etag = configManager.etag
+        val lastModified = configManager.ifModified
+        val timestamp = configManager.configTimestamp
+
+        MParticle.setInstance(null)
+        mServer.setupConfigResponse(config2.toString())
+
+        MParticle.start(options)
+        latch = MPLatch(1)
+        configManager.onNewConfig { latch.countDown() }
+
+        //after restart, we should still have config1
+        assertEquals(config1.toString(), configManager.config)
+        assertEquals(etag, configManager.etag)
+        assertEquals(lastModified, configManager.ifModified)
+        assertEquals(timestamp, configManager.configTimestamp)
+
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        assertEquals(config2.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+    }
+
+    @Test
+    fun testAlwaysStale() {
+        val config1 = randomJson(4)
+        val config2 = randomJson(4);
+        var latch = MPLatch(1);
+        val options = MParticleOptions.builder(mContext)
+            .addCredentials()
+            .configMaxAgeSeconds(0)
+            .build()
+
+        mServer.setupConfigResponse(config1.toString())
+
+        MParticle.start(options)
+
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        assertEquals(config1.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+
+        MParticle.setInstance(null)
+
+        mServer.setupConfigResponse(config2.toString())
+
+        MParticle.start(options)
+        latch = MPLatch(1)
+
+        //directly after restart, config should be cleared
+        assertNull(configManager.config)
+        assertNull(configManager.etag)
+        assertNull(configManager.ifModified)
+        assertNull(configManager.configTimestamp)
+
+        configManager.onNewConfig { latch.countDown() }
+        latch.await()
+
+        //after config has been fetched, we should see config2
+        assertEquals(config2.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+    }
+
+    private fun randomJson(size: Int) =
+        (1..size)
+            .map { mRandomUtils.getAlphaNumericString(4) to mRandomUtils.getAlphaNumericString(6) }
+            .fold(JSONObject()) { init, attribute ->
+                init.apply { put(attribute.first, attribute.second) }
+            }
+
+    fun <T> T?.assertNotNull(): T {
+        assertNotNull(this)
+        return this
+    }
+
+    fun MParticleOptions.Builder.addCredentials() = this.credentials("apiKey", "apiSecret")
+
+    fun ConfigManager.onNewConfig(callback: () -> Unit) {
+        addConfigUpdatedListener { configType, config ->
+            if (configType == ConfigManager.ConfigType.NEW) {
+                callback()
+            }
+        }
+    }
+}

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
@@ -62,7 +62,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         var latch = MPLatch(1);
         val options = MParticleOptions.builder(mContext)
             .addCredentials()
-            .configMaxAgeSeconds(1)
+            .configMaxAgeSeconds(1L)
             .build()
 
         mServer.setupConfigResponse(config1.toString())
@@ -103,7 +103,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         var latch = MPLatch(1);
         val options = MParticleOptions.builder(mContext)
             .addCredentials()
-            .configMaxAgeSeconds(100)
+            .configMaxAgeSeconds(100L)
             .build()
 
         mServer.setupConfigResponse(config1.toString())
@@ -143,7 +143,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         var latch = MPLatch(1);
         val options = MParticleOptions.builder(mContext)
             .addCredentials()
-            .configMaxAgeSeconds(0)
+            .configMaxAgeSeconds(0L)
             .build()
 
         mServer.setupConfigResponse(config1.toString())

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -99,7 +99,7 @@ public class MParticle {
     protected MParticle() { }
     
     private MParticle(MParticleOptions options) {
-        ConfigManager configManager = new ConfigManager(options.getContext(), options.getEnvironment(), options.getApiKey(), options.getApiSecret(), options.getDataplanOptions(), options.getDataplanId(), options.getDataplanVersion(), options);
+        ConfigManager configManager = new ConfigManager(options);
         configManager.setUploadInterval(options.getUploadInterval());
         configManager.setSessionTimeout(options.getSessionTimeout());
         configManager.setIdentityConnectionTimeout(options.getConnectionTimeout());
@@ -362,7 +362,6 @@ public class MParticle {
             mMessageManager.logEvent(event, mAppStateManager.getCurrentActivityName());
             Logger.debug("Logged event - \n", event.toString());
             mKitManager.logEvent(event);
-
         }
     }
 

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -41,6 +41,7 @@ public class MParticleOptions {
     private Boolean mAndroidIdDisabled = false;
     private Integer mUploadInterval = ConfigManager.DEFAULT_UPLOAD_INTERVAL;  //seconds
     private Integer mSessionTimeout = ConfigManager.DEFAULT_SESSION_TIMEOUT_SECONDS; //seconds
+    private Long mConfigMaxAge = null;
     private Boolean mUnCaughtExceptionLogging = false;
     private MParticle.LogLevel mLogLevel = MParticle.LogLevel.DEBUG;
     private AttributionListener mAttributionListener;
@@ -95,6 +96,13 @@ public class MParticleOptions {
                 Logger.warning("Session Timeout must be a positive number, disregarding value.");
             } else {
                 this.mSessionTimeout = builder.sessionTimeout;
+            }
+        }
+        if (builder.configMaxAge != null) {
+            if (builder.configMaxAge < 0) {
+                Logger.warning("Config Max Age must be a positive number, disregarding value.");
+            } else {
+                this.mConfigMaxAge = builder.configMaxAge;
             }
         }
         if (builder.unCaughtExceptionLogging != null) {
@@ -219,6 +227,11 @@ public class MParticleOptions {
     }
 
     @NonNull
+    public Long getConfigMaxAge() {
+        return mConfigMaxAge;
+    }
+
+    @NonNull
     public Boolean isUncaughtExceptionLoggingEnabled() {
         return mUnCaughtExceptionLogging;
     }
@@ -320,6 +333,7 @@ public class MParticleOptions {
         private Boolean androidIdDisabled = null;
         private Integer uploadInterval = null;
         private Integer sessionTimeout = null;
+        private Long configMaxAge = null;
         private Boolean unCaughtExceptionLogging = null;
         private MParticle.LogLevel logLevel = null;
         BaseIdentityTask identityTask;
@@ -471,6 +485,28 @@ public class MParticleOptions {
         @NonNull
         public Builder sessionTimeout(int sessionTimeout) {
             this.sessionTimeout = sessionTimeout;
+            return this;
+        }
+
+        /**
+         * Set a maximum threshold for stored configuration age.
+         *
+         * When the SDK starts, before we attempt to fetch a fresh config from the server, we
+         * will load the most recent previous config from disk. when configMaxAge is set, we will
+         * check the timestamp on that config and, if it's age is greater than the threshold, instead
+         * of loading it we will delete it and wait for the fresh config to arrive.
+         *
+         * This field is especially useful if your application often updates the kit/forwarding logic and
+         * has a portion of user's who experience prolonged network interruptions. In these cases, a reasonable
+         * configMaxAge will prevent those users from potentially using very forwarding logic
+         *
+         * @param configMaxAge the upper limit for config age, in seconds
+         *
+         * @return the instance of the builder, for chaining calls
+         */
+        @NonNull
+        public Builder configMaxAgeSeconds(Long configMaxAge) {
+            this.configMaxAge = configMaxAge;
             return this;
         }
 

--- a/android-core/src/main/java/com/mparticle/internal/MParticleApiClientImpl.java
+++ b/android-core/src/main/java/com/mparticle/internal/MParticleApiClientImpl.java
@@ -144,11 +144,11 @@ public class MParticleApiClientImpl extends MParticleBaseClientImpl implements M
             }
 
             connection.setRequestProperty("User-Agent", mUserAgent);
-            String etag = mPreferences.getString(Constants.PrefKeys.ETAG, null);
+            String etag = mConfigManager.getEtag();
             if (etag != null){
                 connection.setRequestProperty("If-None-Match", etag);
             }
-            String modified = mPreferences.getString(Constants.PrefKeys.IF_MODIFIED, null);
+            String modified = mConfigManager.getIfModified();
             if (modified != null){
                 connection.setRequestProperty("If-Modified-Since", modified);
             }
@@ -179,17 +179,10 @@ public class MParticleApiClientImpl extends MParticleBaseClientImpl implements M
                         connection.getResponseMessage() +"\n" +
                         "response:\n" + response.toString());
 
-                mConfigManager.updateConfig(response);
                 String newEtag = connection.getHeaderField("ETag");
                 String newModified = connection.getHeaderField("Last-Modified");
-                SharedPreferences.Editor editor = mPreferences.edit();
-                if (!MPUtility.isEmpty(newEtag)) {
-                    editor.putString(Constants.PrefKeys.ETAG, newEtag);
-                }
-                if (!MPUtility.isEmpty(newModified)) {
-                    editor.putString(Constants.PrefKeys.IF_MODIFIED, newModified);
-                }
-                editor.apply();
+
+                mConfigManager.updateConfig(response, newEtag, newModified);
             }else if (connection.getResponseCode() == 400) {
                 throw new MPConfigException();
             } else if (connection.getResponseCode() == 304) {

--- a/android-core/src/test/java/com/mparticle/internal/ConfigManagerTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/ConfigManagerTest.java
@@ -8,6 +8,7 @@ import com.mparticle.MockMParticle;
 import com.mparticle.identity.IdentityApi;
 import com.mparticle.internal.messages.BaseMPMessage;
 import com.mparticle.testutils.AndroidUtils;
+import com.mparticle.testutils.RandomUtils;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -35,12 +36,13 @@ public class ConfigManagerTest {
     private static final String sampleConfig = "{ \"dt\":\"ac\", \"id\":\"5b7b8073-852b-47c2-9b89-c4bc66e3bd55\", \"ct\":1428030730685, \"dbg\":false, \"cue\":\"appdefined\", \"pmk\":[ \"mp_message\", \"com.urbanairship.push.ALERT\", \"alert\", \"a\", \"message\" ], \"cnp\":\"appdefined\", \"soc\":0, \"oo\":false, \"tri\" : { \"mm\" : [{ \"dt\" : \"x\", \"eh\" : true } ], \"evts\" : [1217787541, 2, 3] }, \"eks\":[ { \"id\":64, \"as\":{ \"clientId\":\"8FMBElARYl9ZtgwYIN5sZA==\", \"surveyId\":\"android_app\", \"sendAppVersion\":\"True\", \"rootUrl\":\"http://survey.foreseeresults.com/survey/display\" }, \"hs\":{ \"et\":{ \"57\":0, \"49\":0, \"55\":0, \"52\":0, \"53\":0, \"50\":0, \"56\":0, \"51\":0, \"54\":0, \"48\":0 }, \"ec\":{ \"609391310\":0, \"-1282670145\":0, \"2138942058\":0, \"-1262630649\":0, \"-877324321\":0, \"1700497048\":0, \"1611158813\":0, \"1900204162\":0, \"-998867355\":0, \"-1758179958\":0, \"-994832826\":0, \"1598473606\":0, \"-2106320589\":0 }, \"ea\":{ \"343635109\":0, \"1162787110\":0, \"-427055400\":0, \"-1285822129\":0, \"1699530232\":0 }, \"svec\":{ \"-725356351\":0, \"-1992427723\":0, \"751512662\":0, \"-118381281\":0, \"-171137512\":0, \"-2036479142\":0, \"-1338304551\":0, \"1003167705\":0, \"1046650497\":0, \"1919407518\":0, \"-1326325184\":0, \"480870493\":0, \"-1087232483\":0, \"-725540438\":0, \"-461793000\":0, \"1935019626\":0, \"76381608\":0, \"273797382\":0, \"-948909976\":0, \"-348193740\":0, \"-685370074\":0, \"-849874419\":0, \"2074021738\":0, \"-767572488\":0, \"-1091433459\":0, \"1671688881\":0, \"1304651793\":0, \"1299738196\":0, \"326063875\":0, \"296835202\":0, \"268236000\":0, \"1708308839\":0, \"101093345\":0, \"-652558691\":0, \"-1613021771\":0, \"1106318256\":0, \"-473874363\":0, \"-1267780435\":0, \"486732621\":0, \"1855792002\":0, \"-881258627\":0, \"698731249\":0, \"1510155838\":0, \"1119638805\":0, \"479337352\":0, \"1312099430\":0, \"1712783405\":0, \"-459721027\":0, \"-214402990\":0, \"617910950\":0, \"428901717\":0, \"-201124647\":0, \"940674176\":0, \"1632668193\":0, \"338835860\":0, \"879890181\":0, \"1667730064\":0 } } } ], \"lsv\":\"2.1.4\", \"pio\":30 }";
     private MParticle mockMp;
     private Random ran = new Random();
+    private RandomUtils randomUtils = new RandomUtils();
 
 
     @Before
     public void setUp() throws Exception {
         context = new com.mparticle.mock.MockContext();
-        manager = new ConfigManager(context, MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null);
+        manager = new ConfigManager(context, MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null, null);
         mockMp = new MockMParticle();
         MParticle.setInstance(mockMp);
         manager.updateConfig(new JSONObject(sampleConfig));
@@ -48,10 +50,10 @@ public class ConfigManagerTest {
 
     @Test
     public void testSaveConfigJson() throws Exception {
-        manager.saveConfigJson(null);
+        manager.saveConfigJson(null, null, null);
         JSONObject json = new JSONObject();
         json.put("test", "value");
-        manager.saveConfigJson(json);
+        manager.saveConfigJson(json, null, null);
         JSONObject object = new JSONObject(manager.sPreferences.getString(ConfigManager.CONFIG_JSON, null));
         assertNotNull(object);
     }
@@ -72,9 +74,9 @@ public class ConfigManagerTest {
     }
 
     @Test
-    public void testUpdateConfigWithBoolean() throws Exception {
+    public void testUpdateConfigWithReload() throws Exception {
         manager.updateConfig(new JSONObject(sampleConfig));
-        manager.updateConfig(new JSONObject(), false);
+        manager.reloadConfig(new JSONObject());
         JSONObject object = new JSONObject(manager.sPreferences.getString(ConfigManager.CONFIG_JSON, null));
         assertTrue(object.keys().hasNext());
     }
@@ -88,7 +90,7 @@ public class ConfigManagerTest {
 
     @Test
     public void testRestrictAAIDBasedOnLAT() throws Exception {
-        ConfigManager testManager = new ConfigManager(context, MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null);
+        ConfigManager testManager = new ConfigManager(context, MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null, null);
         assertTrue(testManager.getRestrictAAIDBasedOnLAT());
         JSONObject config = new JSONObject();
         config.put("rdlat", "false");
@@ -600,7 +602,7 @@ public class ConfigManagerTest {
         int maxWindow = ran.nextInt();
         JSONObject jsonObject = new JSONObject()
                 .put(ConfigManager.ALIAS_MAX_WINDOW, maxWindow);
-        manager.updateConfig(jsonObject, true);
+        manager.updateConfig(jsonObject);
 
         assertEquals(maxWindow, manager.getAliasMaxWindow());
     }
@@ -612,4 +614,81 @@ public class ConfigManagerTest {
         return result;
     }
 
+    @Test
+    public void testETag() throws JSONException {
+        manager = new ConfigManager(context, MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null, null);
+        String newEtag = new RandomUtils().getAlphaString(24);
+        //test default value
+        assertNull(manager.getEtag());
+
+        //test set via config
+        manager.updateConfig(new JSONObject(), newEtag, null);
+        assertEquals(newEtag, manager.getEtag());
+    }
+
+    @Test
+    public void testLastModified() throws JSONException {
+        manager = new ConfigManager(context, MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null, null);
+        String lastModified = String.valueOf(Math.abs(ran.nextLong()));
+
+        //test default value
+        assertNull(manager.getIfModified());
+
+        //test set via config
+        manager.updateConfig(new JSONObject(), null, lastModified);
+        assertEquals(lastModified, manager.getIfModified());
+    }
+
+    @Test
+    public void testConfigTimestamp() throws InterruptedException, JSONException {
+        ConfigManager.clear();
+
+        //test default value
+        assertNull(manager.getConfigTimestamp());
+
+        //test set via config, make sure it is after previous timestamp
+        Long startTime = System.currentTimeMillis();
+        manager.updateConfig(new JSONObject(), null, null);
+        Long endTime = System.currentTimeMillis();
+
+        Long setTimestamp = manager.getConfigTimestamp();
+        assertNotNull(setTimestamp);
+        assertTrue(setTimestamp >= startTime);
+        assertTrue(setTimestamp <= endTime);
+
+        //test that it stays consistant
+        Thread.sleep(10);
+        assertEquals(setTimestamp, manager.getConfigTimestamp());
+    }
+
+    @Test
+    public void testGetConfig() throws JSONException {
+        ConfigManager.clear();
+        
+        JSONObject newConfigJson = new JSONObject();
+        int configSize = Math.abs(ran.nextInt() % 15);
+        for (int i = 0; i < configSize; i++) {
+            newConfigJson.put(randomUtils.getAlphaNumericString(8), randomUtils.getAlphaNumericString(12));
+        }
+
+        //test defaults
+        assertNull(manager.getConfig());
+        assertNull(manager.getEtag());
+        assertNull(manager.getIfModified());
+        assertNull(manager.getConfigTimestamp());
+
+        //test reload() does not set config
+        manager.reloadConfig(newConfigJson);
+        assertNull(manager.getConfig());
+        assertNull(manager.getEtag());
+        assertNull(manager.getIfModified());
+        assertNull(manager.getConfigTimestamp());
+
+        //test update DOES set config
+        manager.updateConfig(newConfigJson,"my ETag", "12345");
+        assertEquals(newConfigJson.toString(), manager.getConfig());
+        assertEquals("my ETag", manager.getEtag());
+        assertEquals("12345", manager.getIfModified());
+        assertNotNull(manager.getConfigTimestamp());
+    }
 }

--- a/android-core/src/test/java/com/mparticle/internal/DeviceAttributesTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/DeviceAttributesTest.java
@@ -61,7 +61,7 @@ public class DeviceAttributesTest {
     public void testAppInfoLaunchCount() throws Exception {
         Context context = new MockContext();
         // Clear out the stored data for the current user, so we don't get any launches from previous tests.
-        new ConfigManager(context, null, null, null, null, null, null, null).deleteUserStorage(context, ConfigManager.getMpid(context));
+        new ConfigManager(context, null, null, null, null, null, null, null, null).deleteUserStorage(context, ConfigManager.getMpid(context));
         JSONObject appInfo = null;
         int launchCount = 20;
         for (int i = 0; i < 20; i++) {

--- a/android-core/src/test/java/com/mparticle/internal/LoggerTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/LoggerTest.java
@@ -43,7 +43,7 @@ public class LoggerTest {
         //Set Logger to lowest level, so it prints everything by default.
         MParticle.setLogLevel(MParticle.LogLevel.VERBOSE);
         //Set environment to Development. Pretty hacky, but the easiest way.
-        new ConfigManager(new MockContext(), MParticle.Environment.Development, null, null, null, null, null, null);
+        new ConfigManager(new MockContext(), MParticle.Environment.Development, null, null, null, null, null, null, null);
 
         assertNotNull(Logger.getLogHandler());
         assertTrue(Logger.getLogHandler() instanceof Logger.DefaultLogHandler);

--- a/android-core/src/test/java/com/mparticle/internal/MParticleApiClientImplTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/MParticleApiClientImplTest.java
@@ -117,7 +117,7 @@ public class MParticleApiClientImplTest {
         Mockito.when(MPUtility.getJsonResponse(mockConnection)).thenReturn(response);
         ArgumentCaptor<JSONObject> captor = ArgumentCaptor.forClass(JSONObject.class);
         client.fetchConfig();
-        Mockito.verify(configManager).updateConfig(captor.capture());
+        Mockito.verify(configManager).updateConfig(captor.capture(), Mockito.nullable(String.class), Mockito.nullable(String.class));
         assertEquals(response, captor.getValue());
     }
 
@@ -223,7 +223,7 @@ public class MParticleApiClientImplTest {
         Mockito.when(MPUtility.getJsonResponse(mockConnection)).thenReturn(response);
         ArgumentCaptor<JSONObject> captor = ArgumentCaptor.forClass(JSONObject.class);
         client.fetchConfig();
-        Mockito.verify(configManager).updateConfig(captor.capture());
+        Mockito.verify(configManager).updateConfig(captor.capture(), Mockito.nullable(String.class), Mockito.nullable(String.class));
         assertEquals(response, captor.getValue());
     }
 

--- a/android-core/src/test/java/com/mparticle/internal/MessageBatchTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/MessageBatchTest.java
@@ -20,7 +20,7 @@ public class MessageBatchTest {
         MParticle mockMp = Mockito.mock(MParticle.class);
         Mockito.when(mockMp.getEnvironment()).thenReturn(MParticle.Environment.Development);
         MParticle.setInstance(mockMp);
-        ConfigManager manager = new ConfigManager(new MockContext(), MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null);
+        ConfigManager manager = new ConfigManager(new MockContext(), MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null, null);
         boolean sessionHistory = true;
         BatchId batchId = new BatchId(manager.getMpid(), null, null, null);
         MessageBatch batch = MessageBatch.create( sessionHistory, manager,new JSONObject(), batchId);
@@ -58,7 +58,7 @@ public class MessageBatchTest {
         MParticle mockMp = Mockito.mock(MParticle.class);
         Mockito.when(mockMp.getEnvironment()).thenReturn(MParticle.Environment.Development);
         MParticle.setInstance(mockMp);
-        ConfigManager manager = new ConfigManager(new MockContext(), MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null);
+        ConfigManager manager = new ConfigManager(new MockContext(), MParticle.Environment.Production, "some api key", "some api secret", null, null, null, null, null);
         boolean sessionHistory = true;
         BatchId batchId = new BatchId(manager.getMpid(), null, null, null);
         MessageBatch batch = MessageBatch.create( sessionHistory, manager,new JSONObject(), batchId);

--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/KitManagerImplTests.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/KitManagerImplTests.kt
@@ -6,13 +6,10 @@ import com.mparticle.MParticle
 import com.mparticle.MParticleOptions
 import com.mparticle.internal.ConfigManager
 import com.mparticle.kits.testkits.*
-import com.mparticle.testutils.BaseCleanInstallEachTest
 import com.mparticle.testutils.MPLatch
-import junit.framework.Assert.assertNotNull
 import junit.framework.Assert.assertTrue
 import org.json.JSONObject
 import org.junit.Test
-import java.util.concurrent.CountDownLatch
 
 class KitManagerImplTests: BaseKitOptionsTest() {
 
@@ -45,7 +42,7 @@ class KitManagerImplTests: BaseKitOptionsTest() {
         //Force the SDK to make a config request (using the ugly internals)
         JSONObject().put("eks", ConfigManager.getInstance(mContext).latestKitConfiguration)
                 .let {
-                    ConfigManager.getInstance(mContext).updateConfig(it, true)
+                    ConfigManager.getInstance(mContext).updateConfig(it)
                 }
         MParticle.reset(mContext)
         latch.countDown()

--- a/testutils/src/main/java/com/mparticle/mock/MockConfigManager.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockConfigManager.java
@@ -6,6 +6,6 @@ import com.mparticle.internal.ConfigManager;
 
 public class MockConfigManager extends ConfigManager {
     public MockConfigManager() {
-        super(new MockContext(), MParticle.Environment.Production, null, null, null, null, null, null);
+        super(new MockContext(), MParticle.Environment.Production, null, null, null, null, null, null,null);
     }
 }

--- a/testutils/src/main/java/com/mparticle/networking/Matcher.java
+++ b/testutils/src/main/java/com/mparticle/networking/Matcher.java
@@ -15,6 +15,7 @@ public class Matcher {
     MockServer.UrlMatcher urlMatcher;
     MockServer.JSONMatch bodyMatch;
     boolean keepAfterMatch;
+    Long timestamp = System.currentTimeMillis();
 
     boolean isMatch(MPConnectionTestImpl mockConnection) {
         if (url != null) {

--- a/testutils/src/main/java/com/mparticle/networking/MockServer.java
+++ b/testutils/src/main/java/com/mparticle/networking/MockServer.java
@@ -14,6 +14,7 @@ import org.json.JSONObject;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -473,7 +474,12 @@ public class MockServer {
     //the server is started before MParticle.start() is called, which means the urls in the "logic"
     //might not contain the same SDK key that was set later in MParticle.start()
     private void reverseAndUpdateKey(List<Map.Entry<Matcher, Object>> logic) {
-        Collections.reverse(logic);
+        Collections.sort(logic, new Comparator<Map.Entry<Matcher, Object>>() {
+            @Override
+            public int compare(Map.Entry<Matcher, Object> o1, Map.Entry<Matcher, Object> o2) {
+                return o1.getKey().timestamp == o2.getKey().timestamp ? 0 : o1.getKey().timestamp < o2.getKey().timestamp ? 1 : -1;
+            }
+        });
         String apiKey = ConfigManager.getInstance(context).getApiKey();
         try {
             for (Map.Entry<Matcher, Object> entry : logic) {


### PR DESCRIPTION
(moved from internal repo)

## Summary
Add public API for setting a max config staleness parameter. If the config is older than staleness limit, we will delete it instead of loading it from memory while we wait for the new config

### Usage

```
val options = MParticleOptions.builder(context)
   .maxConfigAge(1000 * 60 * 60 * 24 * 7)                   <- set a max age of 1 week
   .build()
```
note: **maxConfigAge value is ~DAYS~ SECONDS**

### API Behavior

- **not setting** maxConfigAge will default it to `null` which means it will **not** take effect and the SDK will behave exactly how it currently does
- setting it to **a negative Integer** will trigger a warning-level log message then proceed as if it was `null` (same as above)
- setting it to `0` will result in the stored config being deleted every time the SDK starts up aka Kits et al we will behave like it's a fresh install every time
~- setting it to **an Integer greater than 100** will trigger a warning-level log message reminding the client that the time unit is days, but still proceed with the value~
- setting it to **a reasonable (<100) Integer** will set that value as the config max-age in ~days~ seconds

### Internal Behavior
- we will check config age exactly once per app start in the ConfigManager constructor
> although it is possible the ConfigManager may get called at other points in our code, no where else will it pass in a configMaxAge, so in those cases it would default to `null`/do nothing
- staleness is determined by `("config timestamp" + "Milliseconds in a day" * configMaxAge) < System.currentTimeMillis`so there is no rounding or anything, the config will be invalid
- when a config is "deleted" for staleness reasons, we **will also delete the stored ETag and stored If-Modified values**.

## Testing Plan
- unit tests for `MParticleOptions` and `ConfigManager`
- integration tests for `maxConfigAge == 0` and "maxConfigAge not set" where we 1) start the SDK 2) wait for config to load 3) stop SDK 4) restart SDK 5) check stored config before the new one is fetched
- integration test for maxConfig == (big #) and make sure it isn't deleted before it should 
- new listener in ComfigManager that will callback when a config is "loaded" and also indicate whether it was a "reload" or a  new config...needed this so we had something to actually wait on when refreshing the config in test

~//TODO~
~- mock time and add an integration test for maxConfig == (some number), change the internal time and verify it gets properly deleted~


## Master Issue
Closes https://mparticle.tpondemand.com/RestUI/Board.aspx#page=board/4842431717611364328&appConfig=eyJhY2lkIjoiMjM4RjY2OUU2RkYxNzFCMTVCMUU5Q0JCRDlFQzQyRTAifQ==&boardPopup=bug/71594/silent