### PR TITLE
fix: Add additional checks for AndroidId

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/DeviceAttributes.java
+++ b/android-core/src/main/java/com/mparticle/internal/DeviceAttributes.java
@@ -144,8 +144,8 @@ public class DeviceAttributes {
     }
 
     public static void addAndroidId(JSONObject attributes, Context context) throws JSONException {
-        if (!MParticle.isAndroidIdDisabled()) {
-            String androidId = MPUtility.getAndroidID(context);
+        String androidId = MPUtility.getAndroidID(context);
+        if (!MPUtility.isEmpty(androidId)) {
             attributes.put(MessageKey.DEVICE_ID, androidId);
             attributes.put(MessageKey.DEVICE_ANID, androidId);
             attributes.put(MessageKey.DEVICE_OPEN_UDID, MPUtility.getOpenUDID(context));

--- a/android-core/src/main/java/com/mparticle/internal/MPUtility.java
+++ b/android-core/src/main/java/com/mparticle/internal/MPUtility.java
@@ -348,8 +348,13 @@ public class MPUtility {
     }
 
     @TargetApi(Build.VERSION_CODES.CUPCAKE)
+    @Nullable
     public static String getAndroidID(Context context) {
-        return Settings.Secure.getString(context.getContentResolver(), "android_id");
+        if (!MParticle.isAndroidIdDisabled()) {
+            return Settings.Secure.getString(context.getContentResolver(), "android_id");
+        } else {
+            return null;
+        }
     }
 
     public static String getTimeZone() {


### PR DESCRIPTION
## Summary
This adds a missing check for whether we should collect and include the AndroidId in Identity requests

## Testing Plan
updated existing checks to ensure that AndroidId is not collected when `isAndroidIdDisabled() == true`

## Master Issue
Closes https://mparticle.tpondemand.com/restui/board.aspx?#page=bug/77526&boardPopup=userstory/77585
