### PR TITLE
ci: Remove Kit lint checks for Pull Requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,22 +57,12 @@ jobs:
           java-version: "11"
       - name: "Run Android Core SDK Lint"
         run: ./gradlew lint
-      - name: "Setup Android Kit Lint"
-        run: ./gradlew publishReleaseLocal
-      - name: "Run Android Kit Lint"
-        run: ./gradlew publishReleaseLocal -c settings-kits.gradle lint
       - name: "Archive Test Results"
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: "core-lint-results"
           path: ./**/build/reports/**
-      - name: "Archive Test Kit Results"
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: "kit-lint-results"
-          path: kits/**/build/reports/**
   automerge:
       name: "Rebase dependabot PRs"
       runs-on: ubuntu-18.04


### PR DESCRIPTION
## Summary
Remove step running lint on kits from our PR CI checks.

## Testing Plan
existing tests pass, this is a net removal

## Master Issue
Closes https://go.mparticle.com/work/77624
