### PR TITLE
feat: Android id disabled default true

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
@@ -155,17 +155,30 @@ public class MParticleOptionsTest extends BaseAbstractTest {
     @Test
     public void testAndroidIdDisabled() throws Exception {
         //test defaults
+        assertFalse(MParticle.isAndroidIdEnabled());
         assertTrue(MParticle.isAndroidIdDisabled());
         MParticle.setInstance(null);
         startMParticle(MParticleOptions.builder(mContext));
+        assertFalse(MParticle.isAndroidIdEnabled());
         assertTrue(MParticle.isAndroidIdDisabled());
 
-        //test androidIdDsabled == true
+        //test androidIdDisabled == true
         MParticle.setInstance(null);
         startMParticle(
                 MParticleOptions.builder(mContext)
                         .androidIdDisabled(true)
         );
+        assertFalse(MParticle.isAndroidIdEnabled());
+        assertTrue(MParticle.isAndroidIdDisabled());
+        MParticle.setInstance(null);
+
+        //test androidIdEnabled == false
+        MParticle.setInstance(null);
+        startMParticle(
+                MParticleOptions.builder(mContext)
+                        .androidIdEnabled(false)
+        );
+        assertFalse(MParticle.isAndroidIdEnabled());
         assertTrue(MParticle.isAndroidIdDisabled());
         MParticle.setInstance(null);
 
@@ -174,6 +187,15 @@ public class MParticleOptionsTest extends BaseAbstractTest {
                 MParticleOptions.builder(mContext)
                         .androidIdDisabled(false)
         );
+        assertTrue(MParticle.isAndroidIdEnabled());
+        assertFalse(MParticle.isAndroidIdDisabled());
+
+        //test androidIdEnabled == true
+        startMParticle(
+                MParticleOptions.builder(mContext)
+                        .androidIdEnabled(true)
+        );
+        assertTrue(MParticle.isAndroidIdEnabled());
         assertFalse(MParticle.isAndroidIdDisabled());
     }
 

--- a/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
@@ -23,6 +23,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
@@ -152,13 +154,26 @@ public class MParticleOptionsTest extends BaseAbstractTest {
 
     @Test
     public void testAndroidIdDisabled() throws Exception {
-        MParticle.setInstance(null);
-        startMParticle(MParticleOptions.builder(mContext)
-                .androidIdDisabled(true));
+        //test defaults
         assertTrue(MParticle.isAndroidIdDisabled());
         MParticle.setInstance(null);
-        startMParticle(MParticleOptions.builder(mContext)
-                .androidIdDisabled(false));
+        startMParticle(MParticleOptions.builder(mContext));
+        assertTrue(MParticle.isAndroidIdDisabled());
+
+        //test androidIdDsabled == true
+        MParticle.setInstance(null);
+        startMParticle(
+                MParticleOptions.builder(mContext)
+                        .androidIdDisabled(true)
+        );
+        assertTrue(MParticle.isAndroidIdDisabled());
+        MParticle.setInstance(null);
+
+        //test androidIdDisabled == false
+        startMParticle(
+                MParticleOptions.builder(mContext)
+                        .androidIdDisabled(false)
+        );
         assertFalse(MParticle.isAndroidIdDisabled());
     }
 
@@ -456,4 +471,38 @@ public class MParticleOptionsTest extends BaseAbstractTest {
         assertNull(options.getConfigMaxAge());
     }
 
+    @Test
+    public void  testAndroidIdLogMessage() {
+        List<String> infoLogs = new ArrayList();
+        Logger.setLogHandler(new Logger.DefaultLogHandler() {
+            @Override
+            public void log(MParticle.LogLevel priority, Throwable error, String messages) {
+                super.log(priority, error, messages);
+                if (priority == MParticle.LogLevel.INFO) {
+                    infoLogs.add(messages);
+                }
+            }
+        });
+        MParticleOptions.builder(mContext)
+                .credentials("this", "that")
+                .androidIdDisabled(true)
+                .build();
+        assertTrue(infoLogs.contains("ANDROID_ID will not be collected based on MParticleOptions settings"));
+        infoLogs.clear();
+
+        MParticleOptions.builder(mContext)
+                .credentials("this", "that")
+                .androidIdDisabled(false)
+                .build();
+        assertTrue(infoLogs.contains("ANDROID_ID will be collected based on MParticleOptions settings"));
+        infoLogs.clear();
+
+        //test default
+        MParticleOptions.builder(mContext)
+                .credentials("this", "that")
+                .build();
+
+        assertTrue(infoLogs.contains("ANDROID_ID will not be collected based on default settings"));
+        infoLogs.clear();
+    }
 }

--- a/android-core/src/androidTest/java/com/mparticle/identity/IdentityApiStartTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/identity/IdentityApiStartTest.java
@@ -40,11 +40,11 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
                 .userIdentities(identities)
                 .build();
         startMParticle(MParticleOptions.builder(mContext)
-                .androidIdDisabled(false)
+                .androidIdEnabled(true)
                 .identify(request));
 
         assertTrue(mServer.Requests().getIdentify().size() == 1);
-        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, false);
+        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, true);
     }
 
     @Test
@@ -55,11 +55,11 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
                 .userIdentities(identities)
                 .build();
         startMParticle(MParticleOptions.builder(mContext)
-                .androidIdDisabled(true)
+                .androidIdEnabled(false)
                 .identify(request));
 
         assertTrue(mServer.Requests().getIdentify().size() == 1);
-        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, true);
+        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, false);
     }
 
 
@@ -68,7 +68,7 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
         startMParticle();
 
         assertEquals(mServer.Requests().getIdentify().size(), 1);
-        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), new HashMap<>(), true);
+        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), new HashMap<>(), false);
     }
 
     @Test
@@ -90,7 +90,7 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
         startMParticle();
 
         assertEquals(mServer.Requests().getIdentify().size(), 1);
-        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, true);
+        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, false);
     }
 
     /**
@@ -175,7 +175,7 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
         assertTrue(called.value);
     }
 
-    private void assertIdentitiesMatch(Request request, Map<MParticle.IdentityType, String> identities, boolean androidIdDisabled) throws Exception {
+    private void assertIdentitiesMatch(Request request, Map<MParticle.IdentityType, String> identities, boolean androidIdEnabled) throws Exception {
         assertTrue(request instanceof IdentityRequest);
         IdentityRequest identityRequest = request.asIdentityRequest();
         assertNotNull(identityRequest);
@@ -183,10 +183,10 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
         JSONObject knownIdentities = identityRequest.getBody().known_identities;
         assertNotNull(knownIdentities);
 
-        if (androidIdDisabled) {
-            assertFalse(knownIdentities.has("android_uuid"));
-        } else {
+        if (androidIdEnabled) {
             assertNotNull(knownIdentities.remove("android_uuid"));
+        } else {
+            assertFalse(knownIdentities.has("android_uuid"));
         }
         assertNotNull(knownIdentities.remove("device_application_stamp"));
 

--- a/android-core/src/androidTest/java/com/mparticle/identity/IdentityApiStartTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/identity/IdentityApiStartTest.java
@@ -68,7 +68,7 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
         startMParticle();
 
         assertEquals(mServer.Requests().getIdentify().size(), 1);
-        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), new HashMap<>(), false);
+        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), new HashMap<>(), true);
     }
 
     @Test
@@ -90,7 +90,7 @@ public final class IdentityApiStartTest extends BaseCleanInstallEachTest {
         startMParticle();
 
         assertEquals(mServer.Requests().getIdentify().size(), 1);
-        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, false);
+        assertIdentitiesMatch(mServer.Requests().getIdentify().get(0), identities, true);
     }
 
     /**

--- a/android-core/src/androidTest/java/com/mparticle/internal/DeviceAttributesTests.java
+++ b/android-core/src/androidTest/java/com/mparticle/internal/DeviceAttributesTests.java
@@ -11,6 +11,8 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DeviceAttributesTests extends BaseCleanInstallEachTest {
@@ -18,12 +20,11 @@ public class DeviceAttributesTests extends BaseCleanInstallEachTest {
     @Test
     public void testAndroidIDCollection() throws Exception {
         Context context = InstrumentationRegistry.getInstrumentation().getContext();
-        String androidId = MPUtility.getAndroidID(context);
         JSONObject attributes = new JSONObject();
         DeviceAttributes.addAndroidId(attributes, context);
-        assertEquals(attributes.getString(Constants.MessageKey.DEVICE_ANID),androidId);
-        assertTrue(attributes.getString(Constants.MessageKey.DEVICE_OPEN_UDID).length() > 0);
-        assertEquals(attributes.getString(Constants.MessageKey.DEVICE_ID),androidId);
+        assertFalse(attributes.has(Constants.MessageKey.DEVICE_ANID));
+        assertFalse(attributes.has(Constants.MessageKey.DEVICE_OPEN_UDID));
+        assertFalse(attributes.has(Constants.MessageKey.DEVICE_ID));
 
         MParticleOptions options = MParticleOptions.builder(context)
                 .androidIdDisabled(true)
@@ -31,7 +32,23 @@ public class DeviceAttributesTests extends BaseCleanInstallEachTest {
                 .build();
         MParticle.start(options);
         JSONObject newAttributes = new JSONObject();
-        DeviceAttributes.addAndroidId(attributes, context);
+        DeviceAttributes.addAndroidId(newAttributes, context);
         assertTrue(newAttributes.length() == 0);
+
+        MParticle.setInstance(null);
+
+        options = MParticleOptions.builder(context)
+                .androidIdDisabled(false)
+                .credentials("key", "secret")
+                .build();
+        MParticle.start(options);
+        newAttributes = new JSONObject();
+        String androidId = MPUtility.getAndroidID(context);
+        DeviceAttributes.addAndroidId(newAttributes, context);
+        assertTrue(newAttributes.length() == 3);
+        assertEquals(newAttributes.getString(Constants.MessageKey.DEVICE_ANID),androidId);
+        assertTrue(newAttributes.getString(Constants.MessageKey.DEVICE_OPEN_UDID).length() > 0);
+        assertEquals(newAttributes.getString(Constants.MessageKey.DEVICE_ID),androidId);
+
     }
 }

--- a/android-core/src/androidTest/java/com/mparticle/internal/DeviceAttributesTests.java
+++ b/android-core/src/androidTest/java/com/mparticle/internal/DeviceAttributesTests.java
@@ -27,7 +27,7 @@ public class DeviceAttributesTests extends BaseCleanInstallEachTest {
         assertFalse(attributes.has(Constants.MessageKey.DEVICE_ID));
 
         MParticleOptions options = MParticleOptions.builder(context)
-                .androidIdDisabled(true)
+                .androidIdEnabled(false)
                 .credentials("key", "secret")
                 .build();
         MParticle.start(options);
@@ -38,7 +38,7 @@ public class DeviceAttributesTests extends BaseCleanInstallEachTest {
         MParticle.setInstance(null);
 
         options = MParticleOptions.builder(context)
-                .androidIdDisabled(false)
+                .androidIdEnabled(true)
                 .credentials("key", "secret")
                 .build();
         MParticle.start(options);

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -90,7 +90,7 @@ public class MParticle {
     @NonNull protected MParticleDBManager mDatabaseManager;
     @NonNull protected volatile AttributionListener mAttributionListener;
     @NonNull protected IdentityApi mIdentityApi;
-    static volatile boolean sAndroidIdDisabled = true;
+    static volatile boolean sAndroidIdEnabled = false;
     static volatile boolean sDevicePerformanceMetricsDisabled;
     @NonNull protected boolean locationTrackingEnabled = false;
     @NonNull protected Internal mInternal = new Internal();
@@ -143,7 +143,7 @@ public class MParticle {
             synchronized (MParticle.class) {
                 if (instance == null) {
                     sDevicePerformanceMetricsDisabled = options.isDevicePerformanceMetricsDisabled();
-                    sAndroidIdDisabled = options.isAndroidIdDisabled();
+                    sAndroidIdEnabled = options.isAndroidIdEnabled();
                     setLogLevel(options.getLogLevel());
 
                     Context originalContext = context;
@@ -229,19 +229,37 @@ public class MParticle {
     }
 
     /**
+     *  @deprecated
+     *  This method has been replaced as the behavior has been inverted - Android ID collection is now disabled by default.
+     *  <p> Use {@link androidIdEnabled(boolean)} instead.
+     *
+     *
      * Query the status of Android ID collection.
      *
-     * By default, the SDK will collect <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID">Android Id</a> for the purpose
-     * of anonymous analytics. If you're not using an mParticle integration that consumes Android ID, the value will be sent to the mParticle
-     * servers and then immediately discarded. Use this API if you would like to additionally disable it from being collected entirely.
+     * By default, the SDK will NOT collect <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID">Android Id</a> for the purpose
+     * of anonymous analytics. If you're not using an mParticle integration that consumes Android ID and you would like to collect it, use this API to enable collection
      *
-     *
-     * @return true if Android ID collection is disabled. (false by default)
+     * @return false if Android ID collection is enabled. (true by default)
 
-     * @see MParticleOptions.Builder#androidIdDisabled(boolean)
+     * @see MParticleOptions.Builder#androidIdEnabled(boolean)
      */
+    @Deprecated
     public static boolean isAndroidIdDisabled() {
-        return sAndroidIdDisabled;
+        return !sAndroidIdEnabled;
+    }
+
+    /**
+     * Query the status of Android ID collection.
+     *
+     * By default, the SDK will NOT collect <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID">Android Id</a> for the purpose
+     * of anonymous analytics. If you're not using an mParticle integration that consumes Android ID and you would like to collect it, use this API to enable collection.
+     *
+     * @return true if Android ID collection is enabled. (false by default)
+
+     * @see MParticleOptions.Builder#androidIdEnabled(boolean)
+     */
+    public static boolean isAndroidIdEnabled() {
+        return sAndroidIdEnabled;
     }
 
     /**

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -90,7 +90,7 @@ public class MParticle {
     @NonNull protected MParticleDBManager mDatabaseManager;
     @NonNull protected volatile AttributionListener mAttributionListener;
     @NonNull protected IdentityApi mIdentityApi;
-    static volatile boolean sAndroidIdDisabled;
+    static volatile boolean sAndroidIdDisabled = true;
     static volatile boolean sDevicePerformanceMetricsDisabled;
     @NonNull protected boolean locationTrackingEnabled = false;
     @NonNull protected Internal mInternal = new Internal();

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -38,7 +38,7 @@ public class MParticleOptions {
     private String mApiSecret;
     private IdentityApiRequest mIdentifyRequest;
     private Boolean mDevicePerformanceMetricsDisabled = false;
-    private Boolean mAndroidIdDisabled = false;
+    private Boolean mAndroidIdDisabled = true;
     private Integer mUploadInterval = ConfigManager.DEFAULT_UPLOAD_INTERVAL;  //seconds
     private Integer mSessionTimeout = ConfigManager.DEFAULT_SESSION_TIMEOUT_SECONDS; //seconds
     private Integer mConfigMaxAge = null;
@@ -84,6 +84,8 @@ public class MParticleOptions {
         if (builder.androidIdDisabled != null) {
             this.mAndroidIdDisabled = builder.androidIdDisabled;
         }
+        Logger.info(String.format("ANDROID_ID will%s be collected based on %s settings", mAndroidIdDisabled ? " not" : "", builder.androidIdDisabled != null ? "MParticleOptions" : "default"));
+
         if (builder.uploadInterval != null) {
             if (builder.uploadInterval <= 0) {
                 Logger.warning("Upload Interval must be a positive number, disregarding value.");

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -18,7 +18,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +37,7 @@ public class MParticleOptions {
     private String mApiSecret;
     private IdentityApiRequest mIdentifyRequest;
     private Boolean mDevicePerformanceMetricsDisabled = false;
-    private Boolean mAndroidIdDisabled = true;
+    private Boolean mAndroidIdEnabled = false;
     private Integer mUploadInterval = ConfigManager.DEFAULT_UPLOAD_INTERVAL;  //seconds
     private Integer mSessionTimeout = ConfigManager.DEFAULT_SESSION_TIMEOUT_SECONDS; //seconds
     private Integer mConfigMaxAge = null;
@@ -81,10 +80,10 @@ public class MParticleOptions {
         if (builder.devicePerformanceMetricsDisabled != null) {
             this.mDevicePerformanceMetricsDisabled = builder.devicePerformanceMetricsDisabled;
         }
-        if (builder.androidIdDisabled != null) {
-            this.mAndroidIdDisabled = builder.androidIdDisabled;
+        if (builder.androidIdEnabled != null) {
+            this.mAndroidIdEnabled = builder.androidIdEnabled;
         }
-        Logger.info(String.format("ANDROID_ID will%s be collected based on %s settings", mAndroidIdDisabled ? " not" : "", builder.androidIdDisabled != null ? "MParticleOptions" : "default"));
+        Logger.info(String.format("ANDROID_ID will%s be collected based on %s settings", mAndroidIdEnabled ? "" : " not", builder.androidIdEnabled != null ? "MParticleOptions" : "default"));
 
         if (builder.uploadInterval != null) {
             if (builder.uploadInterval <= 0) {
@@ -205,12 +204,26 @@ public class MParticleOptions {
     }
 
     /**
+     * @deprecated
+     * This method has been replaced as the behavior has been inverted - Android ID collection is now disabled by default.
+     * <p> Use {@link isAndroidIdEnabled(boolean)} instead.
+     *
      * Query whether Android Id collection is enabled or disabled.
      * @return true if collection is disabled, false if it is enabled
      */
     @NonNull
+    @Deprecated
     public Boolean isAndroidIdDisabled() {
-        return mAndroidIdDisabled;
+        return !mAndroidIdEnabled;
+    }
+
+    /**
+     * Query whether Android Id collection is enabled or disabled.
+     * @return true if collection is enabled, false if it is disabled
+     */
+    @NonNull
+    public Boolean isAndroidIdEnabled() {
+        return mAndroidIdEnabled;
     }
 
     /**
@@ -332,7 +345,7 @@ public class MParticleOptions {
         private MParticle.Environment environment;
         private IdentityApiRequest identifyRequest;
         private Boolean devicePerformanceMetricsDisabled = null;
-        private Boolean androidIdDisabled = null;
+        private Boolean androidIdEnabled = null;
         private Integer uploadInterval = null;
         private Integer sessionTimeout = null;
         private Integer configMaxAge = null;
@@ -448,17 +461,36 @@ public class MParticleOptions {
         }
 
         /**
-         * By default, the SDK will collect <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID">Android Id</a> for the purpose
-         * of anonymous analytics. If you're not using an mParticle integration that consumes Android ID, the value will be sent to the mParticle
-         * servers and then immediately discarded. Use this API if you would like to additionally disable it from being collected entirely.
+         * @deprecated
+         * This method has been replaced as the behavior has been inverted - Android ID collection is now disabled by default.
+         * <p> Use {@link androidIdEnabled(boolean)} instead.
          *
-         * @param disabled true to disable collection (false by default)
+         *
+         * By default, the SDK will NOT collect <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID">Android Id</a> for the purpose
+         * of anonymous analytics. If you're not using an mParticle integration that consumes Android ID and you would like to collect it, use this API to enable collection.
+         *
+         * @param disabled false to enable collection (true by default)
          *
          * @return the instance of the builder, for chaining calls
          */
         @NonNull
+        @Deprecated
         public Builder androidIdDisabled(boolean disabled) {
-            this.androidIdDisabled = disabled;
+            this.androidIdEnabled = !disabled;
+            return this;
+        }
+
+        /**
+         * By default, the SDK will NOT collect <a href="http://developer.android.com/reference/android/provider/Settings.Secure.html#ANDROID_ID">Android Id</a> for the purpose
+         * of anonymous analytics. If you're not using an mParticle integration that consumes Android ID and you would like to collect it, use this API to enable collection
+         *
+         * @param enabled true to enable collection (false by default)
+         *
+         * @return the instance of the builder, for chaining calls
+         */
+        @NonNull
+        public Builder androidIdEnabled(boolean enabled) {
+            this.androidIdEnabled = enabled;
             return this;
         }
 

--- a/android-core/src/test/java/com/mparticle/external/ApiVisibilityTest.java
+++ b/android-core/src/test/java/com/mparticle/external/ApiVisibilityTest.java
@@ -21,7 +21,7 @@ public class ApiVisibilityTest {
                 publicMethodCount++;
             }
         }
-        assertEquals(61, publicMethodCount);
+        assertEquals(62, publicMethodCount);
     }
 
     @Test


### PR DESCRIPTION
## Summary

#### Breaking Change!!

Change the default value for `MParticleOptions.isAndroidIdDisabled()` and `MParticle.isAndroidIdDisabled()` to `true`. Previously the default was false.

The net result will be that any client (including existing clients) who do not explicitly call `MParticleOptions.Builder.androidIdDisabled(Boolean)` will see the SDK behavior change. Previously, for these clients, we included Android ID as a `known_identities` entry in Identity Requests as well as a Device Attribute field in Batch Messages, but with this change we will only do so if they set `androidIdDisabled(true)` when building `MParticleOptions`

#### API Change

We have deprecated `MParticleOptions#isAndroIdDisabled()` and `MParticle.isAndroidIdDisabled()`. These methods were replaced by`MParticleOptions#isAndroidIdEnabled()` and `MParticle.isAndroidIdEnabled()`, respectively 



## Testing Plan
updated existing tests, added unit tests for `MParticleOptions` to check that default is correct and setter still works, added integration tests to make sure the setting properly propegated

## Master Issue
Closes https://go.mparticle.com/work/77592
