### PR TITLE
ci: create first version of daily android health check cron job

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -1,4 +1,4 @@
-name: Cross Platform Tests
+name: "Cross Platform Tests"
 on:
   pull_request_target
 jobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,154 @@
+name: "Daily Cron"
+
+on:
+  # Run daily at midnight
+  schedule:
+    - cron: "0 0 * * *"
+
+  # Allow workflow to be manually run from the GitHub UI
+  workflow_dispatch:
+
+jobs:
+
+  instrumented-tests:
+    name: "Instrumented Tests"
+    timeout-minutes: 30
+    runs-on: macos-11
+    steps:
+      - name: "Checkout development branch"
+        uses: actions/checkout@v2
+        with:
+          repository: mparticle/mparticle-android-sdk
+          ref: development
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Run Instrumented Tests"
+        uses: reactivecircus/android-emulator-runner@v2.20.0
+        with:
+          api-level: 29
+          script: ./gradlew :android-core:cAT :android-kit-base:cAT --stacktrace
+      - name: "Archive Instrumented Test Results"
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: test-results
+          path: android-core/build/reports/androidTests/connected/**
+
+  unit-tests:
+    name: "Unit Tests"
+    timeout-minutes: 15
+    runs-on: ubuntu-18.04
+    steps:
+      - name: "Checkout development branch"
+        uses: actions/checkout@v2
+        with:
+          repository: mparticle/mparticle-android-sdk
+          ref: development
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Run Unit Tests"
+        run: ./gradlew test
+      - name: "Android Test Report"
+        uses: asadmansr/android-test-report-action@v1.2.0
+        if: ${{ always() }}
+  lint-checks:
+    name: "Lint Checks"
+    timeout-minutes: 15
+    runs-on: macos-11
+    steps:
+      - name: "Checkout Branch"
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Run Android Core SDK Lint"
+        run: ./gradlew lint
+      - name: "Setup Android Kit Lint"
+        run: ./gradlew publishReleaseLocal
+      - name: "Run Android Kit Lint"
+        run: ./gradlew publishReleaseLocal -c settings-kits.gradle lint
+      - name: "Archive Test Results"
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: "core-lint-results"
+          path: ./**/build/reports/**
+      - name: "Archive Test Kit Results"
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: "kit-lint-results"
+          path: kits/**/build/reports/**
+  update-kits:
+    name: "Update Kits"
+    needs: [instrumented-tests, unit-tests]
+    runs-on: macos-11
+    env:
+      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_EMAIL: developers@mparticle.com
+      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_EMAIL: developers@mparticle.com
+    steps:
+      - name: "Checkout development branch"
+        uses: actions/checkout@v2
+        with:
+          repository: mparticle/mparticle-android-sdk
+          ref: development
+          submodules: recursive
+      - name: "Install JDK 11"
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "11"
+      - name: "Build Android Core"
+        run: ./gradlew -PisRelease=true clean publishReleaseLocal
+      - name: "Update Kit references"
+        run: git submodule foreach "git fetch; git reset --hard origin/main";
+      - name: "Test Kits"
+        run: ./gradlew -PisRelease=true clean testRelease publishReleaseLocal -c settings-kits.gradle
+
+  semantic-release:
+    name: "Test Semantic Release"
+    needs: update-kits
+    runs-on: macos-11
+    env:
+      GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_EMAIL: developers@mparticle.com
+      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_EMAIL: developers@mparticle.com
+    steps:
+      - name: "Checkout public main branch"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: main
+      - name: "Merge future release branch into main branch"
+        run: |
+          git pull origin development
+      - name: "Semantic Release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+          GIT_AUTHOR_NAME: mparticle-bot
+          GIT_AUTHOR_EMAIL: developers@mparticle.com
+          GIT_COMMITTER_NAME: mparticle-bot
+          GIT_COMMITTER_EMAIL: developers@mparticle.com
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @semantic-release/exec@5 \
+          semantic-release
+

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,11 +9,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  confirm-public-repo-development-branch:
+    name: "Confirm android daily cron is run from public origin repo"
+    runs-on: ubuntu-18.04
+    steps:
+      - name: "Cancel workflow"
+        if: ${{ github.repository != 'mParticle/mparticle-android-sdk' }}
+        uses: andymckay/cancel-action@0.2
 
   instrumented-tests:
     name: "Instrumented Tests"
     timeout-minutes: 30
     runs-on: macos-11
+    needs: confirm-public-repo-development-branch
     steps:
       - name: "Checkout development branch"
         uses: actions/checkout@v2
@@ -41,6 +49,7 @@ jobs:
     name: "Unit Tests"
     timeout-minutes: 15
     runs-on: ubuntu-18.04
+    needs: confirm-public-repo-development-branch
     steps:
       - name: "Checkout development branch"
         uses: actions/checkout@v2
@@ -61,6 +70,7 @@ jobs:
     name: "Lint Checks"
     timeout-minutes: 15
     runs-on: macos-11
+    needs: confirm-public-repo-development-branch
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@v2
@@ -119,7 +129,7 @@ jobs:
 
   semantic-release:
     name: "Test Semantic Release"
-    needs: update-kits
+    needs: [update-kits]
     runs-on: macos-11
     env:
       GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: "Build and Test"
 on: [push, pull_request]
 jobs:
   instrumented-tests:

--- a/.github/workflows/reusable-workflows.yml
+++ b/.github/workflows/reusable-workflows.yml
@@ -1,15 +1,15 @@
-name: PR Reusable Checks
+name: "PR Reusable Checks"
 
 on:
   pull_request:
 
 jobs:
   pr-branch-check-name:
-    name: Check PR for semantic branch name
+    name: "Check PR for semantic branch name"
     uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-check-name.yml@stable
   pr-title-check:
-    name: Check PR for semantic title
+    name: "Check PR for semantic title"
     uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable
   pr-branch-target-gitflow:
-    name: Check PR for semantic target branch
+    name: "Check PR for semantic target branch"
     uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-gitflow.yml@stable


### PR DESCRIPTION
## Summary
- Add a daily android health check cron job (for releases)

## Testing Plan
- Running cron from workflow dispatch should pass

## Master Issue
- Closes https://go.mparticle.com/work/77650