### PR TITLE
fix: Change configMaxAge type from Long to int

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
@@ -436,22 +436,22 @@ public class MParticleOptionsTest extends BaseAbstractTest {
         //0 should return 0
         options = MParticleOptions.builder(mContext)
                 .credentials("key", "secret")
-                .configMaxAgeSeconds(0L)
+                .configMaxAgeSeconds(0)
                 .build();
         assertEquals(0, options.getConfigMaxAge().intValue());
 
         //positive number should return positive number
-        Long testValue = Math.abs(ran.nextLong());
+        int testValue = Math.abs(ran.nextInt());
         options = MParticleOptions.builder(mContext)
                 .credentials("key", "secret")
                 .configMaxAgeSeconds(testValue)
                 .build();
-        assertEquals(testValue, options.getConfigMaxAge());
+        assertEquals(testValue, options.getConfigMaxAge().intValue());
 
         //negative number should get thrown out and return null
         options = MParticleOptions.builder(mContext)
                 .credentials("key", "secret")
-                .configMaxAgeSeconds(-5L)
+                .configMaxAgeSeconds(-5)
                 .build();
         assertNull(options.getConfigMaxAge());
     }

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
@@ -62,7 +62,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         var latch = MPLatch(1);
         val options = MParticleOptions.builder(mContext)
             .addCredentials()
-            .configMaxAgeSeconds(1L)
+            .configMaxAgeSeconds(1)
             .build()
 
         mServer.setupConfigResponse(config1.toString())
@@ -103,7 +103,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         var latch = MPLatch(1);
         val options = MParticleOptions.builder(mContext)
             .addCredentials()
-            .configMaxAgeSeconds(100L)
+            .configMaxAgeSeconds(100)
             .build()
 
         mServer.setupConfigResponse(config1.toString())
@@ -143,7 +143,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         var latch = MPLatch(1);
         val options = MParticleOptions.builder(mContext)
             .addCredentials()
-            .configMaxAgeSeconds(0L)
+            .configMaxAgeSeconds(0)
             .build()
 
         mServer.setupConfigResponse(config1.toString())

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -41,7 +41,7 @@ public class MParticleOptions {
     private Boolean mAndroidIdDisabled = false;
     private Integer mUploadInterval = ConfigManager.DEFAULT_UPLOAD_INTERVAL;  //seconds
     private Integer mSessionTimeout = ConfigManager.DEFAULT_SESSION_TIMEOUT_SECONDS; //seconds
-    private Long mConfigMaxAge = null;
+    private Integer mConfigMaxAge = null;
     private Boolean mUnCaughtExceptionLogging = false;
     private MParticle.LogLevel mLogLevel = MParticle.LogLevel.DEBUG;
     private AttributionListener mAttributionListener;
@@ -227,7 +227,7 @@ public class MParticleOptions {
     }
 
     @NonNull
-    public Long getConfigMaxAge() {
+    public Integer getConfigMaxAge() {
         return mConfigMaxAge;
     }
 
@@ -333,7 +333,7 @@ public class MParticleOptions {
         private Boolean androidIdDisabled = null;
         private Integer uploadInterval = null;
         private Integer sessionTimeout = null;
-        private Long configMaxAge = null;
+        private Integer configMaxAge = null;
         private Boolean unCaughtExceptionLogging = null;
         private MParticle.LogLevel logLevel = null;
         BaseIdentityTask identityTask;
@@ -505,7 +505,7 @@ public class MParticleOptions {
          * @return the instance of the builder, for chaining calls
          */
         @NonNull
-        public Builder configMaxAgeSeconds(Long configMaxAge) {
+        public Builder configMaxAgeSeconds(int configMaxAge) {
             this.configMaxAge = configMaxAge;
             return this;
         }

--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -99,7 +99,7 @@ public class ConfigManager {
     private JSONObject mCurrentCookies;
     private String mDataplanId;
     private Integer mDataplanVersion;
-    private Long mMaxConfigAge;
+    private Integer mMaxConfigAge;
     public static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 30;
     public static final int MINIMUM_CONNECTION_TIMEOUT_SECONDS = 1;
     public static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 60;
@@ -130,7 +130,7 @@ public class ConfigManager {
         this(options.getContext(), options.getEnvironment(), options.getApiKey(), options.getApiSecret(), options.getDataplanOptions(), options.getDataplanId(), options.getDataplanVersion(), options.getConfigMaxAge(), options.getConfigurationsForTarget(ConfigManager.class));
     }
 
-    public ConfigManager(@NonNull Context context, @Nullable MParticle.Environment environment, @Nullable String apiKey, @Nullable String apiSecret, @Nullable MParticleOptions.DataplanOptions dataplanOptions, @Nullable String dataplanId, @Nullable Integer dataplanVersion, @Nullable Long configMaxAge, @Nullable List<Configuration<ConfigManager>> configurations) {
+    public ConfigManager(@NonNull Context context, @Nullable MParticle.Environment environment, @Nullable String apiKey, @Nullable String apiSecret, @Nullable MParticleOptions.DataplanOptions dataplanOptions, @Nullable String dataplanId, @Nullable Integer dataplanVersion, @Nullable Integer configMaxAge, @Nullable List<Configuration<ConfigManager>> configurations) {
         mContext = context.getApplicationContext();
         sPreferences = getPreferences(mContext);
         mLocalPrefs = new AppConfig(mContext, environment, sPreferences, apiKey, apiSecret);


### PR DESCRIPTION
## Summary
update configMaxAge field type from `Long` -> `int`. This will limit the client's ability to set a maximum config age threshold to 24,855 days, but that seems like a reasonable maximum in retrospect

## Testing Plan
updated existing tests

## Master Issue
Closes https://go.mparticle.com/work/77698
