### PR TITLE
fix: update java docs syntax after gradle upgrade

### DIFF
--- a/android-core/build.gradle
+++ b/android-core/build.gradle
@@ -96,17 +96,23 @@ android {
 }
 
 task coreSdkJavadocs(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        source += 'build/generated/source/buildConfig/release/'
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    android.libraryVariants.all { variant ->
+        if (variant.name == 'release') {
+            source = android.sourceSets.main.java.srcDirs
+            source += 'build/generated/source/buildConfig/release/'
+            owner.classpath += variant.javaCompileProvider.get().classpath
+            classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+            classpath += project.files('src/main/java')
+        }
         title = 'mParticle Android SDK API Reference'
-        failOnError false
+        failOnError true
+        getOptions().setNoTimestamp(true)
         exclude {
             String filePath = it.toString()
             filePath.contains('/com/mparticle/internal/') ||
                     filePath.contains('/com/mparticle/kits/')
         }
-        getOptions().setNoTimestamp(true)
+    }
 }
 
 task generateJavadocsJar(type: Jar, dependsOn: coreSdkJavadocs) {
@@ -124,7 +130,7 @@ dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
     compileOnly 'com.android.installreferrer:installreferrer:[1.0, )'
     compileOnly 'com.google.android.instantapps:instantapps:[1.0, )'
-    compileOnly 'androidx.annotation:annotation:[1.0.0,)'
+    api 'androidx.annotation:annotation:[1.0.0,)'
     compileOnly 'androidx.core:core:[1.3.2, )'
 
     api 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -1623,6 +1623,10 @@ public class MParticle {
         void onReset();
     }
 
+
+    /**
+     * @hidden
+     */
     public class Internal {
         protected Internal() { }
 

--- a/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
@@ -460,6 +460,9 @@ public class IdentityApi {
         }
     }
 
+    /**
+     * @hidden
+     */
     public class Internal {
         public void reset() {
             IdentityApi.this.reset();

--- a/android-kit-base/build.gradle
+++ b/android-kit-base/build.gradle
@@ -40,16 +40,16 @@ android {
 }
 
 task kitSdkJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    source += 'build/generated/source/buildConfig/release/'
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    title = 'mParticle Android Kit API Reference'
-    failOnError false
     include {
         String filePath = it.toString()
         filePath.contains('KitIntegration.java') ||
                 filePath.contains('KitUtils')
     }
+    source = android.sourceSets.main.java.srcDirs
+    source += 'build/generated/source/buildConfig/release/'
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    title = 'mParticle Android Kit API Reference'
+    failOnError true
     getOptions().setNoTimestamp(true)
 }
 
@@ -65,7 +65,7 @@ task generateSourcesJar(type: Jar) {
 
 dependencies {
     api project(':android-core')
-    compileOnly 'androidx.annotation:annotation:[1.0.0,)'
+    api 'androidx.annotation:annotation:[1.0.0,)'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation  files('libs/java-json.jar')

--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,8 @@ allprojects {
         google()
         mavenCentral()
     }
+
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
 }


### PR DESCRIPTION
## Summary
- update java docs syntax after gradle upgrade

## Testing Plan
- CI tests should pass and javadocs should also generate

## Master Issue
Closes https://go.mparticle.com/work/78794
