### PR TITLE
ci: fix archive unit test results step

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: test-results
+          name: instrumented-test-results
           path: android-core/build/reports/androidTests/connected/**
 
   unit-tests:
@@ -63,9 +63,15 @@ jobs:
           java-version: "11"
       - name: "Run Unit Tests"
         run: ./gradlew test
-      - name: "Android Test Report"
+      - name: "Print Android Unit Tests Report"
         uses: asadmansr/android-test-report-action@v1.2.0
         if: ${{ always() }}
+      - name: "Archive Unit Test Results"
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: "unit-tests-results"
+          path: ./**/build/reports/**
   lint-checks:
     name: "Lint Checks"
     timeout-minutes: 15

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,8 +44,11 @@ jobs:
           java-version: "11"
       - name: "Run Unit Tests"
         run: ./gradlew test
-      - name: "Android Unit Tests Report"
+      - name: "Print Android Unit Tests Report"
         uses: asadmansr/android-test-report-action@v1.2.0
+        if: ${{ always() }}
+      - name: "Archive Unit Test Results"
+        uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: "unit-tests-results"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: test-results
+          name: instrumented-test-results
           path: android-core/build/reports/androidTests/connected/**
 
   unit-tests:
@@ -75,9 +75,15 @@ jobs:
           java-version: "11"
       - name: "Run Unit Tests"
         run: ./gradlew test
-      - name: "Android Test Report"
+      - name: "Print Android Unit Tests Report"
         uses: asadmansr/android-test-report-action@v1.2.0
         if: ${{ always() }}
+      - name: "Archive Unit Test Results"
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: "unit-tests-results"
+          path: ./**/build/reports/**
 
   update-kits:
     name: "Update Kits"


### PR DESCRIPTION
## Summary
Fix the configuration of our "Archive Unit Test Results" step. Previously we were _printing_ the results to the console, but failing to archive the files

## Testing Plan

## Master Issue
Closes https://go.mparticle.com/work/80837
