### PR TITLE
feat: split configuration into core and kits

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/PushRegistrationTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/PushRegistrationTest.java
@@ -163,9 +163,17 @@ public class PushRegistrationTest extends BaseCleanStartedEachTest {
                     //For enablePushNotifications() to set the push registration, we need to mimic
                     //the Firebase dependency, and clear the push-fetched flags
                     TestingUtils.setFirebasePresent(true, pushRegistration.instanceId);
-                    ConfigManager.getInstance(mContext).clearPushRegistration();
-
                     MParticle.getInstance().Messaging().enablePushNotifications(pushRegistration.senderId);
+                    //this method setting push is async, so wait for confirmation before continuing
+                    ConfigManager configManager = ConfigManager.getInstance(mContext);
+                    while (!configManager.isPushEnabled()) {
+                        try {
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    TestingUtils.setFirebasePresent(false, null);
                 }
 
                 @Override
@@ -249,7 +257,7 @@ public class PushRegistrationTest extends BaseCleanStartedEachTest {
 
                 @Override
                 public String getName() {
-                    return null;
+                    return "startMParticle(MParticleOptions.builder(mContext).pushRegistration(null, null))";
                 }
             }
     };

--- a/android-core/src/androidTest/java/com/mparticle/internal/ConfigManagerInstrumentedTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/internal/ConfigManagerInstrumentedTest.java
@@ -1,15 +1,25 @@
 package com.mparticle.internal;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.mparticle.Configuration;
 import com.mparticle.MParticle;
+import com.mparticle.MParticleOptions;
+import com.mparticle.testutils.AndroidUtils;
 import com.mparticle.testutils.BaseAbstractTest;
+import com.mparticle.testutils.MPLatch;
+import com.mparticle.testutils.TestingUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ConfigManagerInstrumentedTest extends BaseAbstractTest {
 
@@ -49,7 +59,7 @@ public class ConfigManagerInstrumentedTest extends BaseAbstractTest {
     }
 
     @Test
-    public void testConfigParsing() throws JSONException, InterruptedException {
+    public void testConfigResponseParsing() throws JSONException, InterruptedException {
         String token = mRandomUtils.getAlphaNumericString(20);
         int aliasMaxWindow = ran.nextInt();
 
@@ -58,17 +68,125 @@ public class ConfigManagerInstrumentedTest extends BaseAbstractTest {
                 .put(ConfigManager.ALIAS_MAX_WINDOW, aliasMaxWindow);
 
         mServer.setupConfigResponse(config.toString());
+        BothConfigsLoadedListener configLoadedListener = new BothConfigsLoadedListener();
+        MPLatch latch = configLoadedListener.latch;
 
-        startMParticle();
+        startMParticle(MParticleOptions.builder(mContext).configuration(new AddConfigListener(configLoadedListener)));
+        latch.await();
+
         assertEquals(token, MParticle.getInstance().Internal().getConfigManager().getWorkspaceToken());
         assertEquals(aliasMaxWindow, MParticle.getInstance().Internal().getConfigManager().getAliasMaxWindow());
 
         //test set defaults when fields are not present
         MParticle.setInstance(null);
         mServer.setupConfigResponse(new JSONObject().toString());
-        startMParticle();
+        configLoadedListener = new BothConfigsLoadedListener();
+        latch = configLoadedListener.latch;
+
+        startMParticle(MParticleOptions.builder(mContext).configuration(new AddConfigListener(configLoadedListener)));
+        latch.await();
+
         assertEquals("", MParticle.getInstance().Internal().getConfigManager().getWorkspaceToken());
         assertEquals(90, MParticle.getInstance().Internal().getConfigManager().getAliasMaxWindow());
+    }
 
+    @Test
+    public void cachedConfigLoadedExactlyOnce() throws InterruptedException, JSONException {
+        MPLatch latch = new MPLatch(1);
+        AndroidUtils.Mutable<Boolean> loadedCoreLocal = new AndroidUtils.Mutable<>(false);
+        AndroidUtils.Mutable<Boolean> loadedKitLocal = new AndroidUtils.Mutable<>(false);
+
+        setCachedConfig(getSimpleConfigWithKits());
+        mServer.setupConfigDeferred();
+        ConfigManager.ConfigLoadedListener configLoadedListener = new ConfigManager.ConfigLoadedListener() {
+            @Override
+            public void onConfigUpdated(ConfigManager.ConfigType configType, boolean isNew) {
+                if (!isNew) {
+                    switch (configType) {
+                        case CORE:
+                            if (loadedCoreLocal.value) {
+                                fail("core config already loaded");
+                            } else {
+                                Logger.error("LOADED CACHED Core");
+                                loadedCoreLocal.value = true;
+                            }
+                        case KIT:
+                            if (loadedKitLocal.value) {
+                                fail("kit config already loaded");
+                            } else {
+                                Logger.error("LOADED CACHED Kit");
+                                loadedKitLocal.value = true;
+                            }
+                    }
+                }
+                if (loadedCoreLocal.value && loadedKitLocal.value) {
+                    latch.countDown();
+
+                }
+                Logger.error("KIT = " + loadedKitLocal.value + " Core: " + loadedCoreLocal.value);
+            }
+        };
+        MParticleOptions options = MParticleOptions.builder(mContext)
+                .credentials("key", "secret")
+                .configuration(new AddConfigListener(configLoadedListener))
+                .build();
+        MParticle.start(options);
+
+        //wait until both local configs are loaded
+        latch.await();
+
+        //try to coerce another load...
+        new ConfigManager(mContext);
+        MParticle instance = MParticle.getInstance();
+        instance.logEvent(TestingUtils.getInstance().getRandomMPEventSimple());
+        instance.setOptOut(true);
+        instance.setOptOut(false);
+
+        //and finally, load remote config
+        mServer.setupConfigResponse(getSimpleConfigWithKits().toString());
+        fetchConfig();
+        BothConfigsLoadedListener bothConfigsLoadedListener = new BothConfigsLoadedListener();
+        MPLatch reloadLatch = bothConfigsLoadedListener.latch;
+        MParticle.getInstance().Internal().getConfigManager().addConfigUpdatedListener(bothConfigsLoadedListener);
+        reloadLatch.await();
+    }
+
+    class BothConfigsLoadedListener implements ConfigManager.ConfigLoadedListener {
+        Set<ConfigManager.ConfigType> types;
+        MPLatch latch = new MPLatch(1);
+
+        public BothConfigsLoadedListener(ConfigManager.ConfigType... configTypes) {
+            if (configTypes == null || configTypes.length == 0) {
+                configTypes = new ConfigManager.ConfigType[]{ConfigManager.ConfigType.CORE};
+            }
+            types = this.types = new HashSet<ConfigManager.ConfigType>(Arrays.asList(configTypes));
+        }
+        @Override
+        public void onConfigUpdated(ConfigManager.ConfigType configType, boolean isNew) {
+            if (isNew) {
+                types.remove(configType);
+            }
+            if (types.size() == 0) {
+                latch.countDown();
+            }
+        }
+    }
+
+    class AddConfigListener implements Configuration<ConfigManager> {
+        ConfigManager.ConfigLoadedListener configLoadedListener;
+
+        public AddConfigListener(ConfigManager.ConfigLoadedListener configLoadedListener) {
+            this.configLoadedListener = configLoadedListener;
+        }
+
+        @Override
+        public Class<ConfigManager> configures() {
+            return ConfigManager.class;
+        }
+
+        @Override
+        public void apply(ConfigManager configManager) {
+            configManager.addConfigUpdatedListener(configLoadedListener);
+        }
     }
 }

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigMigrationTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigMigrationTest.kt
@@ -1,0 +1,140 @@
+package com.mparticle.internal
+
+import com.mparticle.MParticle
+import com.mparticle.MParticleOptions
+import com.mparticle.testutils.BaseCleanInstallEachTest
+import org.json.JSONObject
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ConfigMigrationTest: BaseCleanInstallEachTest() {
+    private val oldConfigSharedprefsKey= "json"
+
+    @Test
+    fun testConfigContentsMigratedProperly() {
+        //store config in the old place
+        val oldConfig = JSONObject().put("foo", "bar")
+        setOldConfigState(oldConfig)
+
+        //double check that there is nothing stored in the new place
+        assertOldConfigState(oldConfig)
+
+        //initialize ConfigManager
+        val configManager = ConfigManager(mContext)
+
+        //make sure the config is in the new place and gone from the old
+        assertNewConfigState(oldConfig)
+
+        //make sure config is also available via ConfigManager api
+        assertEquals(oldConfig.toString(), configManager.config)
+    }
+
+    @Test
+    fun testConfigMetadataRemainsDuringMigration() {
+        val oldConfig = JSONObject().put("foo", "bar")
+        val testTimestamp = System.currentTimeMillis() - 1000L
+        val testEtag = "some etag"
+        val testIfModified = "foo bar"
+
+        //set metadata + config in the old place
+        ConfigManager(mContext).apply {
+            saveConfigJson(JSONObject(), null, testEtag, testIfModified, testTimestamp)
+            setOldConfigState(oldConfig)
+        }
+
+        assertOldConfigState(oldConfig)
+
+        //trigger migration, check that config metadata remained the same
+        ConfigManager(mContext).apply {
+            assertNewConfigState(oldConfig)
+            assertEquals(oldConfig.toString(), config)
+            assertEquals(testTimestamp, configTimestamp)
+            assertEquals(testEtag, etag)
+            assertEquals(testIfModified, ifModified)
+        }
+    }
+
+    @Test
+    fun testMigratingStaleConfig() {
+        val oldConfig = JSONObject().put("foo", "bar")
+        val testTimestamp = System.currentTimeMillis() - 1000L
+        val testEtag = "some etag"
+        val testIfModified = "foo bar"
+
+        //set metadata + config in the old place
+        ConfigManager(mContext).apply {
+            saveConfigJson(JSONObject(), null, testEtag, testIfModified, testTimestamp)
+            setOldConfigState(oldConfig)
+        }
+
+        assertOldConfigState(oldConfig)
+
+        MParticleOptions.builder(mContext)
+            .credentials("key", "secret")
+            .configMaxAgeSeconds(0)
+            .build()
+            .let {
+                //start it the simple way, we don't want to block or anything so we can test config state
+                MParticle.start(it)
+            }
+
+        //make sure config is deleted
+        MParticle.getInstance()!!.Internal().configManager.let {
+            assertNull(it.config)
+            assertNull(it.configTimestamp)
+            assertNull(it.etag)
+            assertNull(it.ifModified)
+        }
+    }
+
+    @Test
+    fun testMigratingNotStaleConfig() {
+        val oldConfig = JSONObject().put("foo", "bar")
+        val testTimestamp = System.currentTimeMillis() - 1000L
+        val testEtag = "some etag"
+        val testIfModified = "foo bar"
+
+        //set metadata + config in the old place
+        ConfigManager(mContext).apply {
+            saveConfigJson(JSONObject(), null, testEtag, testIfModified, testTimestamp)
+            setOldConfigState(oldConfig)
+        }
+
+        assertOldConfigState(oldConfig)
+
+        MParticleOptions.builder(mContext)
+            .credentials("key", "secret")
+            .configMaxAgeSeconds(Integer.MAX_VALUE)
+            .build()
+            .let {
+                //start it the simple way, we don't want to block or anything so we can test config state
+                MParticle.start(it)
+            }
+
+        //make sure config is deleted
+        MParticle.getInstance()!!.Internal().configManager.let {
+            assertEquals(oldConfig.toString(), it.config)
+            assertEquals(testTimestamp, it.configTimestamp)
+            assertEquals(testEtag, it.etag)
+            assertEquals(testIfModified, it.ifModified)
+        }
+    }
+
+    private fun setOldConfigState(config: JSONObject) {
+        MPUtilityKotlin.clearFile(mContext, ConfigManager.CONFIG_FILE_NAME)
+        ConfigManager.getPreferences(mContext).edit().putString(oldConfigSharedprefsKey, config.toString()).apply()
+    }
+
+    private fun assertOldConfigState(config: JSONObject) {
+        assertNull(MPUtilityKotlin.readFile(mContext, ConfigManager.CONFIG_FILE_NAME))
+        assertEquals(config.toString(), ConfigManager.getPreferences(mContext).getString(oldConfigSharedprefsKey, null))
+    }
+
+    private fun assertNewConfigState(config: JSONObject) {
+        val configString = ConfigManager.getPreferences(mContext).getString(ConfigManager.CONFIG_JSON, null)
+        assertNull(JSONObject(configString).optJSONArray(ConfigManager.KEY_EMBEDDED_KITS))
+        assertEquals(config.optString(ConfigManager.KEY_EMBEDDED_KITS, null), MPUtilityKotlin.readFile(mContext, ConfigManager.CONFIG_FILE_NAME))
+    }
+}

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/ConfigStalenessCheckTest.kt
@@ -172,7 +172,7 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
         latch.await()
 
         //after config has been fetched, we should see config2
-        assertEquals(config2.toString(), MParticle.getInstance()?.Internal()?.configManager?.config)
+        assertEquals(config2.toString(), configManager.config)
     }
 
     private fun randomJson(size: Int) =
@@ -190,8 +190,8 @@ class ConfigStalenessCheckTest: BaseCleanInstallEachTest() {
     fun MParticleOptions.Builder.addCredentials() = this.credentials("apiKey", "apiSecret")
 
     fun ConfigManager.onNewConfig(callback: () -> Unit) {
-        addConfigUpdatedListener { configType, config ->
-            if (configType == ConfigManager.ConfigType.NEW) {
+        addConfigUpdatedListener { configType, isNew ->
+            if (isNew && configType == ConfigManager.ConfigType.CORE) {
                 callback()
             }
         }

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -196,6 +196,7 @@ public class MParticle {
                             instance.mConfigManager.clearPushRegistrationBackground();
                         }
                     }
+                    instance.mConfigManager.onMParticleStarted();
                 }
             }
         }

--- a/android-core/src/main/java/com/mparticle/internal/MPUtilityKotlin.kt
+++ b/android-core/src/main/java/com/mparticle/internal/MPUtilityKotlin.kt
@@ -1,0 +1,59 @@
+package com.mparticle.internal
+
+import android.content.Context
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
+
+object MPUtilityKotlin {
+
+    @JvmStatic
+    fun readFile(context: Context, path: String): String? {
+        return try {
+            getFile(context, path).run {
+                if (exists())  {
+                    readText(Charsets.UTF_8)
+                } else {
+                    null
+                }
+            }
+        } catch (ex: Exception) {
+            Logger.warning("Unable to read file $path")
+            null
+        }
+    }
+
+    @JvmStatic
+    fun writeToFile(context: Context, path: String, contents: String?): Boolean {
+        return try {
+            getFile(context, path).apply {
+                if (contents.isNullOrEmpty()) {
+                    clearFile(context, path)
+                } else {
+                    if (!exists()) {
+                        parentFile.mkdirs()
+                        createNewFile()
+                    }
+                    writeText(contents ?: "", Charsets.UTF_8)
+                }
+            }
+            true
+        } catch (ex: Exception) {
+            Logger.warning("Unable to write to $path")
+            Logger.debug(ex.stackTraceToString())
+            false
+        }
+    }
+
+    @JvmStatic
+    fun clearFile(context: Context, path: String) {
+        getFile(context, path).apply {
+            if (exists()) {
+                delete()
+            }
+        }
+    }
+
+    private fun getFile(context: Context,  path: String): File = File(context.filesDir.path, path)
+}

--- a/android-core/src/main/java/com/mparticle/internal/MessageManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/MessageManager.java
@@ -830,7 +830,7 @@ public class MessageManager implements MessageManagerCallbacks, ReportingManager
     }
 
     public void initConfigDelayed() {
-        mUploadHandler.sendEmptyMessageDelayed(UploadHandler.INIT_CONFIG, 20 * 1000);
+        mUploadHandler.sendEmptyMessageDelayed(UploadHandler.INIT_CONFIG, 1000);
     }
 
     @Override

--- a/android-core/src/test/java/com/mparticle/internal/ConfigManagerTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/ConfigManagerTest.java
@@ -49,11 +49,31 @@ public class ConfigManagerTest {
     }
 
     @Test
+    public void testInitialization() {
+        manager = new ConfigManager(context, MParticle.Environment.Production, "key1", "secret1", null, null, null, null, null);
+        assertEquals("key1", manager.getApiKey());
+        assertEquals("secret1", manager.getApiSecret());
+        assertEquals(MParticle.Environment.Production, ConfigManager.getEnvironment());
+
+        //should persist when we start configmanager without any arguments
+        manager = new ConfigManager(context);
+        assertEquals("key1", manager.getApiKey());
+        assertEquals("secret1", manager.getApiSecret());
+        assertEquals(MParticle.Environment.Production, ConfigManager.getEnvironment());
+
+        //updates key/secret if one is non-null
+        manager = new ConfigManager(context, MParticle.Environment.Development, "key2", null, null, null, null, null, null);
+        assertEquals("key2", manager.getApiKey());
+        assertNull(manager.getApiSecret());
+        assertEquals(MParticle.Environment.Development, ConfigManager.getEnvironment());
+    }
+
+    @Test
     public void testSaveConfigJson() throws Exception {
-        manager.saveConfigJson(null, null, null);
+        manager.saveConfigJson(null);
         JSONObject json = new JSONObject();
         json.put("test", "value");
-        manager.saveConfigJson(json, null, null);
+        manager.saveConfigJson(json);
         JSONObject object = new JSONObject(manager.sPreferences.getString(ConfigManager.CONFIG_JSON, null));
         assertNotNull(object);
     }
@@ -76,7 +96,7 @@ public class ConfigManagerTest {
     @Test
     public void testUpdateConfigWithReload() throws Exception {
         manager.updateConfig(new JSONObject(sampleConfig));
-        manager.reloadConfig(new JSONObject());
+        manager.reloadCoreConfig(new JSONObject());
         JSONObject object = new JSONObject(manager.sPreferences.getString(ConfigManager.CONFIG_JSON, null));
         assertTrue(object.keys().hasNext());
     }
@@ -653,7 +673,7 @@ public class ConfigManagerTest {
         assertNull(manager.getConfigTimestamp());
 
         //test reload() does not set config
-        manager.reloadConfig(newConfigJson);
+        manager.reloadCoreConfig(newConfigJson);
         assertNull(manager.getConfig());
         assertNull(manager.getEtag());
         assertNull(manager.getIfModified());

--- a/testutils/src/main/java/com/mparticle/mock/MockApplication.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockApplication.java
@@ -7,6 +7,8 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 
+import java.io.File;
+
 /**
  * Created by sdozor on 4/10/15.
  */
@@ -61,5 +63,10 @@ public class MockApplication extends Application {
     @Override
     public Resources getResources() {
         return mContext.getResources();
+    }
+
+    @Override
+    public File getFilesDir() {
+        return mContext.getFilesDir();
     }
 }

--- a/testutils/src/main/java/com/mparticle/mock/MockContext.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockContext.java
@@ -404,7 +404,7 @@ public class MockContext extends Context {
 
     @Override
     public File getFilesDir() {
-        return null;
+        return new File("test_dir");
     }
 
     @Override

--- a/testutils/src/main/java/com/mparticle/testutils/BaseAbstractTest.java
+++ b/testutils/src/main/java/com/mparticle/testutils/BaseAbstractTest.java
@@ -243,6 +243,10 @@ public abstract class BaseAbstractTest {
     }
 
     protected JSONObject setupConfigMessageForKits(Map<Class<? extends KitIntegration>, JSONObject> kitIds) {
+        return setupConfigMessageForKits(kitIds, false);
+    }
+
+    protected JSONObject setupConfigMessageForKits(Map<Class<? extends KitIntegration>, JSONObject> kitIds, Boolean localConfigOnly) {
         JSONArray eks = new JSONArray();
         int i = -1;
         mCustomTestKits = new HashMap<>();
@@ -266,11 +270,36 @@ public abstract class BaseAbstractTest {
         }
         try {
             JSONObject configObject = new JSONObject().put("eks", eks);
-            mServer.setupConfigResponse(configObject.toString());
+            if (localConfigOnly) {
+                 mServer.setupConfigDeferred();
+            } else {
+                mServer.setupConfigResponse(configObject.toString());
+            }
             return configObject;
         } catch (JSONException e) {
             throw new RuntimeException("Error sending custom eks to config.");
         }
+    }
+
+    protected void fetchConfig() {
+        MParticle.getInstance().Internal().getMessageManager().refreshConfiguration();
+    }
+
+    protected void setCachedConfig(JSONObject config) throws JSONException {
+        ConfigManager.getInstance(mContext).saveConfigJson(config, null, null, System.currentTimeMillis());
+    }
+
+    protected JSONObject getSimpleConfigWithKits() throws JSONException {
+        return new JSONObject()
+                .put("id", 12345)
+                .put(
+                        "eks",
+                        new JSONArray()
+                                .put(
+                                        new JSONObject()
+                                                .put("id", 1)
+                                )
+                );
     }
 
     private boolean checkStorageCleared(int counter) {


### PR DESCRIPTION
## Summary
`SharedPreferences` loads pretty slow. Worse than that, it seems to grow linearly with the overall size of the file. The edge cases where we see very slow startup time are generally in cases where the user has a large number of Kit filters or projections, which lead to a very large config (stored in `SharedPreferences`) and result in a slow loading time when we fetch our first pair from the file. Outside of the various Kit configuration properties, the rest of the config has a fairly low ceiling for how big it could possibly get.

Since we don't actually need the kit portion of the configuration at startup, it makes sense to store it outside of `SharedPreferences` so we can load _just_ the data we need at startup. This PR splits the config when it is fetched and continues to persist the "core config" (everything outside of `"eks"`) in `SharedPreferences`, but saves the "kit config" (`"eks"`) in a separate file. Instead of being loaded on SDK initialization, the kit config will not be loaded in `delayedStart()`. Additionally, we reduced the delay for `delayedStart()` from 20 seconds to 1 second (reviewed w/Sam)

Additionally, we added a migration step that will remove any old kit config that may be stored in `SharedPreferences` when the SDK is initialized


## Testing Plan
Added tests coving the migration logic, fixed the flakey `PustRegistrationTest` case

## Master Issue
Closes https://go.mparticle.com/work/80843
