### PR TITLE
feat: synchronize File IO

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/MPUtilityKotlinTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/MPUtilityKotlinTest.kt
@@ -1,0 +1,71 @@
+package com.mparticle.internal
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import com.mparticle.testutils.AndroidUtils
+import com.mparticle.testutils.BaseAbstractTest
+import com.mparticle.testutils.MPLatch
+import com.mparticle.testutils.RandomUtils
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class MPUtilityKotlinTest: BaseAbstractTest() {
+    val cruft = RandomUtils().getAlphaNumericString(1000)
+
+    @Test
+    fun testFileSynchronization() {
+        val thread1Handler = HandlerThread("some thread1")
+            .apply { start() }
+            .let { Handler(it.looper) }
+        val thread2Handler = HandlerThread("some thread2")
+            .apply { start() }
+            .let { Handler(it.looper) }
+        val assertionThreadHandler = HandlerThread("some thread2")
+            .apply { start() }
+            .let { Handler(it.looper) }
+
+        val thread1Count = AndroidUtils.Mutable(1000)
+        val thread2Count = AndroidUtils.Mutable(1000)
+
+        var runnable = {}
+        runnable = {
+            val contents = MPUtilityKotlin.readFile(mContext, "testFile")
+            if (contents != cruft) {
+                fail("Corrupted file! File writes may not be synchronized")
+            }
+            MPUtilityKotlin.writeToFile(mContext, "testFile",cruft)
+            val loopCount = if (Looper.myLooper() == thread1Handler.looper) {
+                thread1Count
+            } else {
+                thread2Count
+            }
+            loopCount.value = loopCount.value - 1
+            if (loopCount.value > 0) {
+                if (Looper.myLooper() == thread1Handler.looper) {
+                    thread1Handler.post(runnable)
+                } else {
+                    thread2Handler.post(runnable)
+                }
+            }
+        }
+        MPUtilityKotlin.writeToFile(mContext, "testFile", cruft)
+        thread1Handler.post(runnable)
+        thread2Handler.post(runnable)
+
+        val latch = MPLatch(1)
+        assertionThreadHandler.post {
+            while (thread2Count.value > 0 || thread1Count.value > 0) {
+
+            }
+            latch.countDown()
+        }
+        latch.await()
+
+        assertEquals(cruft, MPUtilityKotlin.readFile(mContext, "testFile"))
+
+
+
+    }
+}

--- a/testutils/src/main/java/com/mparticle/mock/MockApplication.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockApplication.java
@@ -69,4 +69,9 @@ public class MockApplication extends Application {
     public File getFilesDir() {
         return mContext.getFilesDir();
     }
+
+    @Override
+    public File getCacheDir() {
+        return mContext.getCacheDir();
+    }
 }

--- a/testutils/src/main/java/com/mparticle/mock/MockContext.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockContext.java
@@ -435,7 +435,7 @@ public class MockContext extends Context {
 
     @Override
     public File getCacheDir() {
-        return null;
+        return new File("test_cache_dir");
     }
 
     @Override


### PR DESCRIPTION
## Summary
Synchronize File IO by the file name. Also move the file location from `Context#fileDir` to `Context#cacheDir`

## Testing Plan
Added instrumented test that forces a collision. If you remove the `synchronized { }` block, it will fail

## Master Issue
Closes https://go.mparticle.com/work/81231
