### PR TITLE
fix: keep package names in proguard to prevent collisions

### DIFF
--- a/android-core/proguard.pro
+++ b/android-core/proguard.pro
@@ -80,6 +80,7 @@
 -keepparameternames
 -renamesourcefileattribute SourceFile
 -keepattributes Exceptions,InnerClasses,Signature,Deprecated,SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
+-repackageclasses com.mparticle
 
 -keep class com.mparticle.MPEvent$* { *; }
 -keep class com.mparticle.MParticle { *; }


### PR DESCRIPTION
## Summary
In our current Proguard configuration, as long as one class is "kept", it will preserve the package name for all classes within. When there are **no** classes kept in a given package, proguard will remove the package alltogether. Unfortunatley we have one package, `com.mparticle.internal.database` which has no kept classes, so these package name is removed, which leaves these classes (obfuscated as `a.java`, `b.java`, etc) open to an east namespace collision.

My fix enables a default package of `com.mparticle`, so all classes will _at least_ be under the "com.mparticle" namespace

## Testing Plan
existing tests pass 

## Master Issue
Closes https://go.mparticle.com/work/81502

### Public Issue
https://github.com/mParticle/mparticle-android-sdk/issues/107
