### PR TITLE
fix: typo in GA4 kit name

### DIFF
--- a/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
@@ -55,7 +55,7 @@ public class KitIntegrationFactory {
         kits.put(MParticle.ServiceProviders.RESPONSYS,                  "com.mparticle.kits.ResponsysKit");
         kits.put(MParticle.ServiceProviders.CLEVERTAP,                  "com.mparticle.kits.CleverTapKit");
         kits.put(MParticle.ServiceProviders.GOOGLE_ANALYTICS_FIREBASE,  "com.mparticle.kits.GoogleAnalyticsFirebaseKit");
-        kits.put(MParticle.ServiceProviders.GOOGLE_ANALYTICS_FIREBASE_GA4,  "com.mparticle.kits.GoogleAnalyticsFirebaseKitGA4");
+        kits.put(MParticle.ServiceProviders.GOOGLE_ANALYTICS_FIREBASE_GA4,  "com.mparticle.kits.GoogleAnalyticsFirebaseGA4Kit");
         kits.put(MParticle.ServiceProviders.PILGRIM,                    "com.mparticle.kits.PilgrimKit");
         kits.put(MParticle.ServiceProviders.ONETRUST,                   "com.mparticle.kits.OneTrustKit");
         kits.put(MParticle.ServiceProviders.SWRVE,                      "com.mparticle.kits.SwrveKit");


### PR DESCRIPTION
## Summary
- Fix typo in the GoogleAnalyticsFirebaseGAKit qualified class name. In its current state, the KitIntegrationFactory is unable to find the kit class

## Testing Plan
manually tested, I don't believe there is any way for us to unit test this effectively

## Master Issue
- Closes https://go.mparticle.com/work/[81918](https://mparticle.tpondemand.com/RestUI/Board.aspx#page=userstory/81918&appConfig=eyJhY2lkIjoiMjM4RjY2OUU2RkYxNzFCMTVCMUU5Q0JCRDlFQzQyRTAifQ==)
