### PR TITLE
ci: improve instrumented test consistency 

### DIFF
--- a/android-core/build.gradle
+++ b/android-core/build.gradle
@@ -158,7 +158,13 @@ dependencies {
 }
 
 
-//trigger the secondary core build, which will be consumed by the custom-lint module
+configurations {
+    all {
+        exclude module: "httpclient"
+        exclude module: "commons-logging"
+    }
+}
+
 afterEvaluate {
     android.buildTypes.all { theBuildType ->
         android.sourceSets.all { sourceSet ->

--- a/android-core/src/androidTest/java/com/mparticle/identity/MParticleIdentityClientImplTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/identity/MParticleIdentityClientImplTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
 import static com.mparticle.identity.MParticleIdentityClientImpl.ANDROID_AAID;
@@ -203,13 +204,13 @@ public class MParticleIdentityClientImplTest extends BaseCleanStartedEachTest {
 
     @Test
     public void testModifyMessage() throws Exception {
-        mConfigManager.setMpid(ran.nextLong(), ran.nextBoolean());
         int iterations = 5;
-        for (int i = 0; i < iterations; i++) {
+        for (int i = 1; i <= iterations; i++) {
+            mConfigManager.setMpid(i, ran.nextBoolean());
+
             final Map<MParticle.IdentityType, String> oldUserIdentities = mRandomUtils.getRandomUserIdentities();
             final Map<MParticle.IdentityType, String> newUserIdentities = mRandomUtils.getRandomUserIdentities();
 
-            AccessUtils.clearUserIdentities((MParticleUserImpl)MParticle.getInstance().Identity().getCurrentUser());
             ((MParticleUserImpl)MParticle.getInstance().Identity().getCurrentUser()).setUserIdentities(oldUserIdentities);
 
             final CountDownLatch latch = new MPLatch(1);
@@ -241,9 +242,9 @@ public class MParticleIdentityClientImplTest extends BaseCleanStartedEachTest {
                                     assertEquals(newValue, newUserIdentities.get(identityType));
                                 }
                             }
+                            setApiClient(null);
                             checked.value = true;
                             latch.countDown();
-                            setApiClient(null);
                         }
                 }
             });


### PR DESCRIPTION
## Summary
testModifyMessage() is one of our flakier tests and I found this is in part due to some asynchronous writed to `SharedPreferences`. In this test, we are making multiple updates to the same mpid/user, which is not required for the test case. This update simply changes the user each iteration so we do not need to account for the async updates

## Testing Plan
existing tests pass

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3571
