### PR TITLE
fix: Proguard keeps KitsLoadedCallback

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,10 +101,34 @@ jobs:
         with:
           name: "kotlin-lint-results"
           path: ./**/build/reports/**
+  kit-compatibility-test:
+      name: "Kit Compatibility Test"
+      runs-on: ubuntu-20.04
+      if: github.event_name == 'pull_request'
+      steps:
+        - name: "Checkout Branch"
+          uses: actions/checkout@v2
+          with:
+            repository: ${{github.event.pull_request.head.repo.full_name}}
+            ref: ${{github.head_ref}}
+            submodules: recursive
+        - name: "Install JDK 11"
+          uses: actions/setup-java@v2
+          with:
+            distribution: "zulu"
+            java-version: "11"
+        - name: "Get Latest Kits"
+          run: git submodule foreach "git checkout main"
+        - name: "Generate Core Release Build"
+          run: ./gradlew -PisRelease=true publishLocal
+        - name: "Run Kit-Base Release Tests and Build"
+          run: ./gradlew -PisRelease=true :android-kit-base:testRelease
+        - name: "Run Kit Release Tests and Build"
+          run: ./gradlew -PisRelease=true -p kits testRelease -c ../settings-kits.gradle
   automerge:
       name: "Rebase dependabot PRs"
       runs-on: ubuntu-18.04
-      needs: [instrumented-tests, unit-tests]
+      needs: [instrumented-tests, unit-tests, kit-compatibility-test]
       if: contains(github.repository, 'internal') && github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
       steps:
           - name: Rebase Dependabot PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
       - name: "Update Kit references"
         run: git submodule foreach "git fetch; git reset --hard origin/main";
       - name: "Test Kits"
-        run: ./gradlew -PisRelease=true clean testRelease publishReleaseLocal -c settings-kits.gradle
+        run: |
+          ./gradlew -PisRelease=true clean publishReleaseLocal -c settings-kits.gradle
+          ./gradlew -p kits testRelease
       - name: "Commit Kit Updates"
         run: |
           git add .

--- a/android-core/proguard.pro
+++ b/android-core/proguard.pro
@@ -134,7 +134,7 @@
 -keep class com.mparticle.internal.MParticleJSInterface { *; }
 -keep class com.mparticle.internal.Logger { *; }
 -keep class com.mparticle.internal.Logger$* { *; }
--keep class com.mparticle.internal.BackgroundTaskHandler { *; }
+-keep class com.mparticle.internal.KitsLoadedCallback { *; }
 
 -keep class com.mparticle.identity.IdentityApi { *; }
 -keep class com.mparticle.identity.IdentityApiRequest { *; }

--- a/android-core/src/main/java/com/mparticle/internal/BackgroundTaskHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/BackgroundTaskHandler.java
@@ -1,5 +1,0 @@
-package com.mparticle.internal;
-
-public interface BackgroundTaskHandler {
-    void executeNetworkRequest(Runnable runnable);
-}

--- a/android-core/src/main/java/com/mparticle/internal/MessageManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/MessageManager.java
@@ -1014,10 +1014,6 @@ public class MessageManager implements MessageManagerCallbacks, ReportingManager
         }
     }
 
-    public BackgroundTaskHandler getTaskHandler() {
-        return mUploadHandler;
-    }
-
     public Handler getMessageHandler() {
         return mMessageHandler;
     }

--- a/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
@@ -30,7 +30,7 @@ import static com.mparticle.networking.NetworkConnection.HTTP_TOO_MANY_REQUESTS;
 /**
  * Primary queue handler which is responsible for querying, packaging, and uploading data.
  */
-public class UploadHandler extends BaseHandler implements BackgroundTaskHandler {
+public class UploadHandler extends BaseHandler {
     private final Context mContext;
     MParticleDBManager mParticleDBManager;
     private final AppStateManager mAppStateManager;
@@ -335,11 +335,6 @@ public class UploadHandler extends BaseHandler implements BackgroundTaskHandler 
 
     public void fetchSegments(long timeout, String endpointId, SegmentListener listener) {
         new SegmentRetriever(audienceDB, mApiClient).fetchSegments(timeout, endpointId, listener);
-    }
-
-    @Override
-    public void executeNetworkRequest(Runnable runnable) {
-        post(runnable);
     }
 
     //added so unit tests can subclass

--- a/android-core/src/test/java/com/mparticle/internal/KitFrameworkWrapperTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/KitFrameworkWrapperTest.java
@@ -32,13 +32,6 @@ import static org.junit.Assert.*;
 @RunWith(PowerMockRunner.class)
 public class KitFrameworkWrapperTest {
 
-    private BackgroundTaskHandler mockBackgroundTaskHandler = new BackgroundTaskHandler() {
-        @Override
-        public void executeNetworkRequest(Runnable runnable) {
-
-        }
-    };
-
     @Test
     public void testLoadKitLibrary() throws Exception {
         ConfigManager mockConfigManager = Mockito.mock(ConfigManager.class);

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitIntegration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitIntegration.java
@@ -335,7 +335,7 @@ public abstract class KitIntegration {
      * Queues and groups network requests on the MParticle Core network handler
      */
     public void executeNetworkRequest(Runnable runnable) {
-        getKitManager().runOnBackgroundThread(runnable);
+        getKitManager().runOnKitThread(runnable);
     }
 
     /**

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -63,7 +63,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
 
     private final ReportingManager mReportingManager;
     protected final CoreCallbacks mCoreCallbacks;
-    private Handler mBackgroundTaskHandler;
+    private Handler mKitHandler;
     KitIntegrationFactory mKitIntegrationFactory;
     private DataplanFilter mDataplanFilter = DataplanFilterImpl.EMPTY;
     private KitOptions mKitOptions;
@@ -151,7 +151,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
     @Override
     public KitsLoadedCallback updateKits(final JSONArray kitConfigs) {
         KitsLoadedCallback callback = new KitsLoadedCallback();
-        runOnBackgroundThread(() -> {
+        runOnKitThread(() -> {
                     kitConfigurations = parseKitConfigurations(kitConfigs);
                     runOnMainThread(() -> {
                         configureKits(kitConfigurations);
@@ -1315,11 +1315,11 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
         }
     }
 
-    public void runOnBackgroundThread(Runnable runnable) {
-        if (mBackgroundTaskHandler == null) {
-            mBackgroundTaskHandler = new Handler(kitHandlerThread.getLooper());
+    public void runOnKitThread(Runnable runnable) {
+        if (mKitHandler == null) {
+            mKitHandler = new Handler(kitHandlerThread.getLooper());
         }
-        mBackgroundTaskHandler.post(runnable);
+        mKitHandler.post(runnable);
     }
 
     public void runOnMainThread(Runnable runnable) {

--- a/android-kit-base/src/test/java/com/mparticle/kits/KitManagerImplTest.java
+++ b/android-kit-base/src/test/java/com/mparticle/kits/KitManagerImplTest.java
@@ -13,7 +13,6 @@ import com.mparticle.consent.ConsentState;
 import com.mparticle.consent.GDPRConsent;
 import com.mparticle.identity.IdentityApi;
 import com.mparticle.identity.MParticleUser;
-import com.mparticle.internal.BackgroundTaskHandler;
 import com.mparticle.internal.CoreCallbacks;
 import com.mparticle.mock.MockKitConfiguration;
 import com.mparticle.mock.MockKitManagerImpl;
@@ -35,13 +34,6 @@ import java.util.List;
 import java.util.Map;
 
 public class KitManagerImplTest {
-    BackgroundTaskHandler mockBackgroundTaskHandler = new BackgroundTaskHandler(){
-
-        @Override
-        public void executeNetworkRequest(Runnable runnable) {
-            //do nothing
-        }
-    };
     MParticle mparticle;
     IdentityApi mockIdentity;
 

--- a/testutils/src/main/java/com/mparticle/mock/MockKitManagerImpl.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockKitManagerImpl.java
@@ -3,14 +3,11 @@ package com.mparticle.mock;
 import android.content.Context;
 
 import com.mparticle.MParticleOptions;
-import com.mparticle.internal.BackgroundTaskHandler;
 import com.mparticle.internal.CoreCallbacks;
 import com.mparticle.internal.ReportingManager;
 import com.mparticle.kits.KitConfiguration;
 import com.mparticle.kits.KitManagerImpl;
-import com.mparticle.testutils.MPLatch;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mockito.Mockito;
@@ -37,7 +34,7 @@ public class MockKitManagerImpl extends KitManagerImpl {
     }
 
     @Override
-    public void runOnBackgroundThread(Runnable runnable) {
+    public void runOnKitThread(Runnable runnable) {
         runnable.run();
     }
 


### PR DESCRIPTION
## Summary
Our last release failed because I missed a progaurd update in our last change which broke kits & kit-base in release builds.

This PR:
- fixes the missed proguard update
- fully removes a few usages of `BackgroundTaskHandler` that I missed
- adds a job in our PR GHA to test kits & kit-base against a release build of the current branch. Note, this will **only** run for pull requests

## Testing Plan
added additional tests to make sure these kinds of bugs are caught during PR

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3593
