### PR TITLE
ci: rollback extraneous release test change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,7 @@ jobs:
         run: git submodule foreach "git fetch; git reset --hard origin/main";
       - name: "Test Kits"
         run: |
-          ./gradlew -PisRelease=true clean publishReleaseLocal -c settings-kits.gradle
-          ./gradlew -p kits testRelease -c ../settings-kits.gradle
+          ./gradlew -PisRelease=true clean testRelease publishReleaseLocal -c settings-kits.gradle
       - name: "Commit Kit Updates"
         run: |
           git add .


### PR DESCRIPTION
## Summary
I beleive the original change we made was unneeded, and as we've moved to fix the implementation error, we're basically just ending up with what we had originally. This PR fully rolls back the change made [here](https://github.com/mParticle/mparticle-android-sdk/pull/119/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R114-R116)

## Testing Plan
- smoke tested locally 
- 
## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3708
