### PR TITLE
fix: include stopped kits in active-kits header

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -28,6 +28,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -444,7 +445,28 @@ public class ConfigManager {
     }
 
     public String getActiveModuleIds() {
-        return MParticle.getInstance().Internal().getKitManager().getActiveModuleIds();
+        Map<Integer, KitManager.KitStatus> kitStatusMap = MParticle.getInstance().Internal().getKitManager().getKitStatus();
+        List<Integer> activeKits = new ArrayList<>();
+        for (Map.Entry<Integer, KitManager.KitStatus> kitStatus: kitStatusMap.entrySet()) {
+            KitManager.KitStatus status = kitStatus.getValue();
+            switch (status) {
+                case ACTIVE:
+                case STOPPED:
+                    activeKits.add(kitStatus.getKey());
+            }
+        }
+        Collections.sort(activeKits);
+        if (activeKits.size() == 0) {
+            return "";
+        } else {
+            StringBuilder builder = new StringBuilder(activeKits.size() * 3);
+            for (Integer kitId: activeKits) {
+                builder.append(kitId);
+                builder.append(",");
+            }
+            builder.deleteCharAt(builder.length() - 1);
+            return builder.toString();
+        }
     }
 
     public boolean getIncludeSessionHistory() {

--- a/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
+++ b/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
@@ -25,6 +25,7 @@ import org.json.JSONArray;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -502,11 +503,12 @@ public class KitFrameworkWrapper implements KitManager {
     }
 
     @Override
-    public String getActiveModuleIds() {
+    public Map<Integer, KitStatus> getKitStatus() {
         if (mKitManager != null) {
-            return mKitManager.getActiveModuleIds();
+            return mKitManager.getKitStatus();
+        } else {
+            return new HashMap<>();
         }
-        return null;
     }
 
     @Override

--- a/android-core/src/main/java/com/mparticle/internal/KitManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/KitManager.java
@@ -82,7 +82,8 @@ public interface KitManager {
 
     void updateDataplan(@NonNull MParticleOptions.DataplanOptions dataplanOptions);
 
-    String getActiveModuleIds();
+    @NonNull
+    Map<Integer, KitStatus> getKitStatus();
 
     void onActivityCreated(Activity activity, Bundle savedInstanceState);
 
@@ -119,4 +120,10 @@ public interface KitManager {
     void onModifyCompleted(MParticleUser user, IdentityApiRequest request);
 
     void reset();
+
+    enum KitStatus {
+        NOT_CONFIGURED,
+        STOPPED,
+        ACTIVE
+    }
 }

--- a/android-core/src/test/java/com/mparticle/internal/ConfigManagerTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/ConfigManagerTest.java
@@ -103,9 +103,20 @@ public class ConfigManagerTest {
 
     @Test
     public void testGetActiveModuleIds() throws Exception {
-        Mockito.when(MParticle.getInstance().Internal().getKitManager().getActiveModuleIds())
-                .thenReturn("this is a test");
-        assertEquals("this is a test", manager.getActiveModuleIds());
+        Map<Integer, KitManager.KitStatus> kitStatusMap = new HashMap<>();
+        kitStatusMap.put(1, KitManager.KitStatus.STOPPED);
+        kitStatusMap.put(2, KitManager.KitStatus.ACTIVE);
+        kitStatusMap.put(3, KitManager.KitStatus.NOT_CONFIGURED);
+        kitStatusMap.put(5, KitManager.KitStatus.STOPPED);
+        kitStatusMap.put(4, KitManager.KitStatus.ACTIVE);
+        kitStatusMap.put(6, KitManager.KitStatus.NOT_CONFIGURED);
+        Mockito.when(MParticle.getInstance().Internal().getKitManager().getKitStatus())
+                .thenReturn(kitStatusMap);
+        assertEquals("1,2,4,5", manager.getActiveModuleIds());
+
+        Mockito.when(MParticle.getInstance().Internal().getKitManager().getKitStatus())
+                .thenReturn(new HashMap<>());
+        assertEquals("", manager.getActiveModuleIds());
     }
 
     @Test

--- a/android-kit-base/src/androidTest/java/com/mparticle/kits/KnownUserKitsLifecycleTest.java
+++ b/android-kit-base/src/androidTest/java/com/mparticle/kits/KnownUserKitsLifecycleTest.java
@@ -44,52 +44,40 @@ public class KnownUserKitsLifecycleTest extends BaseKitOptionsTest {
     @Test
     public void testExcludeUnknownUsers() throws InterruptedException {
         MParticle.getInstance().Internal().getConfigManager().setMpid(123, true);
-        waitForNewIdentityKitStart(123);
+        waitForKitReload();
 
         assertTrue(MParticle.getInstance().isKitActive(-1));
         assertTrue(MParticle.getInstance().isKitActive(-2));
         assertTrue(MParticle.getInstance().isKitActive(-3));
 
         MParticle.getInstance().Internal().getConfigManager().setMpid(123, false);
-        waitForNewIdentityKitStart(123);
+        waitForKitReload();
 
         assertFalse(MParticle.getInstance().isKitActive(-1));
         assertTrue(MParticle.getInstance().isKitActive(-2));
         assertFalse(MParticle.getInstance().isKitActive(-3));
 
         MParticle.getInstance().Internal().getConfigManager().setMpid(321, false);
-        waitForNewIdentityKitStart(321);
+        waitForKitReload();
 
         assertFalse(MParticle.getInstance().isKitActive(-1));
         assertTrue(MParticle.getInstance().isKitActive(-2));
         assertFalse(MParticle.getInstance().isKitActive(-3));
 
         MParticle.getInstance().Internal().getConfigManager().setMpid(123, true);
-        waitForNewIdentityKitStart(123);
+        waitForKitReload();
 
         assertTrue(MParticle.getInstance().isKitActive(-1));
         assertTrue(MParticle.getInstance().isKitActive(-2));
         assertTrue(MParticle.getInstance().isKitActive(-3));
 
         MParticle.getInstance().Internal().getConfigManager().setMpid(456, true);
-        waitForNewIdentityKitStart(456);
+        waitForKitReload();
 
         assertTrue(MParticle.getInstance().isKitActive(-1));
         assertTrue(MParticle.getInstance().isKitActive(-2));
         assertTrue(MParticle.getInstance().isKitActive(-3));
 
-    }
-
-    private void waitForNewIdentityKitStart(final long mpid) throws InterruptedException {
-        final CountDownLatch latch = new MPLatch(1);
-        AccessUtils.getKitManager().addKitsLoadedListener((kits, previousKits, kitConfigs) -> {
-            if (kitConfigs != null && kitConfigs.size() == 3) {
-                latch.countDown();
-                Logger.error("kits started: " + kits.size());
-            }
-        });
-        latch.await(3, TimeUnit.SECONDS);
-        assertEquals(mpid, MParticle.getInstance().Identity().getCurrentUser().getId());
     }
 
     public static class TestKit1 extends TestKit { }

--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/BaseKitOptionsTest.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/BaseKitOptionsTest.kt
@@ -73,4 +73,16 @@ open class BaseKitOptionsTest : BaseCleanInstallEachTest() {
         }
         latch.await()
     }
+
+    @Throws(InterruptedException::class)
+    @JvmOverloads
+    fun waitForKitReload(after: (() -> Unit)? = null) {
+        val latch = MPLatch(1)
+        com.mparticle.internal.AccessUtils.getKitManager()
+            .addKitsLoadedListener { _: Map<Int?, KitIntegration?>, _: Map<Int?, KitIntegration?>?, _: List<KitConfiguration?>? ->
+                latch.countDown()
+            }
+        after?.invoke()
+        latch.await()
+    }
 }

--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/KitManagerImplTests.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/KitManagerImplTests.kt
@@ -2,14 +2,19 @@ package com.mparticle.kits
 
 import android.os.Handler
 import android.os.Looper
+import com.mparticle.MPEvent
 import com.mparticle.MParticle
 import com.mparticle.MParticleOptions
 import com.mparticle.internal.ConfigManager
+import com.mparticle.internal.KitManager
 import com.mparticle.kits.testkits.AttributeListenerTestKit
 import com.mparticle.kits.testkits.IdentityListenerTestKit
 import com.mparticle.kits.testkits.UserAttributeListenerTestKit
+import com.mparticle.networking.Matcher
 import com.mparticle.testutils.MPLatch
 import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -48,5 +53,57 @@ class KitManagerImplTests : BaseKitOptionsTest() {
             }
         MParticle.reset(mContext)
         latch.countDown()
+    }
+
+    @Test
+    fun testActiveKitReporting() {
+        MParticleOptions.builder(mContext)
+            .configuration(
+                ConfiguredKitOptions {
+                    addKit(-1, AttributeListenerTestKit::class.java, JSONObject().put("eau", true))
+                    addKit(-2, IdentityListenerTestKit::class.java)
+                    addKit(-3, UserAttributeListenerTestKit::class.java)
+                    addKit(-4, AttributeListenerTestKit::class.java, JSONObject().put("eau", true))
+                    addKit(-5, IdentityListenerTestKit::class.java)
+                    addKit(-6, UserAttributeListenerTestKit::class.java)
+                }.apply {
+                    // do not make a config for kits with id -2 or -5..This will mimic having the
+                    // kit dependency in the classpath, but not in the /config response
+                    testingConfiguration[-2] = null
+                    testingConfiguration[-5] = null
+                }
+            ).let {
+                startMParticle(it)
+                waitForKitReload() {
+                    MParticle.getInstance()?.Internal()?.configManager?.setMpid(123, false)
+                }
+            }
+        val kitStatus = MParticle.getInstance()?.Internal()?.kitManager?.kitStatus
+        assertNotNull(kitStatus)
+        if (kitStatus == null) {
+            return
+        }
+        assertEquals(6, kitStatus.size)
+        assertEquals(kitStatus[-1], KitManager.KitStatus.STOPPED)
+        assertEquals(kitStatus[-2], KitManager.KitStatus.NOT_CONFIGURED)
+        assertEquals(kitStatus[-3], KitManager.KitStatus.ACTIVE)
+        assertEquals(kitStatus[-4], KitManager.KitStatus.STOPPED)
+        assertEquals(kitStatus[-5], KitManager.KitStatus.NOT_CONFIGURED)
+        assertEquals(kitStatus[-6], KitManager.KitStatus.ACTIVE)
+
+        // double check that ConfigManager is generating the right string
+        val expectedActiveKits = "-6,-4,-3,-1"
+        val expectedBundledKits = "-6,-5,-4,-3,-2.-1"
+        assertEquals(expectedActiveKits, MParticle.getInstance()?.Internal()?.configManager?.activeModuleIds)
+
+        // check that the active kits value is sent to the server
+        MParticle.getInstance()?.apply {
+            logEvent(MPEvent.Builder("some event").build())
+            upload()
+        }
+        mServer.waitForVerify(Matcher(mServer.Endpoints().eventsUrl)) {
+            assertEquals(it.headers["x-mp-kits"], expectedActiveKits)
+            assertEquals(it.headers["x-mp-bundled-kits"], expectedBundledKits)
+        }
     }
 }

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -311,25 +311,20 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
     }
 
     @Override
-    public String getActiveModuleIds() {
-        if (providers.isEmpty()) {
-            return "";
-        } else {
-            Set keys = providers.keySet();
-            StringBuilder buffer = new StringBuilder(keys.size() * 3);
-
-            Iterator<Integer> it = keys.iterator();
-            while (it.hasNext()) {
-                Integer next = it.next();
-                if (providers.get(next) != null && !providers.get(next).isDisabled()) {
-                    buffer.append(next);
-                    if (it.hasNext()) {
-                        buffer.append(",");
-                    }
-                }
-            }
-            return buffer.toString();
+    public Map<Integer, KitStatus> getKitStatus() {
+        Map<Integer, KitStatus> kitStatusMap = new HashMap<>();
+        for(Integer kitId: mKitIntegrationFactory.getSupportedKits()) {
+            kitStatusMap.put(kitId, KitStatus.NOT_CONFIGURED);
         }
+        for(KitConfiguration kitConfiguration: kitConfigurations) {
+            kitStatusMap.put(kitConfiguration.getKitId(), KitStatus.STOPPED);
+        }
+        for(Map.Entry<Integer, KitIntegration> activeKit: providers.entrySet()) {
+            if (!activeKit.getValue().isDisabled()) {
+                kitStatusMap.put(activeKit.getKey(), KitStatus.ACTIVE);
+            }
+        }
+        return kitStatusMap;
     }
 
     @Override

--- a/android-kit-base/src/test/java/com/mparticle/kits/KitManagerTest.java
+++ b/android-kit-base/src/test/java/com/mparticle/kits/KitManagerTest.java
@@ -2,6 +2,7 @@ package com.mparticle.kits;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -14,6 +15,7 @@ import android.os.Looper;
 import com.mparticle.MPEvent;
 import com.mparticle.MParticle;
 import com.mparticle.internal.ConfigManager;
+import com.mparticle.internal.KitManager;
 import com.mparticle.mock.MockContext;
 import com.mparticle.mock.MockCoreCallbacks;
 import com.mparticle.mock.MockKitConfiguration;
@@ -138,12 +140,15 @@ public class KitManagerTest  {
         JSONArray array = configJson.optJSONArray(ConfigManager.KEY_EMBEDDED_KITS);
         manager.updateKits(array);
 
-        String activeModuleIds = manager.getActiveModuleIds();
-        String[] ids = activeModuleIds.split(",");
+        Map<Integer, KitManager.KitStatus> kitStatus = manager.getKitStatus();
         String[] testIds = {"56", "64", "37", "68"};
         List<String> idList = Arrays.asList(testIds);
-        for (String id : ids){
-            assertTrue(activeModuleIds, idList.contains(id.trim()));
+        for (Map.Entry<Integer, KitManager.KitStatus> status : kitStatus.entrySet()){
+            if (status.getValue() == KitManager.KitStatus.ACTIVE) {
+                assertTrue(idList.contains(status.getKey().toString()));
+            } else {
+                assertFalse(idList.contains(status.getKey().toString()));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Update the "x-mp-kits" header to include, not only kits actively receiving forwarding, but also kits that are configured but disabled due to client-side settings

## Testing Plan
- added unit test for header string generation and an End to End test

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3737
