### PR TITLE
fix: add value for api in custom lint IssueRegistry

### DIFF
--- a/tooling/custom-lint-rules/src/main/java/com/mparticle/lints/MParticleIssueRegistry.kt
+++ b/tooling/custom-lint-rules/src/main/java/com/mparticle/lints/MParticleIssueRegistry.kt
@@ -1,6 +1,7 @@
 package com.mparticle.lints
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
 import com.mparticle.lints.detectors.DataplanDetector
 import com.mparticle.lints.detectors.GradleBuildDetector
 import com.mparticle.lints.detectors.MpApiDetectorKt
@@ -19,4 +20,7 @@ class MParticleIssueRegistry : IssueRegistry() {
         DataplanDetector.NODE_MISSING,
         DataplanDetector.NO_DATA_PLAN
     )
+
+    override val api: Int
+        get() = CURRENT_API
 }


### PR DESCRIPTION
## Summary
I was testing the linter in a project and noticed that we are receiving a linter error due to this missing field. It looks like it became a required value at some point instead of falling back to the most recent API version

## Testing Plan
- manually tested

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4002
