### PR TITLE
feat: update customAttributes to accept Object/Any

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/UploadMessageTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/UploadMessageTest.java
@@ -191,7 +191,7 @@ public final class UploadMessageTest extends BaseCleanStartedEachTest {
             assertTrue(mpEvent.getEventType().toString().equals(jsonObject.getString("et")));
         }
 
-        Map<String, String> customAttributesTarget = mpEvent.getCustomAttributes() == null ? new HashMap<String, String>() : mpEvent.getCustomAttributes();
+        Map<String, String> customAttributesTarget = mpEvent.getCustomAttributeStrings() == null ? new HashMap<String, String>() : mpEvent.getCustomAttributeStrings();
         JSONObject customAttributes = jsonObject.optJSONObject("attrs");
         if (customAttributes != null) {
             Iterator<String> keysIterator = customAttributes.keys();

--- a/android-core/src/androidTest/java/com/mparticle/internal/MParticleJSInterfaceITest.java
+++ b/android-core/src/androidTest/java/com/mparticle/internal/MParticleJSInterfaceITest.java
@@ -435,7 +435,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                     assertNull(transactionAttributes.getShipping());
                     assertNull(transactionAttributes.getAffiliation());
                     assertNull(transactionAttributes.getCouponCode());
-                    assertJsonEqual(customAttributes, MPUtility.mapToJson(commerceEvent.getCustomAttributes()));
+                    assertJsonEqual(customAttributes, MPUtility.mapToJson(commerceEvent.getCustomAttributeStrings()));
                     called.value = true;
                 } catch (Exception e) {
                     error.value = e;

--- a/android-core/src/main/java/com/mparticle/BaseEvent.java
+++ b/android-core/src/main/java/com/mparticle/BaseEvent.java
@@ -9,13 +9,14 @@ import com.mparticle.internal.messages.BaseMPMessageBuilder;
 
 import org.json.JSONArray;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class BaseEvent {
     private MessageType mType;
-    private Map<String, List<String>> mCustomFlags;
-    private Map<String, String> mCustomAttributes;
+    private Map<String, List<String>> mCustomFlags = new HashMap<>();
+    private Map<String, Object> mCustomAttributes = new HashMap<>();
     private boolean mShouldUploadEvent = true;
 
     protected BaseEvent(MessageType type) {
@@ -47,13 +48,13 @@ public class BaseEvent {
      *
      * @return returns the map of custom flags, or null if none are set
      */
-    @Nullable
+    @NonNull
     public Map<String, List<String>> getCustomFlags() {
         return mCustomFlags;
     }
 
 
-    protected void setCustomFlags(@Nullable Map<String, List<String>> flags) {
+    protected void setCustomFlags(@NonNull Map<String, List<String>> flags) {
         if (flags != null && MPUtility.containsNullKey(flags)) {
             Logger.warning(String.format("disregarding \"MPEvent.customFlag\" value of %s. Key was found to be null", new JSONArray(flags.get(null))));
             flags.remove(null);
@@ -66,17 +67,27 @@ public class BaseEvent {
      *
      * @return returns a Map of custom attributes, or null if no custom attributes are set.
      */
-    @Nullable
-    public Map<String, String> getCustomAttributes() {
+    @NonNull
+    public Map<String, Object> getCustomAttributes() {
         return mCustomAttributes;
     }
 
-    public void setCustomAttributes(@Nullable Map<String, String> customAttributes) {
+    @NonNull
+    public Map<String, String> getCustomAttributeStrings() {
+        Map<String, String> attributes = new HashMap<>();
+        for (Map.Entry<String, Object> entry: mCustomAttributes.entrySet()) {
+            Object value = entry.getValue();
+            attributes.put(entry.getKey(), value == null ? null : value.toString());
+        }
+        return attributes;
+    }
+
+    public void setCustomAttributes(@NonNull Map<String, ?> customAttributes) {
         if (customAttributes != null && MPUtility.containsNullKey(customAttributes)) {
             Logger.warning(String.format("disregarding \"Event.customFlag\" value of \"%s\". Key was found to be null", customAttributes.get(null)));
             customAttributes.remove(null);
         }
-        this.mCustomAttributes = customAttributes;
+        this.mCustomAttributes = new HashMap<>(customAttributes);
     }
 
     public BaseMPMessageBuilder getMessage() {

--- a/android-core/src/main/java/com/mparticle/commerce/CommerceEvent.java
+++ b/android-core/src/main/java/com/mparticle/commerce/CommerceEvent.java
@@ -580,9 +580,9 @@ public final class CommerceEvent extends BaseEvent {
         public Builder(@NonNull CommerceEvent event) {
             mProductAction = event.getProductAction();
             mPromotionAction = event.getPromotionAction();
-            if (event.getCustomAttributes() != null) {
+            if (event.getCustomAttributeStrings() != null) {
                 Map<String, String> shallowCopy = new HashMap<String, String>();
-                shallowCopy.putAll(event.getCustomAttributes());
+                shallowCopy.putAll(event.getCustomAttributeStrings());
                 customAttributes = shallowCopy;
             }
             if (event.getPromotions() != null) {

--- a/android-core/src/main/java/com/mparticle/internal/MessageManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/MessageManager.java
@@ -374,7 +374,7 @@ public class MessageManager implements MessageManagerCallbacks, ReportingManager
                         .timestamp(mAppStateManager.getSession().mLastEventTime)
                         .name(event.getEventName())
                         .flags(event.getCustomFlags())
-                        .attributes(MPUtility.enforceAttributeConstraints(event.getCustomAttributes()))
+                        .attributes(MPUtility.enforceAttributeConstraints(event.getCustomAttributeStrings()))
                         .build(mAppStateManager.getSession(), mLocation, mConfigManager.getMpid());
 
                 message.put(MessageKey.EVENT_START_TIME, mAppStateManager.getSession().mLastEventTime);

--- a/android-core/src/main/java/com/mparticle/internal/messages/MPCommerceMessage.java
+++ b/android-core/src/main/java/com/mparticle/internal/messages/MPCommerceMessage.java
@@ -59,8 +59,8 @@ public class MPCommerceMessage extends BaseMPMessage {
                 if (event.getCurrency() != null) {
                     message.put(Constants.Commerce.CURRENCY, event.getCurrency());
                 }
-                if (event.getCustomAttributes() != null) {
-                    message.put(Constants.Commerce.ATTRIBUTES, MPUtility.mapToJson(event.getCustomAttributes()));
+                if (event.getCustomAttributeStrings() != null) {
+                    message.put(Constants.Commerce.ATTRIBUTES, MPUtility.mapToJson(event.getCustomAttributeStrings()));
                 }
                 if (event.getProductAction() != null) {
                     JSONObject productAction = new JSONObject();

--- a/android-core/src/test/java/com/mparticle/MPEventTests.java
+++ b/android-core/src/test/java/com/mparticle/MPEventTests.java
@@ -103,8 +103,8 @@ public class MPEventTests  {
         assertEquals("another name", copiedEvent.getEventName());
         assertEquals(MParticle.EventType.Social, copiedEvent.getEventType());
         assertEquals("category", copiedEvent.getCategory());
-        assertEquals("value 1", copiedEvent.getCustomAttributes().get("key 1"));
-        assertEquals("value 2", copiedEvent.getCustomAttributes().get("key 2"));
+        assertEquals("value 1", copiedEvent.getCustomAttributeStrings().get("key 1"));
+        assertEquals("value 2", copiedEvent.getCustomAttributeStrings().get("key 2"));
         Map<String, List<String>> flags = copiedEvent.getCustomFlags();
         assertEquals(flags.get("cool flag key").size(), 2);
         assertEquals(flags.get("cool flag key 2").size(), 1);

--- a/android-core/src/test/java/com/mparticle/MockMParticle.java
+++ b/android-core/src/test/java/com/mparticle/MockMParticle.java
@@ -12,6 +12,9 @@ import com.mparticle.mock.MockContext;
 
 import org.mockito.Mockito;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class MockMParticle extends MParticle {
 
     public MockMParticle() {
@@ -28,6 +31,10 @@ public class MockMParticle extends MParticle {
         mMedia = Mockito.mock(MPMediaAPI.class);
         mIdentityApi = new IdentityApi(new MockContext(), mAppStateManager, mMessageManager, Internal().getConfigManager(), mKitManager, OperatingSystem.ANDROID);
         Mockito.when(mKitManager.updateKits(Mockito.any())).thenReturn(new KitsLoadedCallback());
+        MPEvent event = new MPEvent.Builder("this")
+                .customAttributes(new HashMap<String, String>())
+                .build();
+        Map<String, ?> attributes = event.getCustomAttributes();
     }
 
 

--- a/android-core/src/test/java/com/mparticle/commerce/CommerceEventTest.java
+++ b/android-core/src/test/java/com/mparticle/commerce/CommerceEventTest.java
@@ -99,7 +99,7 @@ public class CommerceEventTest {
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("cool attribute key", "cool attribute value");
         CommerceEvent event = new CommerceEvent.Builder(Product.ADD_TO_CART, product).customAttributes(attributes).nonInteraction(true).build();
-        assertEquals("cool attribute value", event.getCustomAttributes().get("cool attribute key"));
+        assertEquals("cool attribute value", event.getCustomAttributeStrings().get("cool attribute key"));
     }
 
     @Test

--- a/android-core/src/test/java/com/mparticle/internal/BaseMPMessageTest.java
+++ b/android-core/src/test/java/com/mparticle/internal/BaseMPMessageTest.java
@@ -27,7 +27,7 @@ public class BaseMPMessageTest {
                 .name(event.getEventName())
                 .timestamp(1235)
                 .length(event.getLength())
-                .attributes(MPUtility.enforceAttributeConstraints(event.getCustomAttributes()))
+                .attributes(MPUtility.enforceAttributeConstraints(event.getCustomAttributeStrings()))
                 .build(session, null, 1);
 
         assertNull(message.opt("el"));
@@ -40,7 +40,7 @@ public class BaseMPMessageTest {
                 .name(event2.getEventName())
                 .timestamp(1235)
                 .length(event2.getLength())
-                .attributes(MPUtility.enforceAttributeConstraints(event2.getCustomAttributes()))
+                .attributes(MPUtility.enforceAttributeConstraints(event2.getCustomAttributeStrings()))
                 .build(session, null, 1);
 
         assertEquals(message2.getAttributes().getString("EventLength"), "321");
@@ -50,7 +50,7 @@ public class BaseMPMessageTest {
                 .name(event3.getEventName())
                 .timestamp(1235)
                 .length(event3.getLength())
-                .attributes(MPUtility.enforceAttributeConstraints(event.getCustomAttributes()))
+                .attributes(MPUtility.enforceAttributeConstraints(event.getCustomAttributeStrings()))
                 .build(session, null, 1);
 
         assertEquals(message3.getAttributes().getString("EventLength"), "123");

--- a/android-kit-base/src/main/java/com/mparticle/kits/CommerceEventUtils.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/CommerceEventUtils.java
@@ -47,8 +47,8 @@ public final class CommerceEventUtils {
             //Set all product action fields to attributes.
             Map<String, String> attributes = new HashMap<String, String>();
             //Start with the custom attributes then overwrite with action fields.
-            if (event.getCustomAttributes() != null) {
-                attributes.putAll(event.getCustomAttributes());
+            if (event.getCustomAttributeStrings() != null) {
+                attributes.putAll(event.getCustomAttributeStrings());
             }
             extractActionAttributes(event, attributes);
             events.add(plusOne.customAttributes(attributes).shouldUploadEvent(event.isShouldUploadEvent()).build());
@@ -186,8 +186,8 @@ public final class CommerceEventUtils {
             for (int i = 0; i < promotions.size(); i++) {
                 MPEvent.Builder itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Transaction);
                 Map<String, String> attributes = new HashMap<String, String>();
-                if (event.getCustomAttributes() != null) {
-                    attributes.putAll(event.getCustomAttributes());
+                if (event.getCustomAttributeStrings() != null) {
+                    attributes.putAll(event.getCustomAttributeStrings());
                 }
                 extractPromotionAttributes(promotions.get(i), attributes);
                 events.add(itemEvent.customAttributes(attributes).shouldUploadEvent(event.isShouldUploadEvent()).build());
@@ -229,8 +229,8 @@ public final class CommerceEventUtils {
                 for (int j = 0; j < products.size(); j++) {
                     MPEvent.Builder itemEvent = new MPEvent.Builder(IMPRESSION_NAME, MParticle.EventType.Transaction);
                     Map<String, String> attributes = new HashMap<String, String>();
-                    if (event.getCustomAttributes() != null) {
-                        attributes.putAll(event.getCustomAttributes());
+                    if (event.getCustomAttributeStrings() != null) {
+                        attributes.putAll(event.getCustomAttributeStrings());
                     }
                     extractProductAttributes(products.get(i), attributes);
                     extractProductFields(products.get(i), attributes);

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -334,7 +334,7 @@ public class KitConfiguration {
     }
 
     protected CommerceEvent filterCommerceEvent(CommerceEvent event) {
-        if (!shouldIncludeFromAttributeValueFiltering(event.getCustomAttributes())) {
+        if (!shouldIncludeFromAttributeValueFiltering(event.getCustomAttributeStrings())) {
             return null;
         }
         if (mTypeFilters != null &&
@@ -431,7 +431,7 @@ public class KitConfiguration {
     }
 
     public final Map<String, String> filterEventAttributes(MPEvent event) {
-        return filterEventAttributes(event.getEventType(), event.getEventName(), mAttributeFilters, event.getCustomAttributes());
+        return filterEventAttributes(event.getEventType(), event.getEventName(), mAttributeFilters, event.getCustomAttributeStrings());
     }
 
     public final Map<String, String> filterScreenAttributes(MParticle.EventType eventType, String eventName, Map<String, String> eventAttributes) {
@@ -510,7 +510,7 @@ public class KitConfiguration {
             return filteredEvent;
         }
         CommerceEvent.Builder builder = new CommerceEvent.Builder(filteredEvent);
-        Map<String, String> customAttributes = filteredEvent.getCustomAttributes();
+        Map<String, String> customAttributes = filteredEvent.getCustomAttributeStrings();
         if (customAttributes != null) {
             Map<String, String> filteredCustomAttributes = new HashMap<String, String>(customAttributes.size());
             for (Map.Entry<String, String> entry : customAttributes.entrySet()) {
@@ -571,7 +571,7 @@ public class KitConfiguration {
 
 
     protected boolean shouldLogEvent(MPEvent event) {
-        if (!shouldIncludeFromAttributeValueFiltering(event.getCustomAttributes())) {
+        if (!shouldIncludeFromAttributeValueFiltering(event.getCustomAttributeStrings())) {
             return false;
         }
         int typeHash = KitUtils.hashForFiltering(event.getEventType().ordinal() + "");

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -827,14 +827,14 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
                     List<ReportingMessage> reportingMessages = new LinkedList<ReportingMessage>();
                     if (projectedEvents == null) {
                         List<ReportingMessage> messages = null;
-                        if (eventCopy.getCustomAttributes() != null
-                                && eventCopy.getCustomAttributes().containsKey(METHOD_NAME)
-                                && eventCopy.getCustomAttributes().get(METHOD_NAME).equals(LOG_LTV)) {
+                        if (eventCopy.getCustomAttributeStrings() != null
+                                && eventCopy.getCustomAttributeStrings().containsKey(METHOD_NAME)
+                                && eventCopy.getCustomAttributeStrings().get(METHOD_NAME).equals(LOG_LTV)) {
                             messages = ((KitIntegration.CommerceListener) provider).logLtvIncrease(
-                                    new BigDecimal(eventCopy.getCustomAttributes().get(RESERVED_KEY_LTV)),
-                                    new BigDecimal(eventCopy.getCustomAttributes().get(RESERVED_KEY_LTV)),
+                                    new BigDecimal(eventCopy.getCustomAttributeStrings().get(RESERVED_KEY_LTV)),
+                                    new BigDecimal(eventCopy.getCustomAttributeStrings().get(RESERVED_KEY_LTV)),
                                     eventCopy.getEventName(),
-                                    eventCopy.getCustomAttributes());
+                                    eventCopy.getCustomAttributeStrings());
                         } else {
                             messages = ((KitIntegration.EventListener) provider).logEvent(eventCopy);
                             mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(messages), eventCopy);
@@ -951,7 +951,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
             try {
                 if (provider instanceof KitIntegration.EventListener && !provider.isDisabled() && provider.getConfiguration().shouldLogScreen(screenEvent.getEventName())) {
                     MPEvent filteredEvent = new MPEvent.Builder(screenEvent)
-                            .customAttributes(provider.getConfiguration().filterScreenAttributes(null, screenEvent.getEventName(), screenEvent.getCustomAttributes()))
+                            .customAttributes(provider.getConfiguration().filterScreenAttributes(null, screenEvent.getEventName(), screenEvent.getCustomAttributeStrings()))
                             .build();
 
                     List<CustomMapping.ProjectionResult> projectedEvents = CustomMapping.projectEvents(
@@ -962,7 +962,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
                             provider.getConfiguration().getDefaultScreenCustomMapping());
                     if (projectedEvents == null) {
                         String eventName = filteredEvent.getEventName();
-                        Map<String, String> eventInfo = filteredEvent.getCustomAttributes();
+                        Map<String, String> eventInfo = filteredEvent.getCustomAttributeStrings();
                         List<ReportingMessage> report = ((KitIntegration.EventListener) provider).logScreen(eventName, eventInfo);
                         mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), eventName, eventInfo);
                         if (report != null && report.size() > 0) {
@@ -976,7 +976,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
                         ReportingMessage masterMessage = new ReportingMessage(provider,
                                 ReportingMessage.MessageType.SCREEN_VIEW,
                                 System.currentTimeMillis(),
-                                filteredEvent.getCustomAttributes());
+                                filteredEvent.getCustomAttributeStrings());
                         boolean forwarded = false;
                         for (CustomMapping.ProjectionResult projectedEvent: projectedEvents) {
                             List<ReportingMessage> report = ((KitIntegration.EventListener) provider).logEvent(projectedEvent.getMPEvent());

--- a/android-kit-base/src/main/java/com/mparticle/kits/ReportingMessage.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/ReportingMessage.java
@@ -89,7 +89,7 @@ public class ReportingMessage implements JsonReportingMessage {
     }
 
     public static ReportingMessage fromEvent(KitIntegration provider, BaseEvent event) {
-        ReportingMessage message = new ReportingMessage(provider, event.getType().getMessageType(), System.currentTimeMillis(), event.getCustomAttributes());
+        ReportingMessage message = new ReportingMessage(provider, event.getType().getMessageType(), System.currentTimeMillis(), event.getCustomAttributeStrings());
         if (event instanceof MPEvent) {
             MPEvent mpEvent = (MPEvent)event;
             message.eventType = mpEvent.getEventType().name();

--- a/android-kit-base/src/main/java/com/mparticle/kits/mappings/CustomMapping.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/mappings/CustomMapping.java
@@ -147,8 +147,8 @@ public class CustomMapping {
         }
         if (mAppendUnmappedAsIs && mMaxCustomParams > 0 && newAttributes.size() < mMaxCustomParams) {
             Map<String, String> originalAttributes;
-            if (event.getCustomAttributes() != null) {
-                originalAttributes = new HashMap<String, String>(event.getCustomAttributes());
+            if (event.getCustomAttributeStrings() != null) {
+                originalAttributes = new HashMap<String, String>(event.getCustomAttributeStrings());
             } else {
                 originalAttributes = new HashMap<String, String>();
             }
@@ -303,8 +303,8 @@ public class CustomMapping {
         if (mAppendUnmappedAsIs && mMaxCustomParams > 0 && mappedAttributes.size() < mMaxCustomParams) {
             CommerceEvent event = eventWrapper.getEvent();
             Map<String, String> originalAttributes;
-            if (event.getCustomAttributes() != null) {
-                originalAttributes = new HashMap<String, String>(event.getCustomAttributes());
+            if (event.getCustomAttributeStrings() != null) {
+                originalAttributes = new HashMap<String, String>(event.getCustomAttributeStrings());
             } else {
                 originalAttributes = new HashMap<String, String>();
             }

--- a/android-kit-base/src/main/java/com/mparticle/kits/mappings/CustomMappingMatch.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/mappings/CustomMappingMatch.java
@@ -124,9 +124,9 @@ final class CustomMappingMatch {
             return true;
         } else if (mMatchType.startsWith(MATCH_TYPE_STRING) &&
                 event.getEventName().equalsIgnoreCase(mEventName) &&
-                event.getCustomAttributes() != null &&
-                event.getCustomAttributes().containsKey(mAttributeKey) &&
-                getAttributeValues().contains(event.getCustomAttributes().get(mAttributeKey).toLowerCase(Locale.US))) {
+                event.getCustomAttributeStrings() != null &&
+                event.getCustomAttributeStrings().containsKey(mAttributeKey) &&
+                getAttributeValues().contains(event.getCustomAttributeStrings().get(mAttributeKey).toLowerCase(Locale.US))) {
             return true;
         } else {
             return false;
@@ -258,7 +258,7 @@ final class CustomMappingMatch {
     }
 
     private boolean matchCommerceAttributes(CommerceEvent event) {
-        Map<String, String> attributes = event.getCustomAttributes();
+        Map<String, String> attributes = event.getCustomAttributeStrings();
         if (attributes == null || attributes.size() < 1) {
             return false;
         }

--- a/android-kit-base/src/main/java/com/mparticle/kits/mappings/EventWrapper.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/mappings/EventWrapper.java
@@ -53,8 +53,8 @@ abstract class EventWrapper {
         public Map<Integer, String> getAttributeHashes() {
             if (attributeHashes == null) {
                 attributeHashes = new HashMap<Integer, String>();
-                if (mCommerceEvent.getCustomAttributes() != null) {
-                    for (Map.Entry<String, String> entry : mCommerceEvent.getCustomAttributes().entrySet()) {
+                if (mCommerceEvent.getCustomAttributeStrings() != null) {
+                    for (Map.Entry<String, String> entry : mCommerceEvent.getCustomAttributeStrings().entrySet()) {
                         int hash = KitUtils.hashForFiltering(getEventTypeOrdinal() + entry.getKey());
                         attributeHashes.put(hash, entry.getKey());
                     }
@@ -85,12 +85,12 @@ abstract class EventWrapper {
 
         public Map.Entry<String, String> findAttribute(String propertyType, int hash, Product product, Promotion promotion) {
             if (CustomMapping.PROPERTY_LOCATION_EVENT_ATTRIBUTE.equalsIgnoreCase(propertyType)) {
-                if (getEvent().getCustomAttributes() == null || getEvent().getCustomAttributes().size() == 0) {
+                if (getEvent().getCustomAttributeStrings() == null || getEvent().getCustomAttributeStrings().size() == 0) {
                     return null;
                 }
                 String key = getAttributeHashes().get(hash);
                 if (key != null) {
-                    return new AbstractMap.SimpleEntry<String, String>(key, mCommerceEvent.getCustomAttributes().get(key));
+                    return new AbstractMap.SimpleEntry<String, String>(key, mCommerceEvent.getCustomAttributeStrings().get(key));
                 }
             } else if (CustomMapping.PROPERTY_LOCATION_EVENT_FIELD.equalsIgnoreCase(propertyType)) {
                 if (eventFieldHashes == null) {
@@ -145,11 +145,11 @@ abstract class EventWrapper {
         @Override
         public Map.Entry<String, String> findAttribute(String propertyType, String keyName, Product product, Promotion promotion) {
             if (CustomMapping.PROPERTY_LOCATION_EVENT_ATTRIBUTE.equalsIgnoreCase(propertyType)) {
-                if (getEvent().getCustomAttributes() == null || getEvent().getCustomAttributes().size() == 0) {
+                if (getEvent().getCustomAttributeStrings() == null || getEvent().getCustomAttributeStrings().size() == 0) {
                     return null;
                 }
-                if (getEvent().getCustomAttributes().containsKey(keyName)) {
-                    return new AbstractMap.SimpleEntry<String, String>(keyName, getEvent().getCustomAttributes().get(keyName));
+                if (getEvent().getCustomAttributeStrings().containsKey(keyName)) {
+                    return new AbstractMap.SimpleEntry<String, String>(keyName, getEvent().getCustomAttributeStrings().get(keyName));
                 }
             } else if (CustomMapping.PROPERTY_LOCATION_EVENT_FIELD.equalsIgnoreCase(propertyType)) {
                 if (eventFieldAttributes == null) {
@@ -210,8 +210,8 @@ abstract class EventWrapper {
         public Map<Integer, String> getAttributeHashes() {
             if (attributeHashes == null) {
                 attributeHashes = new HashMap<Integer, String>();
-                if (mEvent.getCustomAttributes() != null) {
-                    for (Map.Entry<String, String> entry : mEvent.getCustomAttributes().entrySet()) {
+                if (mEvent.getCustomAttributeStrings() != null) {
+                    for (Map.Entry<String, String> entry : mEvent.getCustomAttributeStrings().entrySet()) {
                         int hash = KitUtils.hashForFiltering(getEventTypeOrdinal() + mEvent.getEventName() + entry.getKey());
                         attributeHashes.put(hash, entry.getKey());
                     }
@@ -251,10 +251,10 @@ abstract class EventWrapper {
 
         public Map.Entry<String, String> findAttribute(String propertyType, String keyName, Product product, Promotion promotion) {
             if (CustomMapping.PROPERTY_LOCATION_EVENT_ATTRIBUTE.equalsIgnoreCase(propertyType)) {
-                if (getEvent().getCustomAttributes() == null) {
+                if (getEvent().getCustomAttributeStrings() == null) {
                     return null;
                 }
-                String value = getEvent().getCustomAttributes().get(keyName);
+                String value = getEvent().getCustomAttributeStrings().get(keyName);
                 if (value != null) {
                     return new AbstractMap.SimpleEntry<String, String>(keyName, value);
                 }
@@ -266,7 +266,7 @@ abstract class EventWrapper {
             if (CustomMapping.PROPERTY_LOCATION_EVENT_ATTRIBUTE.equalsIgnoreCase(propertyType)) {
                 String key = getAttributeHashes().get(hash);
                 if (key != null) {
-                    return new AbstractMap.SimpleEntry<>(key, mEvent.getCustomAttributes().get(key));
+                    return new AbstractMap.SimpleEntry<>(key, mEvent.getCustomAttributeStrings().get(key));
                 }
             }
             return null;

--- a/android-kit-base/src/main/kotlin/com/mparticle/kits/DataplanFilter.kt
+++ b/android-kit-base/src/main/kotlin/com/mparticle/kits/DataplanFilter.kt
@@ -89,7 +89,7 @@ Data Plan parsed for Kit Filtering:
             }
             val dataPoint = dataPoints[dataPointKey.toString()]
             if (blockEventAttributes) {
-                event.customAttributes = event.customAttributes?.filterKeys {
+                event.customAttributes = event.customAttributeStrings?.filterKeys {
                     // null dataPoint means there are no constraints for custom attributes
                     if (dataPoint == null || dataPoint.contains(it)) {
                         true

--- a/android-kit-base/src/test/java/com/mparticle/kits/KitConfigurationTest.java
+++ b/android-kit-base/src/test/java/com/mparticle/kits/KitConfigurationTest.java
@@ -142,16 +142,16 @@ public class KitConfigurationTest {
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("my custom attribute", "whatever");
         CommerceEvent event = new CommerceEvent.Builder(Product.ADD_TO_CART, new Product.Builder("name", "sku", 2).build()).customAttributes(attributes).build();
-        assertEquals("whatever", event.getCustomAttributes().get("my custom attribute"));
+        assertEquals("whatever", event.getCustomAttributeStrings().get("my custom attribute"));
         CommerceEvent filteredEvent = configuration.filterCommerceEvent(event);
-        assertNull(filteredEvent.getCustomAttributes().get("my custom attribute"));
+        assertNull(filteredEvent.getCustomAttributeStrings().get("my custom attribute"));
 
         //make sure we're only doing it for ADD_TO_CART
         CommerceEvent event2 = new CommerceEvent.Builder(Product.PURCHASE, new Product.Builder("name", "sku", 2).build()).customAttributes(attributes).transactionAttributes(new TransactionAttributes().setId("some id")).build();
 
-        assertEquals("whatever", event2.getCustomAttributes().get("my custom attribute"));
+        assertEquals("whatever", event2.getCustomAttributeStrings().get("my custom attribute"));
         CommerceEvent filteredEvent2 = configuration.filterCommerceEvent(event2);
-        assertEquals("whatever", filteredEvent2.getCustomAttributes().get("my custom attribute"));
+        assertEquals("whatever", filteredEvent2.getCustomAttributeStrings().get("my custom attribute"));
 
         event = new CommerceEvent.Builder(Product.CHECKOUT, new Product.Builder("name", "sku", 2).build()).checkoutOptions("cool options").build();
 

--- a/android-kit-base/src/test/java/com/mparticle/kits/mappings/CustomMappingTest.java
+++ b/android-kit-base/src/test/java/com/mparticle/kits/mappings/CustomMappingTest.java
@@ -125,8 +125,8 @@ public class CustomMappingTest {
         assertEquals(event, newEvent);
         info.put("yet another key", "yet another value");
         //sanity check to make sure we're duplicating the map, not passing around a reference
-        assertTrue(event.getCustomAttributes().containsKey("yet another key"));
-        assertFalse(newEvent.getCustomAttributes().containsKey("yet another key"));
+        assertTrue(event.getCustomAttributeStrings().containsKey("yet another key"));
+        assertFalse(newEvent.getCustomAttributeStrings().containsKey("yet another key"));
     }
 
     /**
@@ -175,10 +175,10 @@ public class CustomMappingTest {
         info.put("another key", "another value");
         MPEvent event = new MPEvent.Builder("whatever", MParticle.EventType.Other).customAttributes(info).build();
         CustomMapping.ProjectionResult newEvent = customMapping.project(new EventWrapper.MPEventWrapper(event)).get(0);
-        assertTrue(newEvent.getMPEvent().getCustomAttributes().size() == 0);
+        assertTrue(newEvent.getMPEvent().getCustomAttributeStrings().size() == 0);
         customMapping = new CustomMapping(new JSONObject("{ \"id\":89, \"matches\":[{ \"message_type\":4, \"event_match_type\":\"\", \"event\":\"\" }], \"behavior\":{ \"append_unmapped_as_is\":true, \"is_default\":true }, \"action\":{ \"projected_event_name\":\"\", \"attribute_maps\":[ ] } }"));
         newEvent = customMapping.project(new EventWrapper.MPEventWrapper(event)).get(0);
-        assertTrue(newEvent.getMPEvent().getCustomAttributes().size() == 2);
+        assertTrue(newEvent.getMPEvent().getCustomAttributeStrings().size() == 2);
     }
 
     /**
@@ -205,25 +205,25 @@ public class CustomMappingTest {
         MPEvent event = new MPEvent.Builder("whatever", MParticle.EventType.Other).customAttributes(info).build();
         CustomMapping.ProjectionResult result = customMapping.project(new EventWrapper.MPEventWrapper(event)).get(0);
         MPEvent newEvent = result.getMPEvent();
-        assertTrue(newEvent.getCustomAttributes().size() == 5);
+        assertTrue(newEvent.getCustomAttributeStrings().size() == 5);
         //key 5 should be there but key 6 should be kicked out due to alphabetic sorting
-        assertTrue(newEvent.getCustomAttributes().containsKey("key 5"));
-        assertFalse(newEvent.getCustomAttributes().containsKey("key 6"));
+        assertTrue(newEvent.getCustomAttributeStrings().containsKey("key 5"));
+        assertFalse(newEvent.getCustomAttributeStrings().containsKey("key 6"));
         //now create the SAME projection, except specify an optional attribute key 6 - it should boot key 5 from the resulting event
         customMapping = new CustomMapping(new JSONObject("{ \"id\":89, \"matches\":[{ \"message_type\":4, \"event_match_type\":\"\", \"event\":\"\" }], \"behavior\":{ \"append_unmapped_as_is\":true, \"max_custom_params\":5, \"is_default\":true }, \"action\":{ \"projected_event_name\":\"\", \"attribute_maps\":[ { \"projected_attribute_name\":\"\", \"match_type\":\"String\", \"value\":\"key 6\", \"data_type\":\"String\" }] } }"));
         result = customMapping.project(new EventWrapper.MPEventWrapper(event)).get(0);
         newEvent = result.getMPEvent();
-        assertFalse(newEvent.getCustomAttributes().containsKey("key 5"));
-        assertTrue(newEvent.getCustomAttributes().containsKey("key 6")); //note that the json also doesn't specify a key name - so we just use the original
-        assertTrue(newEvent.getCustomAttributes().size() == 5);
+        assertFalse(newEvent.getCustomAttributeStrings().containsKey("key 5"));
+        assertTrue(newEvent.getCustomAttributeStrings().containsKey("key 6")); //note that the json also doesn't specify a key name - so we just use the original
+        assertTrue(newEvent.getCustomAttributeStrings().size() == 5);
 
         //test what happens if max isn't even set (everything should be there)
         customMapping = new CustomMapping(new JSONObject("{ \"id\":89, \"matches\":[{ \"message_type\":4, \"event_match_type\":\"\", \"event\":\"\" }], \"behavior\":{ \"append_unmapped_as_is\":true, \"is_default\":true }, \"action\":{ \"projected_event_name\":\"\", \"attribute_maps\":[ { \"projected_attribute_name\":\"\", \"match_type\":\"String\", \"value\":\"key 6\", \"data_type\":\"String\" }] } }"));
         result = customMapping.project(new EventWrapper.MPEventWrapper(event)).get(0);
         newEvent = result.getMPEvent();
-        assertTrue(newEvent.getCustomAttributes().containsKey("key 5"));
-        assertTrue(newEvent.getCustomAttributes().containsKey("key 6")); //note that the json also doesn't specify a key name - so we just use the original
-        assertTrue(newEvent.getCustomAttributes().size() == 6);
+        assertTrue(newEvent.getCustomAttributeStrings().containsKey("key 5"));
+        assertTrue(newEvent.getCustomAttributeStrings().containsKey("key 6")); //note that the json also doesn't specify a key name - so we just use the original
+        assertTrue(newEvent.getCustomAttributeStrings().size() == 6);
     }
 
     /**
@@ -236,7 +236,7 @@ public class CustomMappingTest {
         CustomMapping customMapping = new CustomMapping(new JSONObject("{ \"id\":89, \"matches\":[{ \"message_type\":4, \"event_match_type\":\"\", \"event\":\"\" }], \"behavior\":{ \"append_unmapped_as_is\":true, \"is_default\":true }, \"action\":{ \"projected_event_name\":\"\", \"attribute_maps\":[ { \"projected_attribute_name\":\"\", \"match_type\":\"String\", \"value\":\"key 6\", \"data_type\":\"String\" },{ \"projected_attribute_name\": \"screen_name_key\", \"match_type\": \"Field\", \"value\": \"ScreenName\", \"data_type\": 1, \"is_required\": true }] } }"));
         MPEvent event = new MPEvent.Builder("screenname", MParticle.EventType.Other).build();
         CustomMapping.ProjectionResult projectedEvent = customMapping.project(new EventWrapper.MPEventWrapper(event)).get(0);
-        assertEquals("screenname", projectedEvent.getMPEvent().getCustomAttributes().get("screen_name_key"));
+        assertEquals("screenname", projectedEvent.getMPEvent().getCustomAttributeStrings().get("screen_name_key"));
     }
 
     /**
@@ -310,7 +310,7 @@ public class CustomMappingTest {
         assertEquals(1, eventList.size());
         MPEvent projEvent1 = eventList.get(0).getMPEvent();
         assertEquals("account - check order status", projEvent1.getEventName());
-        assertEquals("some value", projEvent1.getCustomAttributes().get("attribute we don't care about"));
+        assertEquals("some value", projEvent1.getCustomAttributeStrings().get("attribute we don't care about"));
 
 
     }
@@ -338,20 +338,20 @@ public class CustomMappingTest {
         MPEvent projEvent1 = eventList.get(0).getMPEvent();
         //same as test 1, but verify for the fun of it.
         assertEquals("account - check order status", projEvent1.getEventName());
-        assertEquals("some value", projEvent1.getCustomAttributes().get("attribute we don't care about"));
+        assertEquals("some value", projEvent1.getCustomAttributeStrings().get("attribute we don't care about"));
 
         //this is the new projection which requires the Value attribute
         projEvent1 = eventList.get(1).getMPEvent();
         assertEquals("pdp - add to tote", projEvent1.getEventName());
         //required attribute
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Last Add to Tote Category")); //the required attribute has been renamed
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Category")); //the required attribute has been renamed
         //non-required attributes which define the same hash as the required one.
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Last Add to Tote Total Amount"));
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Last Add to Tote SKU"));
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Total Amount"));
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Last Add to Tote SKU"));
 
         //static attributes are in this projection as well.
-        assertEquals("10", projEvent1.getCustomAttributes().get("Last Add to Tote Quantity"));
-        assertEquals("1321", projEvent1.getCustomAttributes().get("Last Add to Tote Unit Price"));
+        assertEquals("10", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Quantity"));
+        assertEquals("1321", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Unit Price"));
 
     }
 
@@ -386,25 +386,25 @@ public class CustomMappingTest {
 
         MPEvent projEvent1 = eventList.get(0).getMPEvent();
         assertEquals("account - check order status", projEvent1.getEventName());
-        assertEquals("some value", projEvent1.getCustomAttributes().get("attribute we don't care about"));
+        assertEquals("some value", projEvent1.getCustomAttributeStrings().get("attribute we don't care about"));
 
         projEvent1 = eventList.get(1).getMPEvent();
         assertEquals("pdp - add to tote", projEvent1.getEventName());
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Last Add to Tote Category"));
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Last Add to Tote Total Amount"));
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Last Add to Tote SKU"));
-        assertEquals("10", projEvent1.getCustomAttributes().get("Last Add to Tote Quantity"));
-        assertEquals("1321", projEvent1.getCustomAttributes().get("Last Add to Tote Unit Price"));
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Category"));
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Total Amount"));
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Last Add to Tote SKU"));
+        assertEquals("10", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Quantity"));
+        assertEquals("1321", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Unit Price"));
 
         //these are new for the 2nd projection, as they match the Hash for the new  "Label" attribute
-        assertEquals("product label", projEvent1.getCustomAttributes().get("Last Add to Tote Name"));
-        assertEquals("product label", projEvent1.getCustomAttributes().get("Last Add to Tote Print"));
+        assertEquals("product label", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Name"));
+        assertEquals("product label", projEvent1.getCustomAttributeStrings().get("Last Add to Tote Print"));
 
         //and here's our 3rd projection, which defines both the original "Value" attribute hash as well as "Label"
         projEvent1 = eventList.get(2).getMPEvent();
         assertEquals("pdp - complete the look", projEvent1.getEventName());
-        assertEquals("product name", projEvent1.getCustomAttributes().get("Complete the Look Product Name"));
-        assertEquals("product label", projEvent1.getCustomAttributes().get("Complete the Look Product Name 2"));
+        assertEquals("product name", projEvent1.getCustomAttributeStrings().get("Complete the Look Product Name"));
+        assertEquals("product label", projEvent1.getCustomAttributeStrings().get("Complete the Look Product Name 2"));
 
     }
 
@@ -437,7 +437,7 @@ public class CustomMappingTest {
             MPEvent event = result.get(i).getMPEvent();
             assertNotNull(event);
             assertEquals("pdp - product view", event.getEventName());
-            Map<String, String> attributes = event.getCustomAttributes();
+            Map<String, String> attributes = event.getCustomAttributeStrings();
             assertEquals("product category " + i, attributes.get("Last Product View Category"));
             assertEquals("dollar bills", attributes.get("Last Product View Currency"));
             assertEquals("product id " + i, attributes.get("Last Product View SKU"));
@@ -644,9 +644,9 @@ public class CustomMappingTest {
         assertNotNull(event);
         assertEquals("checkout - place order", event.getEventName());
         assertEquals(5, event.getProducts().size());
-        assertEquals("category 4", event.getCustomAttributes().get("Last Place Order Category"));
-        assertEquals("some product list source", event.getCustomAttributes().get("Projected list source"));
-        assertEquals("sample custom event value", event.getCustomAttributes().get("Projected sample event attribute"));
+        assertEquals("category 4", event.getCustomAttributeStrings().get("Last Place Order Category"));
+        assertEquals("some product list source", event.getCustomAttributeStrings().get("Projected list source"));
+        assertEquals("sample custom event value", event.getCustomAttributeStrings().get("Projected sample event attribute"));
 
         config.getJSONObject("behavior").put("selector", "foreach");
         result = new CustomMapping(config).project(new EventWrapper.CommerceEventWrapper(commerceEvent));
@@ -658,13 +658,13 @@ public class CustomMappingTest {
             CommerceEvent event1 = projectionResult1.getCommerceEvent();
             assertEquals("checkout - place order", event1.getEventName());
             assertEquals(1, event1.getProducts().size());
-            assertEquals("some product list source", event1.getCustomAttributes().get("Projected list source"));
-            assertEquals("sample custom event value", event1.getCustomAttributes().get("Projected sample event attribute"));
+            assertEquals("some product list source", event1.getCustomAttributeStrings().get("Projected list source"));
+            assertEquals("sample custom event value", event1.getCustomAttributeStrings().get("Projected sample event attribute"));
             if (i == 1 || i == 2) {
-                assertEquals("sample custom product attribute value", event1.getCustomAttributes().get("Projected sample custom attribute"));
+                assertEquals("sample custom product attribute value", event1.getCustomAttributeStrings().get("Projected sample custom attribute"));
             }
             assertNotNull(event1);
-            assertEquals("category " + i, event1.getCustomAttributes().get("Last Place Order Category"));
+            assertEquals("category " + i, event1.getCustomAttributeStrings().get("Last Place Order Category"));
         }
 
         //make the ProductAttribute mapping required, should limit down the results to 2 products
@@ -708,11 +708,11 @@ public class CustomMappingTest {
         assertEquals(1, results.size());
         MPEvent result = results.get(0).getMPEvent();
         assertEquals(expectedMappedEvent.getEventName(), result.getEventName());
-        assertEquals(expectedMappedEvent.getCustomAttributes().keySet().size(), result.getCustomAttributes().size());
-        for (String key: expectedMappedEvent.getCustomAttributes().keySet()) {
-            String val = result.getCustomAttributes().get(key);
+        assertEquals(expectedMappedEvent.getCustomAttributeStrings().keySet().size(), result.getCustomAttributeStrings().size());
+        for (String key: expectedMappedEvent.getCustomAttributeStrings().keySet()) {
+            String val = result.getCustomAttributeStrings().get(key);
             assertTrue(val != null);
-            assertEquals(expectedMappedEvent.getCustomAttributes().get(key), val);
+            assertEquals(expectedMappedEvent.getCustomAttributeStrings().get(key), val);
         }
     }
 
@@ -728,8 +728,8 @@ public class CustomMappingTest {
         assertTrue(mapping.isMatch(new EventWrapper.MPEventWrapper(event)));
         assertTrue(events.size() == 1);
         assertTrue(events.get(0).getMPEvent().getEventName().equals("new_premium_subscriber"));
-        assertTrue(events.get(0).getMPEvent().getCustomAttributes().get("plan").equals("premium"));
-        assertTrue(events.get(0).getMPEvent().getCustomAttributes().get("plan 2").equals("premium 2"));
+        assertTrue(events.get(0).getMPEvent().getCustomAttributeStrings().get("plan").equals("premium"));
+        assertTrue(events.get(0).getMPEvent().getCustomAttributeStrings().get("plan 2").equals("premium 2"));
         info.put("plan", "notPremium");
         event = new MPEvent.Builder("subscription_success").customAttributes(info).build();
         assertFalse(mapping.isMatch(new EventWrapper.MPEventWrapper(event) ));
@@ -772,8 +772,8 @@ public class CustomMappingTest {
         List<CustomMapping.ProjectionResult> events = mapping.project(new EventWrapper.MPEventWrapper(event));
         assertTrue(events.size() == 1);
         assertTrue(events.get(0).getMPEvent().getEventName().equals("X_NEW_NOAH_SUBSCRIPTION"));
-        assertTrue(events.get(0).getMPEvent().getCustomAttributes().get("plan_id").equals("8"));
-        assertTrue(events.get(0).getMPEvent().getCustomAttributes().get("outcome").equals("new_subscription"));
+        assertTrue(events.get(0).getMPEvent().getCustomAttributeStrings().get("plan_id").equals("8"));
+        assertTrue(events.get(0).getMPEvent().getCustomAttributeStrings().get("outcome").equals("new_subscription"));
         info.remove("outcome");
         event = new MPEvent.Builder("SUBSCRIPTION_END").customAttributes(info).build();
         assertFalse(mapping.isMatch(new EventWrapper.MPEventWrapper(event)));

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/DataplanFilterImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/DataplanFilterImplTest.kt
@@ -235,7 +235,7 @@ class DataplanFilterImplTest {
 
             dataplanPoints.put(datapoint.toString(), allowedAttributes.keys.toHashSet())
             val dataplanFilter = DataplanFilterImpl(dataplanPoints, true, Random.nextBoolean(), false, false)
-            assertEquals(allowedAttributes, dataplanFilter.transformEventForEvent(event)?.customAttributes)
+            assertEquals(allowedAttributes, dataplanFilter.transformEventForEvent(event)?.customAttributeStrings)
             diversity.remove(datapoint.type)
         }
     }
@@ -272,7 +272,7 @@ class DataplanFilterImplTest {
 
             dataplanPoints.put(datapoint.toString(), allowedAttributes.keys.toHashSet())
             val dataplanFilter = DataplanFilterImpl(dataplanPoints, Random.Default.nextBoolean(), true, false, false)
-            assertEquals(allowedAttributes, dataplanFilter.transformEventForEvent(event)?.customAttributes)
+            assertEquals(allowedAttributes, dataplanFilter.transformEventForEvent(event)?.customAttributeStrings)
             diversity.remove(datapoint.type)
         }
     }


### PR DESCRIPTION
## Summary

Update customAttributes API's for `BaseEvent` & `MPEvent` to accept any value type. This change will bring us to parity with the iOS SDK. We are required to still send `String` customAttributes values to the Server, but the non-String type will be preserved and accessable to Kit consumers. Before the value is sent to the server, we stringify it by invoking the object's `toString()` method

BREAKING CHANGE

For Java consumers, if you have access MPEvents#getCustomAttribute() or BaseEvent#getCustomAttributes() and assign the return value to a Map with explicit generic types: Map<String, String>, then you will have to update the type of the assigned field to Map<String, Object/Any/?>
## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4013
