### PR TITLE
fix: change dependence from stable tag to branch in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
   regression-check:
     needs: create-release-branch
     name: "Run regression"
-    uses: mParticle/mparticle-android-sdk/.github/workflows/daily.yml@stable
+    uses: mParticle/mparticle-android-sdk/.github/workflows/daily.yml@development
     with:
       dry_run: ${{ github.event.inputs.dryRun }}
       branch_name: release/${{ github.run_number }}


### PR DESCRIPTION
## Instructions
1. PR target branch should be against development
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-branch-check-name.yml

## Summary
- change dependence from stable tag to branch in release job

## Testing Plan
- release job should pass

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4016
