### PR TITLE
test: add BatchCreationListener integration tests

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
+++ b/android-core/src/androidTest/java/com/mparticle/MParticleOptionsTest.java
@@ -3,6 +3,8 @@ package com.mparticle;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Looper;
+
+import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
@@ -19,6 +21,7 @@ import com.mparticle.testutils.AndroidUtils.Mutable;
 import com.mparticle.testutils.BaseAbstractTest;
 import com.mparticle.testutils.MPLatch;
 
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -526,5 +529,33 @@ public class MParticleOptionsTest extends BaseAbstractTest {
 
         assertTrue(infoLogs.contains("ANDROID_ID will not be collected based on default settings"));
         infoLogs.clear();
+    }
+
+    @Test
+    public void testBatchCreationCallback() throws InterruptedException {
+        MParticleOptions.BatchCreationListener listener = new MParticleOptions.BatchCreationListener() {
+            @NonNull
+            @Override
+            public JSONObject onBatchCreated(@NonNull JSONObject batch) {
+                return batch;
+            }
+        };
+        MParticleOptions options = MParticleOptions.builder(mProductionContext)
+                .batchCreationListener(listener)
+                .credentials("this", "that")
+                .build();
+        assertEquals(listener, options.getBatchCreationListener());
+
+        options = MParticleOptions.builder(mProductionContext)
+                .credentials("this", "that")
+                .batchCreationListener(listener)
+                .batchCreationListener(null)
+                .build();
+        assertNull(options.getBatchCreationListener());
+
+        options = MParticleOptions.builder(mProductionContext)
+                .credentials("this", "that")
+                .build();
+        assertNull(options.getBatchCreationListener());
     }
 }

--- a/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
@@ -1,0 +1,189 @@
+package com.mparticle
+
+import com.mparticle.internal.Constants
+import com.mparticle.networking.Matcher
+import com.mparticle.testutils.BaseCleanInstallEachTest
+import com.mparticle.testutils.TestingUtils.assertJsonEqual
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BatchCreationCallbackTests : BaseCleanInstallEachTest() {
+
+    @Test
+    fun testListenerNoChange() {
+        var receivedBatch: JSONObject? = null
+        val options = MParticleOptions.builder(mContext)
+            .batchCreationListener {
+                receivedBatch = JSONObject(it.toString())
+                it
+            }
+        startMParticle(options)
+
+        MParticle.getInstance()?.apply {
+            logEvent(
+                MPEvent.Builder("test event")
+                    .build()
+            )
+            upload()
+        }
+
+        mServer.waitForVerify(
+            Matcher(mServer.Endpoints().eventsUrl).bodyMatch {
+                it.optJSONArray("msgs")
+                    ?.toList()
+                    ?.filterIsInstance<JSONObject>()
+                    ?.any { it.optString("n") == "test event" }
+                    ?.also { isMatch ->
+                        val modified = it.remove(Constants.MessageKey.MODIFIED_BATCH)
+                        assertTrue(modified.toString().toBooleanStrict())
+                        if (isMatch) {
+                            // check new key
+                            assertJsonEqual(it, receivedBatch)
+                        }
+                    } ?: false
+            }
+        )
+    }
+
+    @Test
+    fun testListenerModified() {
+        var newBatch = JSONObject().put("the whole", "batch")
+        val targetEventName = "should not send"
+
+        val options = MParticleOptions.builder(mContext)
+            .batchCreationListener {
+                it.optJSONArray("msgs")
+                    ?.toList()
+                    ?.filterIsInstance<JSONObject>()
+                    ?.any { it.optString("n") == targetEventName }
+                    ?.let { result ->
+                        if (result) {
+                            JSONObject(newBatch.toString())
+                        } else {
+                            it
+                        }
+                    } ?: it
+            }
+        startMParticle(options)
+
+        MParticle.getInstance()?.apply {
+            logEvent(
+                MPEvent.Builder(targetEventName)
+                    .build()
+            )
+            upload()
+        }
+
+        mServer.waitForVerify(
+            Matcher(mServer.Endpoints().eventsUrl).bodyMatch {
+                val modified = it.remove(Constants.MessageKey.MODIFIED_BATCH)
+                assertTrue(modified.toString().toBooleanStrict())
+                it.toString() == newBatch.toString()
+            }
+        )
+
+        // make sure the upload queue is cleared
+        MParticle.getInstance()?.apply {
+            logEvent(MPEvent.Builder("test").build())
+            upload()
+        }
+
+        mServer.waitForVerify(
+            Matcher(mServer.Endpoints().eventsUrl).bodyMatch {
+                it.optJSONArray("msgs")
+                    ?.toList()
+                    ?.filterIsInstance<JSONObject>()
+                    ?.any { it.optString("n") == "test" } ?: false
+            }
+        )
+
+        mServer.Requests().events.any {
+            it.bodyJson.optJSONArray("msgs")
+                ?.toList()
+                ?.filterIsInstance<JSONObject>()
+                ?.any { it.optString("n") == targetEventName } ?: false
+        }.let {
+            assertFalse { it }
+        }
+    }
+
+    @Test
+    fun testListenerCrashes() {
+        var newBatch = JSONObject().put("the whole", "batch")
+        val targetEventName = "should not send"
+
+        val options = MParticleOptions.builder(mContext)
+            .batchCreationListener {
+                it.optJSONArray("msgs")
+                    ?.toList()
+                    ?.filterIsInstance<JSONObject>()
+                    ?.any { it.optString("n") == targetEventName }
+                    ?.let { result ->
+                        if (result) {
+                            throw RuntimeException()
+                        } else {
+                            it
+                        }
+                    } ?: it
+            }
+        startMParticle(options)
+
+        MParticle.getInstance()?.apply {
+            logEvent(MPEvent.Builder(targetEventName).build())
+            upload()
+        }
+
+        // make sure the upload queue is cleared
+        MParticle.getInstance()?.apply {
+            logEvent(MPEvent.Builder("test").build())
+            upload()
+        }
+
+        mServer.waitForVerify(
+            Matcher(mServer.Endpoints().eventsUrl).bodyMatch {
+                it.optJSONArray("msgs")
+                    ?.toList()
+                    ?.filterIsInstance<JSONObject>()
+                    ?.any { it.optString("n") == "test" } ?: false
+            }
+        )
+
+        mServer.Requests().events.any {
+            it.bodyJson.optJSONArray("msgs")
+                ?.toList()
+                ?.filterIsInstance<JSONObject>()
+                ?.any { it.optString("n") == targetEventName } ?: false
+        }.let {
+            assertFalse { it }
+        }
+    }
+
+    @Test
+    fun testNoMPWhenNoListener() {
+        startMParticle()
+        MParticle.getInstance()?.apply {
+            logEvent(MPEvent.Builder("test").build())
+            upload()
+        }
+
+        mServer.waitForVerify(
+            Matcher(mServer.Endpoints().eventsUrl).bodyMatch {
+                it.optJSONArray("msgs")
+                    ?.toList()
+                    ?.filterIsInstance<JSONObject>()
+                    ?.any { it.optString("n") == "test" }
+                    ?.also { result ->
+                        if (result) {
+                            assertNull(it.opt(Constants.MessageKey.MODIFIED_BATCH))
+                        }
+                    } ?: false
+            }
+        )
+    }
+}
+
+fun JSONArray.toList(): List<Any> = (0 until length()).map { this.get(it) }

--- a/android-core/src/main/java/com/mparticle/internal/Constants.java
+++ b/android-core/src/main/java/com/mparticle/internal/Constants.java
@@ -392,6 +392,9 @@ public class Constants {
         String API_KEY = "api_key";
         String DATA = "data";
         String ALIAS_REQUEST_TYPE = "alias";
+
+        //batch was mutated
+        String MODIFIED_BATCH = "mb";
     }
 
     public interface Commerce {

--- a/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
@@ -314,15 +314,16 @@ public class MParticleDBManager {
                 if (options != null && options.getBatchCreationListener() != null) {
                     try {
                         batch = options.getBatchCreationListener().onBatchCreated(batch);
+                        if (batch == null || batch.length() == 0) {
+                            Logger.error("Not uploading batch due to 'onCreateBatch' handler being empty");
+                            return;
+                        } else {
+                            batch.put(Constants.MessageKey.MODIFIED_BATCH, true);
+                        }
                     } catch (Exception e) {
                         Logger.error(e, "batch creation listener error, batch will not be uploaded");
                         return;
                     }
-                }
-
-                if (batch == null || batch.length() == 0) {
-                    Logger.error("Not uploading batch due to 'onCreateBatch' handler being empty");
-                    return;
                 }
 
                 UploadService.insertUpload(db, batch, configManager.getApiKey());

--- a/testutils/src/main/java/com/mparticle/testutils/TestingUtils.java
+++ b/testutils/src/main/java/com/mparticle/testutils/TestingUtils.java
@@ -188,6 +188,12 @@ public class TestingUtils {
         if (object1 == object2) {
             return;
         }
+        try {
+            object1 = new JSONObject(object1.toString());
+            object2 = new JSONObject(object2.toString());
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
         assertEquals(object1.length(), object2.length());
         Iterator<String> keys = object1.keys();
         while (keys.hasNext()) {


### PR DESCRIPTION
## Summary
- Add E2E tests for the new BatchCreationListener endpoint

## Testing Plan
- added instrumented tests

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4066
