### PR TITLE
fix: add in missing sync step for dependabot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
           git push origin HEAD:main
           git push origin HEAD:development
+          git push -f origin HEAD:chore/dependabot
       - name: "Push release commits to internal main"
         if: ${{ github.event.inputs.dryRun == 'false' }}
         run: |


### PR DESCRIPTION
## Instructions
1. PR target branch should be against development
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-branch-check-name.yml

## Summary
- add in missing sync step for dependabot

## Testing Plan
- release job should still work

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4219
