### PR TITLE
fix: forward foreground push messages to kit

### DIFF
--- a/android-core/src/main/java/com/mparticle/MPServiceUtil.java
+++ b/android-core/src/main/java/com/mparticle/MPServiceUtil.java
@@ -162,10 +162,15 @@ public class MPServiceUtil {
                     Logger.warning("FCM parsing error: " + e);
                 }
             };
-            MParticle.start(MParticleOptions
-                    .builder(mContext)
-                    .configuration(new KitsLoadedListenerConfiguration(kitsLoadedListener))
-                    .buildForInternalRestart());
+            MParticle instance = MParticle.getInstance();
+            if (instance != null) {
+                instance.Internal().getKitManager().addKitsLoadedListener(kitsLoadedListener);
+            } else {
+                MParticle.start(MParticleOptions
+                        .builder(mContext)
+                        .configuration(new KitsLoadedListenerConfiguration(kitsLoadedListener))
+                        .buildForInternalRestart());
+            }
 
         } catch (Exception e) {
             Logger.warning("FCM parsing error: " + e);

--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/BaseKitOptionsTest.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/BaseKitOptionsTest.kt
@@ -12,6 +12,10 @@ import org.json.JSONObject
 open class BaseKitOptionsTest : BaseCleanInstallEachTest() {
 
     override fun startMParticle(optionsBuilder: MParticleOptions.Builder) {
+        startMParticle(optionsBuilder, true)
+    }
+
+    fun startMParticle(optionsBuilder: MParticleOptions.Builder, awaitKitLoaded: Boolean) {
         AccessUtils.setCredentialsIfEmpty(optionsBuilder)
         val kitsLoadedLatch = MPLatch(1)
         var kitCount = 0
@@ -56,7 +60,9 @@ open class BaseKitOptionsTest : BaseCleanInstallEachTest() {
             kitsLoadedLatch.countDown()
         }
         super.startMParticle(optionsBuilder)
-        kitsLoadedLatch.await()
+        if (awaitKitLoaded) {
+            kitsLoadedLatch.await()
+        }
     }
 
     protected fun waitForKitToStart(kitId: Int) {

--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/GCMPushMessageForwardingTest.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/GCMPushMessageForwardingTest.kt
@@ -1,0 +1,41 @@
+package com.mparticle.kits
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import com.mparticle.MPServiceUtil
+import com.mparticle.MParticle
+import com.mparticle.MParticleOptions
+import com.mparticle.kits.testkits.PushListenerTestKit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class GCMPushMessageForwardingTest : BaseKitOptionsTest() {
+
+    @Test
+    fun testPushForwardedAfterSDKStarted() {
+        var receivedIntent: Intent? = null
+
+        MParticleOptions.builder(mContext)
+            .credentials("key", "secret")
+            .configuration(KitOptions().addKit(1, PushListenerTestKit::class.java))
+            .let {
+                startMParticle(it)
+            }
+
+        val intent = Intent()
+            .apply {
+                action = "com.google.android.c2dm.intent.RECEIVE"
+                data = Uri.EMPTY
+                putExtras(Bundle())
+            }
+        (MParticle.getInstance()?.getKitInstance(1) as PushListenerTestKit).onPushMessageReceived = { context, intent ->
+            receivedIntent = intent
+        }
+        MPServiceUtil(mContext).onHandleIntent(intent)
+
+        assertNotNull(receivedIntent)
+        assertEquals(intent, receivedIntent)
+    }
+}

--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/testkits/PushListenerTestKit.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/testkits/PushListenerTestKit.kt
@@ -1,0 +1,19 @@
+package com.mparticle.kits.testkits
+
+import android.content.Context
+import android.content.Intent
+import com.mparticle.kits.KitIntegration
+
+class PushListenerTestKit : BaseTestKit(), KitIntegration.PushListener {
+    var onPushMessageReceived: (Context, Intent?) -> Unit = { _, _ -> }
+    var onPushRegistration: (String?, String?) -> Boolean = { _, _ -> false }
+    override fun willHandlePushMessage(intent: Intent?) = true
+
+    override fun onPushMessageReceived(context: Context, pushIntent: Intent?) {
+        onPushMessageReceived.invoke(context, pushIntent)
+    }
+
+    override fun onPushRegistration(instanceId: String?, senderId: String?): Boolean {
+        return onPushRegistration.invoke(instanceId, senderId)
+    }
+}


### PR DESCRIPTION
## Summary
- GCM Push Messages are being inadvertently ignored by the kit manager if the SDK has already been started. This was a regression introduced in [PR 118](https://github.com/mParticle/mparticle-android-sdk/pull/118), version 5.37.0
- 
## Testing Plan
- TODO, backfill tests, working on adding E2E tests to cover this scenario

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4116
