### PR TITLE
fix: retain the original attribute value type when forwarded to kits

### DIFF
--- a/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/testkits/EventTestKit.kt
+++ b/android-kit-base/src/androidTest/kotlin/com/mparticle/kits/testkits/EventTestKit.kt
@@ -1,0 +1,38 @@
+package com.mparticle.kits.testkits
+
+import com.mparticle.MPEvent
+import com.mparticle.kits.KitIntegration
+import com.mparticle.kits.ReportingMessage
+
+class EventTestKit : ListenerTestKit(), KitIntegration.EventListener {
+    var onLogEvent: (MPEvent) -> MutableList<ReportingMessage>? = { null }
+
+    override fun logEvent(baseEvent: MPEvent): MutableList<ReportingMessage>? {
+        return onLogEvent(baseEvent)
+    }
+    override fun leaveBreadcrumb(breadcrumb: String?): MutableList<ReportingMessage> {
+        TODO("Not yet implemented")
+    }
+
+    override fun logError(
+        message: String?,
+        errorAttributes: MutableMap<String, String>?
+    ): MutableList<ReportingMessage> {
+        TODO("Not yet implemented")
+    }
+
+    override fun logException(
+        exception: Exception?,
+        exceptionAttributes: MutableMap<String, String>?,
+        message: String?
+    ): MutableList<ReportingMessage> {
+        TODO("Not yet implemented")
+    }
+
+    override fun logScreen(
+        screenName: String?,
+        screenAttributes: MutableMap<String, String>?
+    ): MutableList<ReportingMessage> {
+        TODO("Not yet implemented")
+    }
+}

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -430,24 +430,24 @@ public class KitConfiguration {
         return builder.build();
     }
 
-    public final Map<String, String> filterEventAttributes(MPEvent event) {
-        return filterEventAttributes(event.getEventType(), event.getEventName(), mAttributeFilters, event.getCustomAttributeStrings());
+    public final Map<String, Object> filterEventAttributes(MPEvent event) {
+        return filterEventAttributes(event.getEventType(), event.getEventName(), mAttributeFilters, event.getCustomAttributes());
     }
 
-    public final Map<String, String> filterScreenAttributes(MParticle.EventType eventType, String eventName, Map<String, String> eventAttributes) {
+    public final Map<String, Object> filterScreenAttributes(MParticle.EventType eventType, String eventName, Map<String, Object> eventAttributes) {
         return filterEventAttributes(eventType, eventName, mScreenNameFilters, eventAttributes);
     }
 
-    public final Map<String, String> filterEventAttributes(MParticle.EventType eventType, String eventName, SparseBooleanArray filter, Map<String, String> eventAttributes) {
+    public final Map<String, Object> filterEventAttributes(MParticle.EventType eventType, String eventName, SparseBooleanArray filter, Map<String, Object> eventAttributes) {
         if (eventAttributes != null && eventAttributes.size() > 0 && filter != null && filter.size() > 0) {
             String eventTypeStr = "0";
             if (eventType != null) {
                 eventTypeStr = eventType.ordinal() + "";
             }
-            Iterator<Map.Entry<String, String>> attIterator = eventAttributes.entrySet().iterator();
-            Map<String, String> newAttributes = new HashMap<String, String>();
+            Iterator<Map.Entry<String, Object>> attIterator = eventAttributes.entrySet().iterator();
+            Map<String, Object> newAttributes = new HashMap<>();
             while (attIterator.hasNext()) {
-                Map.Entry<String, String> entry = attIterator.next();
+                Map.Entry<String, Object> entry = attIterator.next();
                 String key = entry.getKey();
                 int hash = KitUtils.hashForFiltering(eventTypeStr + eventName + key);
                 if (filter.get(hash, true)) {

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -951,7 +951,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
             try {
                 if (provider instanceof KitIntegration.EventListener && !provider.isDisabled() && provider.getConfiguration().shouldLogScreen(screenEvent.getEventName())) {
                     MPEvent filteredEvent = new MPEvent.Builder(screenEvent)
-                            .customAttributes(provider.getConfiguration().filterScreenAttributes(null, screenEvent.getEventName(), screenEvent.getCustomAttributeStrings()))
+                            .customAttributes(provider.getConfiguration().filterScreenAttributes(null, screenEvent.getEventName(), screenEvent.getCustomAttributes()))
                             .build();
 
                     List<CustomMapping.ProjectionResult> projectedEvents = CustomMapping.projectEvents(


### PR DESCRIPTION
## Summary
- Event attributes are being stringified somewhere before they land in the kits. These attributes should retain their original types and only be stringified when they are sent to the server. It appears that the issue is in our projection and mapping code, so it is possible we will need a wider fix for other paths events take (CommerceEvents, Screen events, projected events, etc). For now, this ticket will address the specifci known issue

## Testing Plan
- Added E2E test 

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4212
