### PR TITLE
fix: modify() call throws an exception when user is not present

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/UpdateAdIdIdentityTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/UpdateAdIdIdentityTest.kt
@@ -1,0 +1,54 @@
+package com.mparticle.internal
+
+import com.mparticle.MParticle
+import com.mparticle.MParticleOptions
+import com.mparticle.identity.BaseIdentityTask
+import com.mparticle.identity.IdentityApiRequest
+import com.mparticle.testutils.BaseCleanInstallEachTest
+import com.mparticle.testutils.MPLatch
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UpdateAdIdIdentityTest : BaseCleanInstallEachTest() {
+
+    @Test
+    fun testAdIdModifyNoUser() {
+        // setup mock server so initial identity request will not set mpid
+        mServer.setupHappyIdentify(0)
+        val latch = MPLatch(1)
+        MParticle.start(
+            MParticleOptions.builder(mContext)
+                .credentials("key", "secret")
+                .identifyTask(BaseIdentityTask().addSuccessListener { latch.countDown() })
+                .build()
+        )
+
+        // execute CheckAdIdRunnable without a current user
+        AppStateManager.CheckAdIdRunnable("newAdId", "oldAdId").run()
+        assertNull(MParticle.getInstance()!!.Identity().currentUser)
+
+        // set a current user
+        mServer.addConditionalIdentityResponse(0, mStartingMpid)
+        latch.await()
+
+        // force a modify request to ensure that the modify request from the CheckAdIdRunnable is completed
+        val latch2 = MPLatch(1)
+        MParticle.getInstance()!!.Identity().modify(IdentityApiRequest.withEmptyUser().customerId("someId").build())
+            .addSuccessListener { latch2.countDown() }
+        latch2.await()
+
+        // check that modify request from CheckAdIdRunnable executed when current user was set
+        mServer.Requests().modify.count { request ->
+            request.asIdentityRequest().body.identity_changes.let {
+                it.size == 1 &&
+                    it[0].let { identityChange ->
+                        identityChange["new_value"] == "newAdId" &&
+                            identityChange["old_value"] == "oldAdId"
+                    }
+            }
+        }.let {
+            assertEquals(1, it)
+        }
+    }
+}

--- a/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
@@ -460,6 +460,18 @@ public class IdentityApi {
         }
     }
 
+    public static abstract class SingleUserIdentificationCallback implements IdentityStateListener {
+
+        @Override
+        public void onUserIdentified(MParticleUser user, MParticleUser previousUser) {
+            MParticle.getInstance().Identity().removeIdentityStateListener(this);
+            onUserFound(user);
+        }
+
+        public abstract void onUserFound(MParticleUser user);
+
+    }
+
     /**
      * @hidden
      */

--- a/android-core/src/main/java/com/mparticle/internal/MParticleJSInterface.java
+++ b/android-core/src/main/java/com/mparticle/internal/MParticleJSInterface.java
@@ -15,6 +15,8 @@ import com.mparticle.commerce.Impression;
 import com.mparticle.commerce.Product;
 import com.mparticle.commerce.Promotion;
 import com.mparticle.commerce.TransactionAttributes;
+import com.mparticle.identity.IdentityApi;
+import com.mparticle.identity.IdentityApi.SingleUserIdentificationCallback;
 import com.mparticle.identity.IdentityApiRequest;
 import com.mparticle.identity.IdentityStateListener;
 import com.mparticle.identity.MParticleUser;
@@ -820,18 +822,6 @@ public class MParticleJSInterface {
             Logger.warning(String.format(errorMsg, (jse.getMessage() + (!MPUtility.isEmpty(previousErrorMessage) ? "\n" + previousErrorMessage : ""))));
         }
         return identityType;
-    }
-
-    abstract class SingleUserIdentificationCallback implements IdentityStateListener {
-
-        @Override
-        public void onUserIdentified(MParticleUser user, MParticleUser previousUser) {
-            MParticle.getInstance().Identity().removeIdentityStateListener(this);
-            onUserFound(user);
-        }
-
-        abstract void onUserFound(MParticleUser user);
-
     }
 
     public static void registerWebView(WebView webView, String workspaceToken) {


### PR DESCRIPTION
## Summary
When the AdId updates, we will generate a modify() request interanlly with the current user. When the current user is not present/null, this request currently fails with an error log or a thrown exception, if the SDK is running in Development mode. In order to avoid losing this modify request or causing an exception, we will defer the modify request until a user is present, if it is not already

## Testing Plan
- added instrumented test, confirmed that it reproduces the error without any changes

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4270
