### PR TITLE
ci: Add security linting on CI runs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -120,6 +120,30 @@ jobs:
         with:
           name: "kotlin-lint-results"
           path: ./**/build/reports/**
+          
+  security-check:
+    name: "Check for security vulnerabilities"
+    runs-on: macos-latest
+    container:
+      image: returntocorp/semgrep
+    # Prevent permissions issues on simple package version bump PR's
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+    - name: "Checkout branch"
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: "Check for Android/Kotlin vulnerabilities and some other security antipatterns"
+      run: semgrep ci
+      env:
+        SEMGREP_RULES:
+          p/kotlin
+          p/java
+          p/r2c-ci
+    - name: "Check for Android-specific vulnerabilities"
+      uses: MobSF/mobsfscan@main
+      with:
+        args: '. --sonarqube'
 
   kit-compatibility-test:
       name: "Kit Compatibility Test"


### PR DESCRIPTION
Signed-off-by: adrikim-mp <98922343+adrikim-mp@users.noreply.github.com>

## Summary
- Adds semgrep checks for Java and Kotlin source files
- Adds mobsfscan for Android-specific checks

## Testing Plan
- Ran semgrep and mobsfscan locally. Will wait on GHA runner to pick this up to ensure that it works as well.
