### PR TITLE
ci: Change dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
     - package-ecosystem: gradle
       directory: "/"
       schedule:
-          interval: daily
+          interval: monthly
       target-branch: "chore/dependabot"
       labels: ["dependabot"]
       open-pull-requests-limit: 10


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Change the dependabot execution interval from daily to monthly

 ## Testing Plan
 - Regression tests should pass

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5302
