### PR TITLE
fix:data plan blocking app crashes

### DIFF
--- a/android-kit-base/src/main/kotlin/com/mparticle/kits/DataplanFilter.kt
+++ b/android-kit-base/src/main/kotlin/com/mparticle/kits/DataplanFilter.kt
@@ -101,7 +101,7 @@ Data Plan parsed for Kit Filtering:
                 if (event is CommerceEvent) {
                     val productActionDatapoint = dataPoints["$dataPointKey.$PRODUCT_ACTION_PRODUCTS"]
                     event.products?.iterator()?.forEach { product ->
-                        product?.customAttributes?.apply {
+                        product?.customAttributes?.toMutableMap()?.apply {
                             val filteredAttributes = filterKeys {
                                 productActionDatapoint?.contains(it) ?: true
                             }
@@ -113,7 +113,7 @@ Data Plan parsed for Kit Filtering:
                     if ((event.impressions?.size ?: 0) > 0) {
                         event.impressions?.iterator()?.forEach {
                             it.products.forEach { product ->
-                                product?.customAttributes?.apply {
+                                product?.customAttributes?.toMutableMap()?.apply {
                                     val filteredAttributes = filterKeys {
                                         productImpressionDatapoint?.contains(it) ?: true
                                     }


### PR DESCRIPTION
 ## Summary
 - A customer reported that their app crashes when enabling blocking for their data plan, after investigating the error log shared, it seemed to be crashing at line 108 of the DataplanFilter.kt file. It seems function such as clear() and putAll() only work for mutableMaps and will crash of Kotlin's mapOf() is passed as a custom attribute. The fix here converts any incoming custom attribute maps

 ## Testing Plan
 - This was tested locally after creating a snapshot of the mParticle SDK that had the fix.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-5362
