### PR TITLE
fix: SQDSDKS-5287 unable to drop batches nullability

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
@@ -85,7 +85,7 @@ class BatchCreationCallbackTests : BaseCleanInstallEachTest() {
 
     @Test
     fun testNullOnBatchCreatedShouldNOTsend() {
-        val targetEventName = "should send"
+        val targetEventName = "should not send"
 
         val options = MParticleOptions.builder(mContext)
             .batchCreationListener { null }

--- a/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
@@ -63,7 +63,7 @@ class BatchCreationCallbackTests : BaseCleanInstallEachTest() {
             upload()
         }
 
-        //Because the BatchCreationListener is null, the event wouldn't be inserted and therefore sent
+        // Because the BatchCreationListener is null, the event wouldn't be inserted and therefore sent
         mServer.Requests().events.any {
             it.bodyJson.optJSONArray("msgs")
                 ?.toList()

--- a/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/BatchCreationCallbackTests.kt
@@ -52,6 +52,29 @@ class BatchCreationCallbackTests : BaseCleanInstallEachTest() {
     }
 
     @Test
+    fun testNullBatchCreationListener() {
+        val options = MParticleOptions.builder(mContext)
+            .batchCreationListener(null)
+        startMParticle(options)
+        val targetEventName = "should send"
+
+        MParticle.getInstance()?.apply {
+            logEvent(MPEvent.Builder(targetEventName).build())
+            upload()
+        }
+
+        //Because the BatchCreationListener is null, the event wouldn't be inserted and therefore sent
+        mServer.Requests().events.any {
+            it.bodyJson.optJSONArray("msgs")
+                ?.toList()
+                ?.filterIsInstance<JSONObject>()
+                ?.any { it.optString("n") == targetEventName } ?: false
+        }.let {
+            assertFalse { it }
+        }
+    }
+
+    @Test
     fun testListenerModified() {
         var newBatch = JSONObject().put("the whole", "batch")
         val targetEventName = "should not send"

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -966,13 +966,13 @@ public class MParticleOptions {
 
     /**
      * Custom handler to modify or block batch data before upload.
-     * If set, this will be called when a new batch of data is created. By returning a different value, you can change the batch contents, or by returning 'nil' you can block the batch from being uploaded.
+     * If set, this will be called when a new batch of data is created. By returning a different value, you can change the batch contents, or by returning 'null' you can block the batch from being uploaded.
      * Use with care. This feature was initially added to allow the value of existing fields to be modified. If you add new data in a format that the platform is not expecting, it may be dropped or not parsed correctly.
      * Note: Use of this handler will also cause the field 'mb' (modified batch) to appear in the batch so we can distinguish for troubleshooting purposes whether data was changed.
      * Also note: Unlike other callbacks, this block will be called on the SDK queue to prevent batches from being processed out of order. Please avoid excessively blocking in this handler as this will prevent the SDK from doing other tasks.
      */
     public interface BatchCreationListener {
-        @NonNull
+        @Nullable
         JSONObject onBatchCreated(@NonNull JSONObject batch);
     }
 }

--- a/testutils/src/main/java/com/mparticle/testutils/MPLatch.java
+++ b/testutils/src/main/java/com/mparticle/testutils/MPLatch.java
@@ -57,10 +57,7 @@ public class MPLatch extends CountDownLatch {
                 return;
             }
         }
-            mHandler.postDelayed(timeoutRunnable, timeoutTimeMs - 100L);
-            this.await(timeoutTimeMs, TimeUnit.MILLISECONDS);
-            if (timedOut.value) {
-                fail("timed out");
-            }
+        this.await(timeoutTimeMs, TimeUnit.MILLISECONDS);
+        mHandler.postDelayed(timeoutRunnable, timeoutTimeMs - 100L);
     }
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adding the ability to drop batches by returning null

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-5287
