### PR TITLE
fix:screen attributes filters not working

### DIFF
--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -435,7 +435,7 @@ public class KitConfiguration {
     }
 
     public final Map<String, Object> filterScreenAttributes(MParticle.EventType eventType, String eventName, Map<String, Object> eventAttributes) {
-        return filterEventAttributes(eventType, eventName, mScreenNameFilters, eventAttributes);
+        return filterEventAttributes(eventType, eventName, mScreenAttributeFilters, eventAttributes);
     }
 
     public final Map<String, Object> filterEventAttributes(MParticle.EventType eventType, String eventName, SparseBooleanArray filter, Map<String, Object> eventAttributes) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - A customer reported that their screenView custom attributes were still forwarding even though it was filtered off on the UI, after further investigation and being able to repro I noticed in our code that we're passing the screenNames array to filter off instead of the screenAttibutes array.

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Created a snapshot kit with the fix and tested locally

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
