### PR TITLE
fix: Kit integration forwarding unplanned/blocked events when fired early on app run

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
+++ b/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
@@ -77,12 +77,13 @@ public class KitFrameworkWrapper implements KitManager {
                             .onKitsLoaded(() -> {
                                         mKitManager = kitManager;
                                         setKitsLoaded(true);
+                                        updateDataplan(mCoreCallbacks.getDataplanOptions());
                                     }
                             );
                 } else {
                     mKitManager = kitManager;
+                    updateDataplan(mCoreCallbacks.getDataplanOptions());
                 }
-                updateDataplan(mCoreCallbacks.getDataplanOptions());
             } catch (Exception e) {
                 Logger.debug("No Kit Framework detected.");
                 setKitsLoaded(true);
@@ -128,7 +129,7 @@ public class KitFrameworkWrapper implements KitManager {
             disableQueuing();
         }
         List<KitsLoadedListener> kitsLoadedListenersCopy = new ArrayList<>(kitsLoadedListeners);
-        for (KitsLoadedListener kitsLoadedListener: kitsLoadedListenersCopy) {
+        for (KitsLoadedListener kitsLoadedListener : kitsLoadedListenersCopy) {
             if (kitsLoadedListener != null) {
                 kitsLoadedListener.onKitsLoaded();
             }
@@ -198,7 +199,7 @@ public class KitFrameworkWrapper implements KitManager {
                         break;
                     case AttributeChange.INCREMENT_ATTRIBUTE:
                         if (attributeChange.value instanceof String) {
-                            mKitManager.incrementUserAttribute(attributeChange.key, attributeChange.incrementedBy, (String)attributeChange.value, attributeChange.mpid);
+                            mKitManager.incrementUserAttribute(attributeChange.key, attributeChange.incrementedBy, (String) attributeChange.value, attributeChange.mpid);
                         }
                         break;
                     case AttributeChange.TAG:
@@ -630,7 +631,7 @@ public class KitFrameworkWrapper implements KitManager {
             mKitManager.onModifyCompleted(user, request);
         }
     }
-    
+
     @Override
     public void onConsentStateUpdated(ConsentState oldState, ConsentState newState, long mpid) {
         if (mKitManager != null) {

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -154,6 +154,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
         runOnKitThread(() -> {
                     kitConfigurations = parseKitConfigurations(kitConfigs);
                     runOnMainThread(() -> {
+                        updateDataplan(mCoreCallbacks.getDataplanOptions());
                         configureKits(kitConfigurations);
                         callback.setKitsLoaded();
                     });


### PR DESCRIPTION
Kit integration forwarding unplanned/blocked events when fired early on app run

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Dataplans was being updated before the config has been loaded, resulting on a race condition.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}
@mmustafa-tse was able to verify the fix.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-5508
