### PR TITLE
fix: Kit Initialization & De-Initialization.

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -319,12 +319,10 @@ public class ConfigManager {
                     .putString(Constants.PrefKeys.ETAG, etag)
                     .putString(Constants.PrefKeys.IF_MODIFIED, lastModified)
                     .apply();
-            if (kitConfigString == null || (kitConfigString != null && !kitConfigString.isEmpty())) {
-                getKitConfigPreferences()
-                        .edit()
-                        .putString(KIT_CONFIG_KEY, kitConfigString)
-                        .apply();
-            }
+            getKitConfigPreferences()
+                    .edit()
+                    .putString(KIT_CONFIG_KEY, kitConfigString)
+                    .apply();
         } else {
             Logger.debug("clearing current configurations");
             clearConfig();

--- a/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
+++ b/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
@@ -70,6 +70,7 @@ public class KitFrameworkWrapper implements KitManager {
                 KitManager kitManager = constructor.newInstance(mContext, mReportingManager, mCoreCallbacks, mOptions);
                 JSONArray configuration = mCoreCallbacks.getLatestKitConfiguration();
                 Logger.debug("Kit Framework loaded.");
+                this.mKitManager = kitManager;
                 if (!MPUtility.isEmpty(configuration)) {
                     Logger.debug("Restoring previous Kit configuration.");
                     kitManager
@@ -81,7 +82,6 @@ public class KitFrameworkWrapper implements KitManager {
                                     }
                             );
                 } else {
-                    mKitManager = kitManager;
                     updateDataplan(mCoreCallbacks.getDataplanOptions());
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Fix for Kit Initialization & De-Initializationg.

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The underlying issues is that when the KitFrameworkManager calls fetchConfig, the kitConfig instance is null (the instance created not yet assigned). Therefore, the ApiClient can get the "supported kits" from the [KitManager.KitIntegrationFactory] and the mp-kit header is not added to the call, resulting in a response with "eks" empty. 

The fix includes assigning the KitManager instance before calling configure kits (which will fetch the config). 
The kitManager config will anyway be reassigned in the configuration callback.
Removing empty validation in ConfigManager since this is a valid case.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-5408
