### PR TITLE
fix: Use DisplayMetrics instead of WindowManager for StrictMode Error

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/DeviceAttributes.java
+++ b/android-core/src/main/java/com/mparticle/internal/DeviceAttributes.java
@@ -1,5 +1,6 @@
 package com.mparticle.internal;
 
+import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
@@ -8,7 +9,6 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;
-import android.view.WindowManager;
 
 import com.mparticle.MParticle;
 import com.mparticle.internal.Constants.MessageKey;
@@ -196,9 +196,9 @@ public class DeviceAttributes {
             attributes.put(MessageKey.OS_VERSION_INT, Build.VERSION.SDK_INT);
             attributes.put(MessageKey.MODEL, android.os.Build.MODEL);
             attributes.put(MessageKey.RELEASE_VERSION, Build.VERSION.RELEASE);
-
+            Application application = (Application) appContext;
             // device ID
-            addAndroidId(attributes, appContext);
+            addAndroidId(attributes, application);
 
             attributes.put(MessageKey.DEVICE_BLUETOOTH_ENABLED, MPUtility.isBluetoothEnabled(appContext));
             attributes.put(MessageKey.DEVICE_BLUETOOTH_VERSION, MPUtility.getBluetoothVersion(appContext));
@@ -210,12 +210,11 @@ public class DeviceAttributes {
             attributes.put(MessageKey.DEVICE_ROOTED, rootedObject);
 
             // screen height/width
-            WindowManager windowManager = (WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE);
-            DisplayMetrics metrics = new DisplayMetrics();
-            windowManager.getDefaultDisplay().getMetrics(metrics);
-            attributes.put(MessageKey.SCREEN_HEIGHT, metrics.heightPixels);
-            attributes.put(MessageKey.SCREEN_WIDTH, metrics.widthPixels);
-            attributes.put(MessageKey.SCREEN_DPI, metrics.densityDpi);
+            DisplayMetrics displayMetrics = appContext.getResources().getDisplayMetrics();
+
+            attributes.put(MessageKey.SCREEN_HEIGHT, displayMetrics.heightPixels);
+            attributes.put(MessageKey.SCREEN_WIDTH, displayMetrics.widthPixels);
+            attributes.put(MessageKey.SCREEN_DPI, displayMetrics.densityDpi);
 
             // locales
             Locale locale = Locale.getDefault();

--- a/android-core/src/main/java/com/mparticle/internal/MPUtility.java
+++ b/android-core/src/main/java/com/mparticle/internal/MPUtility.java
@@ -20,8 +20,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.provider.Settings;
 import android.telephony.TelephonyManager;
-import android.view.Display;
-import android.view.WindowManager;
+import android.util.DisplayMetrics;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
@@ -369,14 +368,12 @@ public class MPUtility {
     }
 
     public static int getOrientation(Context context) {
-        WindowManager windowManager = (WindowManager) context
-                .getSystemService(Context.WINDOW_SERVICE);
-        Display getOrient = windowManager.getDefaultDisplay();
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
         int orientation = Configuration.ORIENTATION_UNDEFINED;
-        if (getOrient.getWidth() == getOrient.getHeight()) {
+        if (displayMetrics.widthPixels == displayMetrics.heightPixels) {
             orientation = Configuration.ORIENTATION_SQUARE;
         } else {
-            if (getOrient.getWidth() < getOrient.getHeight()) {
+            if (displayMetrics.widthPixels < displayMetrics.heightPixels) {
                 orientation = Configuration.ORIENTATION_PORTRAIT;
             } else {
                 orientation = Configuration.ORIENTATION_LANDSCAPE;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 -Resolved StrictMode error by replacing direct usage of application context's WindowManager with DisplayMetrics.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6262
