### PR TITLE
fix: Use DisplayMetrics instead of WindowManager for StrictMode Error

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/DeviceAttributes.java
+++ b/android-core/src/main/java/com/mparticle/internal/DeviceAttributes.java
@@ -1,5 +1,6 @@
 package com.mparticle.internal;
 
+import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
@@ -197,8 +198,9 @@ public class DeviceAttributes {
             attributes.put(MessageKey.MODEL, android.os.Build.MODEL);
             attributes.put(MessageKey.RELEASE_VERSION, Build.VERSION.RELEASE);
 
+            Application application = (Application) appContext;
             // device ID
-            addAndroidId(attributes, appContext);
+            addAndroidId(attributes, application);
 
             attributes.put(MessageKey.DEVICE_BLUETOOTH_ENABLED, MPUtility.isBluetoothEnabled(appContext));
             attributes.put(MessageKey.DEVICE_BLUETOOTH_VERSION, MPUtility.getBluetoothVersion(appContext));
@@ -210,12 +212,10 @@ public class DeviceAttributes {
             attributes.put(MessageKey.DEVICE_ROOTED, rootedObject);
 
             // screen height/width
-            WindowManager windowManager = (WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE);
-            DisplayMetrics metrics = new DisplayMetrics();
-            windowManager.getDefaultDisplay().getMetrics(metrics);
-            attributes.put(MessageKey.SCREEN_HEIGHT, metrics.heightPixels);
-            attributes.put(MessageKey.SCREEN_WIDTH, metrics.widthPixels);
-            attributes.put(MessageKey.SCREEN_DPI, metrics.densityDpi);
+            DisplayMetrics displayMetrics = appContext.getResources().getDisplayMetrics();
+            attributes.put(MessageKey.SCREEN_HEIGHT, displayMetrics.heightPixels);
+            attributes.put(MessageKey.SCREEN_WIDTH, displayMetrics.widthPixels);
+            attributes.put(MessageKey.SCREEN_DPI, displayMetrics.densityDpi);
 
             // locales
             Locale locale = Locale.getDefault();

--- a/android-core/src/main/java/com/mparticle/internal/MPUtility.java
+++ b/android-core/src/main/java/com/mparticle/internal/MPUtility.java
@@ -20,6 +20,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.provider.Settings;
 import android.telephony.TelephonyManager;
+import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
 
@@ -369,17 +370,17 @@ public class MPUtility {
     }
 
     public static int getOrientation(Context context) {
-        WindowManager windowManager = (WindowManager) context
-                .getSystemService(Context.WINDOW_SERVICE);
-        Display getOrient = windowManager.getDefaultDisplay();
         int orientation = Configuration.ORIENTATION_UNDEFINED;
-        if (getOrient.getWidth() == getOrient.getHeight()) {
-            orientation = Configuration.ORIENTATION_SQUARE;
-        } else {
-            if (getOrient.getWidth() < getOrient.getHeight()) {
-                orientation = Configuration.ORIENTATION_PORTRAIT;
+        if (context != null) {
+            DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+            if (displayMetrics.widthPixels == displayMetrics.heightPixels) {
+                orientation = Configuration.ORIENTATION_SQUARE;
             } else {
-                orientation = Configuration.ORIENTATION_LANDSCAPE;
+                if (displayMetrics.widthPixels < displayMetrics.heightPixels) {
+                    orientation = Configuration.ORIENTATION_PORTRAIT;
+                } else {
+                    orientation = Configuration.ORIENTATION_LANDSCAPE;
+                }
             }
         }
         return orientation;

--- a/android-core/src/test/kotlin/com/mparticle/internal/MPUtilityTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/MPUtilityTest.kt
@@ -2,7 +2,10 @@ package com.mparticle.internal
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.content.res.Configuration
+import android.content.res.Resources
 import android.telephony.TelephonyManager
+import android.util.DisplayMetrics
 import com.mparticle.mock.MockContext
 import com.mparticle.mock.utils.RandomUtils
 import org.json.JSONArray
@@ -11,6 +14,7 @@ import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import java.util.Collections
 import java.util.UUID
 
@@ -252,5 +256,69 @@ class MPUtilityTest {
         Assert.assertEquals("asdvasd", MPUtility.toNumberOrString("asdvasd"))
         Assert.assertEquals("234sdvsda", MPUtility.toNumberOrString("234sdvsda"))
         Assert.assertNull(MPUtility.toNumberOrString(null))
+    }
+
+    @Test
+    fun testGetOrientation() {
+        val mockResources = Mockito.mock(
+            Resources::class.java
+        )
+        val context = Mockito.mock(
+            Context::class.java
+        )
+        val displayMetrics = Mockito.mock(
+            DisplayMetrics::class.java
+        )
+        `when`(context.getResources()).thenReturn(mockResources)
+        `when`(mockResources.getDisplayMetrics()).thenReturn(displayMetrics)
+        displayMetrics.widthPixels = 1080
+        displayMetrics.heightPixels = 1920
+        val orientation: Int = MPUtility.getOrientation(context)
+        Assert.assertEquals(Configuration.ORIENTATION_PORTRAIT, orientation)
+    }
+
+    @Test
+    fun testGetOrientation_When_ORIENTATION_LANDSCAPE() {
+        val mockResources = Mockito.mock(
+            Resources::class.java
+        )
+        val context = Mockito.mock(
+            Context::class.java
+        )
+        val displayMetrics = Mockito.mock(
+            DisplayMetrics::class.java
+        )
+        `when`(context.getResources()).thenReturn(mockResources)
+        `when`(mockResources.getDisplayMetrics()).thenReturn(displayMetrics)
+        displayMetrics.widthPixels = 1953
+        displayMetrics.heightPixels = 1920
+        val orientation: Int = MPUtility.getOrientation(context)
+        Assert.assertEquals(Configuration.ORIENTATION_LANDSCAPE, orientation)
+    }
+
+    @Test
+    fun testGetOrientation_When_ORIENTATION_SQUARE() {
+        val mockResources = Mockito.mock(
+            Resources::class.java
+        )
+        val context = Mockito.mock(
+            Context::class.java
+        )
+        val displayMetrics = Mockito.mock(
+            DisplayMetrics::class.java
+        )
+        `when`(context.getResources()).thenReturn(mockResources)
+        `when`(mockResources.getDisplayMetrics()).thenReturn(displayMetrics)
+        displayMetrics.widthPixels = 850
+        displayMetrics.heightPixels = 850
+        val orientation: Int = MPUtility.getOrientation(context)
+        Assert.assertEquals(Configuration.ORIENTATION_SQUARE, orientation)
+    }
+
+    @Test
+    fun testGetOrientation_When_Context_IS_NULL() {
+        val context: Context? = null
+        val orientation: Int = MPUtility.getOrientation(context)
+        Assert.assertEquals(Configuration.ORIENTATION_UNDEFINED, orientation)
     }
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
-Resolved StrictMode error by replacing direct usage of application context's WindowManager with DisplayMetrics.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6262
