### PR TITLE
fix: update java version into release yml file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,11 +130,11 @@ jobs:
           repository: mparticle/mparticle-android-sdk
           ref: release/${{ github.run_number }}
           submodules: recursive
-      - name: "Install JDK 11"
+      - name: "Install JDK 17"
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
       - name: "Publish Core, KitManager, KitPlugin"
         if: ${{ github.event.inputs.dryRun == 'false'}}
         run: |


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - update java version from 11 to 17 

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6420
