### PR TITLE
fix: Pin conventional commits to version 7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
           -p @semantic-release/exec@5 \
-          -p conventional-changelog-conventionalcommits \
+          -p conventional-changelog-conventionalcommits@7 \
           semantic-release --dry-run
       - name: "Semantic Release"
         if: ${{ github.event.inputs.dryRun == 'false' }}
@@ -107,7 +107,7 @@ jobs:
           -p @semantic-release/changelog@5 \
           -p @semantic-release/git@9 \
           -p @semantic-release/exec@5 \
-          -p conventional-changelog-conventionalcommits \
+          -p conventional-changelog-conventionalcommits@7 \
           semantic-release
       - name: "Push automated release commits to release branch"
         if: ${{ github.event.inputs.dryRun == 'false' }}


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - change conventional commits to version 7, there was major version bump to  8 on 5/03/2024, which seems to have broken the release. 

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 -yml file changes, so can not test locally.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6420
