### PR TITLE
fix: Add callback functionality to upload method

### DIFF
--- a/android-core/build.gradle
+++ b/android-core/build.gradle
@@ -83,6 +83,7 @@ android {
             jvmArgs += ['--add-opens', 'java.base/java.util=ALL-UNNAMED']
             jvmArgs += ['--add-opens', 'java.base/java.text=ALL-UNNAMED']
             jvmArgs += ['--add-opens', 'java.base/java.math=ALL-UNNAMED']
+            jvmArgs += ['--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED']
             jvmArgs += ['--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED']
             jvmArgs += ['--add-opens', 'java.base/java.lang.ref=ALL-UNNAMED']
         }

--- a/android-core/src/main/java/com/mparticle/internal/MessageManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/MessageManager.java
@@ -62,6 +62,7 @@ public class MessageManager implements MessageManagerCallbacks, ReportingManager
     private ConfigManager mConfigManager = null;
     private MParticleDBManager mMParticleDBManager;
     private MParticle.OperatingSystem mOperatingSystem;
+    private MParticle.UploadCallback uploadCallback;
 
 
     /**
@@ -525,7 +526,10 @@ public class MessageManager implements MessageManagerCallbacks, ReportingManager
         mUploadHandler.sendMessageDelayed(mUploadHandler.obtainMessage(UploadHandler.UPLOAD_MESSAGES, mConfigManager.getMpid()), Constants.INITIAL_UPLOAD_DELAY);
     }
 
-    public void doUpload() {
+    public void doUpload(MParticle.UploadCallback... callbacks) {
+        if (callbacks.length > 0) {
+            uploadCallback = callbacks[0];
+        }
         mMessageHandler.sendMessage(mMessageHandler.obtainMessage(MessageHandler.CLEAR_MESSAGES_FOR_UPLOAD));
     }
 
@@ -977,6 +981,14 @@ public class MessageManager implements MessageManagerCallbacks, ReportingManager
                 .putBoolean(Constants.PrefKeys.FIRSTRUN_AST + mConfigManager.getApiKey(), firstRun)
                 .remove(Constants.PrefKeys.FIRSTRUN_OBSELETE + mConfigManager.getApiKey())
                 .apply();
+    }
+
+    public MParticle.UploadCallback getUploadCallback() {
+        return uploadCallback;
+    }
+
+    public void setUploadCallback(MParticle.UploadCallback uploadCallback) {
+        this.uploadCallback = uploadCallback;
     }
 
     @SuppressLint("MissingPermission")

--- a/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
@@ -238,13 +238,28 @@ public class UploadHandler extends BaseHandler {
                     }
                 }
             }
+            if (mMessageManager != null && mMessageManager.getUploadCallback() != null) {
+                mMessageManager.getUploadCallback().onSuccess();
+            }
         } catch (MParticleApiClientImpl.MPThrottleException e) {
+            if (mMessageManager != null && mMessageManager.getUploadCallback() != null) {
+                mMessageManager.getUploadCallback().onFailed();
+            }
         } catch (SSLHandshakeException ssle) {
             Logger.debug("SSL handshake failed while preparing uploads - possible MITM attack detected.");
+            if (mMessageManager != null && mMessageManager.getUploadCallback() != null) {
+                mMessageManager.getUploadCallback().onFailed();
+            }
         } catch (MParticleApiClientImpl.MPConfigException e) {
             Logger.error("Bad API request - is the correct API key and secret configured?");
+            if (mMessageManager != null && mMessageManager.getUploadCallback() != null) {
+                mMessageManager.getUploadCallback().onFailed();
+            }
         } catch (Exception e) {
             Logger.error(e, "Error processing batch uploads in mParticle DB.");
+            if (mMessageManager != null && mMessageManager.getUploadCallback() != null) {
+                mMessageManager.getUploadCallback().onFailed();
+            }
         }
         return processingSessionEnd;
     }

--- a/android-core/src/test/kotlin/com/mparticle/internal/MessageManagerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/MessageManagerTest.kt
@@ -18,8 +18,8 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
+import org.junit.Assert.assertNotNull
 import org.junit.Before
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Answers
 import org.mockito.Mockito
@@ -30,8 +30,11 @@ import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.Random
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertNull
 
 @RunWith(PowerMockRunner::class)
+@PrepareForTest(MessageManager::class)
 class MessageManagerTest {
     private lateinit var context: MockContext
     private lateinit var configManager: ConfigManager
@@ -543,6 +546,32 @@ class MessageManagerTest {
                 Message::class.java
             )
         )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testDoUpload_With_callback() {
+        val mockCallback = Mockito.mock(MParticle.UploadCallback::class.java)
+        manager.doUpload(mockCallback)
+        Mockito.verify(messageHandler, Mockito.times(1)).sendMessage(
+            Mockito.any(
+                Message::class.java
+            )
+        )
+        assertNotNull(manager.uploadCallback)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testDoUpload_With_set_NUll_callback() {
+        manager.uploadCallback = null
+        manager.doUpload()
+        Mockito.verify(messageHandler, Mockito.times(1)).sendMessage(
+            Mockito.any(
+                Message::class.java
+            )
+        )
+        assertNull(manager.uploadCallback)
     }
 
     @Test


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Added callback functionality to the upload method. The callback parameter is only required when using it with the 'doUpload()' method in the 'MessageManager' class.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally and with new unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6465
