### PR TITLE
feat: Add option to disable certificate pinning

### DIFF
--- a/android-core/src/main/java/com/mparticle/networking/NetworkConnection.java
+++ b/android-core/src/main/java/com/mparticle/networking/NetworkConnection.java
@@ -129,7 +129,7 @@ public class NetworkConnection extends BaseNetworkConnection {
 
     private boolean shouldDisablePinning() {
         NetworkOptions networkOptions = mConfigManager.getNetworkOptions();
-        return ConfigManager.getEnvironment() == MParticle.Environment.Development && networkOptions.pinningDisabledInDevelopment;
+        return networkOptions.pinningDisabled || (ConfigManager.getEnvironment() == MParticle.Environment.Development && networkOptions.pinningDisabledInDevelopment);
     }
 
 

--- a/android-core/src/main/java/com/mparticle/networking/NetworkOptions.java
+++ b/android-core/src/main/java/com/mparticle/networking/NetworkOptions.java
@@ -25,6 +25,7 @@ public class NetworkOptions {
 
     Map<Endpoint, DomainMapping> domainMappings = new HashMap<Endpoint, DomainMapping>();
     boolean pinningDisabledInDevelopment = false;
+    boolean pinningDisabled = false;
 
     private NetworkOptions() {
     }
@@ -35,6 +36,10 @@ public class NetworkOptions {
         }
         if (builder.pinningDisabledInDevelopment != null) {
             pinningDisabledInDevelopment = builder.pinningDisabledInDevelopment;
+        }
+
+        if (builder.pinningDisabled != null) {
+            pinningDisabled = builder.pinningDisabled;
         }
     }
 
@@ -52,6 +57,7 @@ public class NetworkOptions {
         try {
             JSONObject jsonObject = new JSONObject(jsonString);
             builder.setPinningDisabledInDevelopment(jsonObject.optBoolean("disableDevPinning", false));
+            builder.setPinningDisabled(jsonObject.optBoolean("disablePinning", false));
             JSONArray domainMappingsJson = jsonObject.getJSONArray("domainMappings");
             for (int i = 0; i < domainMappingsJson.length(); i++) {
                 builder.addDomainMapping(DomainMapping
@@ -93,6 +99,10 @@ public class NetworkOptions {
         return pinningDisabledInDevelopment;
     }
 
+    public boolean isPinningDisabled() {
+        return pinningDisabled;
+    }
+
     DomainMapping getDomain(Endpoint endpoint) {
         return domainMappings.get(endpoint);
     }
@@ -109,6 +119,7 @@ public class NetworkOptions {
         try {
             JSONArray domainMappingsJson = new JSONArray();
             networkOptions.put("disableDevPinning", pinningDisabledInDevelopment);
+            networkOptions.put("disablePinning", pinningDisabled);
             networkOptions.put("domainMappings", domainMappingsJson);
             for (DomainMapping domainMapping : domainMappings.values()) {
                 domainMappingsJson.put(domainMapping.toString());
@@ -122,6 +133,7 @@ public class NetworkOptions {
     public static class Builder {
         private Map<Endpoint, DomainMapping> domainMappings = new HashMap<Endpoint, DomainMapping>();
         private Boolean pinningDisabledInDevelopment;
+        private Boolean pinningDisabled;
 
         private Builder() {
         }
@@ -160,6 +172,12 @@ public class NetworkOptions {
         @NonNull
         public Builder setPinningDisabledInDevelopment(boolean disabledInDevelopment) {
             this.pinningDisabledInDevelopment = disabledInDevelopment;
+            return this;
+        }
+
+        @NonNull
+        public Builder setPinningDisabled(boolean disabled) {
+            this.pinningDisabled = disabled;
             return this;
         }
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Added an option to disable certificate pinning, even in production.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample application
 - Bad certificate and pinning option is false ( no response from the api)
 
![Screenshot 2024-06-25 at 5 30 58 PM](https://github.com/mParticle/mparticle-android-sdk/assets/159845845/a6637558-6454-4687-8897-b10ac8f8ac43)

 - Bad certificate and pinning option is true 
 
![Screenshot 2024-06-25 at 5 33 37 PM](https://github.com/mParticle/mparticle-android-sdk/assets/159845845/eae6ce60-4d0e-4b9f-bc03-877e962db3b5)

![Screenshot 2024-06-25 at 5 34 55 PM](https://github.com/mParticle/mparticle-android-sdk/assets/159845845/a226eaa7-11e6-451a-b0be-5d32317eb61b)


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6541
