### PR TITLE
fix: Add enum types for commerce event

### DIFF
--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -1269,18 +1269,18 @@ public class MParticle {
      * @see #logEvent(BaseEvent)
      */
     public enum EventType {
-        Unknown(0), Navigation(1), Location(2), Search(3), Transaction(4), UserContent(5), UserPreference(6), Social(7), Other(8), Media(9);
 
+        Unknown(0), Navigation(1), Location(2), Search(3), Transaction(4), UserContent(5), UserPreference(6),
+        Social(7), Other(8), Media(9), AddToCart(10), RemoveFromCart(11), Checkout(12), CheckoutOption(13),
+        Click(14), ViewDetail(15), Purchase(16), Refund(17), PromotionView(18), PromotionClick(19), AddToWishlist(20),
+        RemoveFromWishlist(21), Impression(22);
         private final int value;
 
         EventType(final int newValue) {
             value = newValue;
         }
 
-        public int getValue() {
-            return value;
-        }
-
+        public int getValue() { return value; }
         @NonNull
         public String toString() {
             return name();

--- a/android-core/src/main/java/com/mparticle/internal/MParticleJSInterface.java
+++ b/android-core/src/main/java/com/mparticle/internal/MParticleJSInterface.java
@@ -479,6 +479,32 @@ public class MParticleJSInterface {
                 return EventType.Social;
             case 9:
                 return EventType.Media;
+            case 10:
+                return EventType.AddToCart;
+            case 11:
+                return EventType.RemoveFromCart;
+            case 12:
+                return EventType.Checkout;
+            case 13:
+                return EventType.CheckoutOption;
+            case 14:
+                return EventType.Click;
+            case 15:
+                return EventType.ViewDetail;
+            case 16:
+                return EventType.Purchase;
+            case 17:
+                return EventType.Refund;
+            case 18:
+                return EventType.PromotionView;
+            case 19:
+                return EventType.PromotionClick;
+            case 20:
+                return EventType.AddToWishlist;
+            case 21:
+                return EventType.RemoveFromWishlist;
+            case 22:
+                return EventType.Impression;
             default:
                 return EventType.Other;
         }

--- a/android-kit-base/src/main/java/com/mparticle/kits/CommerceEventUtils.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/CommerceEventUtils.java
@@ -56,7 +56,42 @@ public final class CommerceEventUtils {
         List<Product> products = event.getProducts();
         if (products != null) {
             for (int i = 0; i < products.size(); i++) {
-                MPEvent.Builder itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.Transaction);
+                MPEvent.Builder itemEvent;
+                switch (productAction) {
+                    case Product.ADD_TO_CART:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.AddToCart);
+                        break;
+                    case Product.CLICK:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.Click);
+                        break;
+                    case Product.ADD_TO_WISHLIST:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.AddToWishlist);
+                        break;
+                    case Product.CHECKOUT:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.Checkout);
+                        break;
+                    case Product.CHECKOUT_OPTION:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.CheckoutOption);
+                        break;
+                    case Product.DETAIL:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.ViewDetail);
+                        break;
+                    case Product.PURCHASE:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.Purchase);
+                        break;
+                    case Product.REFUND:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.Refund);
+                        break;
+                    case Product.REMOVE_FROM_CART:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.RemoveFromCart);
+                        break;
+                    case Product.REMOVE_FROM_WISHLIST:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.RemoveFromWishlist);
+                        break;
+                    default:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, productAction), MParticle.EventType.Transaction);
+                }
+
                 Map<String, String> attributes = new HashMap<String, String>();
                 OnAttributeExtracted attributeExtracted = new StringAttributeExtractor(attributes);
                 extractProductFields(products.get(i), attributeExtracted);
@@ -184,7 +219,41 @@ public final class CommerceEventUtils {
         List<Promotion> promotions = event.getPromotions();
         if (promotions != null) {
             for (int i = 0; i < promotions.size(); i++) {
-                MPEvent.Builder itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Transaction);
+                MPEvent.Builder itemEvent;
+                switch (promotionAction) {
+                    case Product.ADD_TO_CART:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.AddToCart);
+                        break;
+                    case Product.CLICK:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Click);
+                        break;
+                    case Product.ADD_TO_WISHLIST:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.AddToWishlist);
+                        break;
+                    case Product.CHECKOUT:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Checkout);
+                        break;
+                    case Product.CHECKOUT_OPTION:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.CheckoutOption);
+                        break;
+                    case Product.DETAIL:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.ViewDetail);
+                        break;
+                    case Product.PURCHASE:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Purchase);
+                        break;
+                    case Product.REFUND:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Refund);
+                        break;
+                    case Product.REMOVE_FROM_CART:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.RemoveFromCart);
+                        break;
+                    case Product.REMOVE_FROM_WISHLIST:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.RemoveFromWishlist);
+                        break;
+                    default:
+                        itemEvent = new MPEvent.Builder(String.format(ITEM_NAME, promotionAction), MParticle.EventType.Transaction);
+                }
                 Map<String, String> attributes = new HashMap<String, String>();
                 if (event.getCustomAttributeStrings() != null) {
                     attributes.putAll(event.getCustomAttributeStrings());

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/CommerceEventUtilsTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/CommerceEventUtilsTest.kt
@@ -1,5 +1,8 @@
 package com.mparticle.kits
 
+import com.mparticle.MParticle.EventType
+import com.mparticle.commerce.CommerceEvent
+import com.mparticle.commerce.Product
 import org.junit.Assert
 import org.junit.Test
 
@@ -9,5 +12,157 @@ class CommerceEventUtilsTest {
     fun testNullProductExpansion() {
         Assert.assertNotNull(CommerceEventUtils.expand(null))
         Assert.assertEquals(0, CommerceEventUtils.expand(null).size.toLong())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_AddToCart() {
+        val product = Product.Builder("Double Room - Econ Rate", "econ-1", 100.00)
+            .quantity(4.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.ADD_TO_CART, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.AddToCart, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_CLICK() {
+        val product = Product.Builder("Double Room - Econ Rate", "econ-1", 100.00)
+            .quantity(4.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.CLICK, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.Click, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_ADD_TO_WISHLIST() {
+        val product = Product.Builder("Double Room - Econ Rate", "econ-1", 100.00)
+            .quantity(4.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.ADD_TO_WISHLIST, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.AddToWishlist, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_CHECKOUT() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.CHECKOUT, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.Checkout, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_CHECKOUT_OPTION() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.CHECKOUT_OPTION, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.CheckoutOption, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_DETAIL() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.DETAIL, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.ViewDetail, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_PURCHASE() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.PURCHASE, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.Transaction, events.get(0).eventType)
+        Assert.assertEquals(EventType.Purchase, events.get(1).eventType)
+        Assert.assertEquals(2, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_REFUND() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.REFUND, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.Transaction, events.get(0).eventType)
+        Assert.assertEquals(EventType.Refund, events.get(1).eventType)
+        Assert.assertEquals(2, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_REMOVE_FROM_CART() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.REMOVE_FROM_CART, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.RemoveFromCart, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testProductExpansion_REMOVE_FROM_WISHLIST() {
+        val product = Product.Builder("Unisex Tee", "128747", 18.00)
+            .quantity(3.0)
+            .build()
+        val event = CommerceEvent.Builder(Product.REMOVE_FROM_WISHLIST, product)
+            .build()
+
+        val events = CommerceEventUtils.expand(event)
+        Assert.assertNotNull(CommerceEventUtils.expand(event))
+        Assert.assertEquals(EventType.RemoveFromWishlist, events.get(0).eventType)
+        Assert.assertEquals(1, events.size)
     }
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Added enums for e-commerce events.
 - 'expandProductAction' to create an event instead of a transaction. Separate it into different e-commerce event types.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested it with a sample application and ran unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/[SQDSDKS-6551
