### PR TITLE
fix: Remove Code for Handling Google AdId on a Separate Thread

### DIFF
--- a/android-core/src/test/kotlin/com/mparticle/internal/MPUtilityTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/MPUtilityTest.kt
@@ -6,10 +6,8 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.telephony.TelephonyManager
 import android.util.DisplayMetrics
-import com.mparticle.internal.MPUtility.AdIdInfo
 import com.mparticle.mock.MockContext
 import com.mparticle.mock.utils.RandomUtils
-import junit.framework.TestCase
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -20,12 +18,8 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
-import java.lang.reflect.Field
-import java.lang.reflect.Method
 import java.util.Collections
 import java.util.UUID
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 class MPUtilityTest {
 
@@ -278,8 +272,6 @@ class MPUtilityTest {
         Assert.assertEquals("234sdvsda", MPUtility.toNumberOrString("234sdvsda"))
         Assert.assertNull(MPUtility.toNumberOrString(null))
     }
-
-
 
     @Test
     fun testGetOrientation() {

--- a/android-core/src/test/kotlin/com/mparticle/internal/MPUtilityTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/MPUtilityTest.kt
@@ -105,12 +105,6 @@ class MPUtilityTest {
     @Test
     @Throws(Exception::class)
     fun googleAdIdInfoWithoutPlayServicesAvailable() {
-        val adIDInfo: AdIdInfo? = null
-        val field: Field = MPUtility::class.java.getDeclaredField("googleAdIdInfo")
-        field.apply {
-            isAccessible = true
-        }
-        field.set(instance, adIDInfo)
         Assert.assertNull(MPUtility.getAdIdInfo(MockContext()))
     }
 
@@ -285,44 +279,7 @@ class MPUtilityTest {
         Assert.assertNull(MPUtility.toNumberOrString(null))
     }
 
-    @Test
-    fun testGetGoogleAdIdInfo() {
-        val adIDInfo = AdIdInfo("12345", true, AdIdInfo.Advertiser.GOOGLE)
-        val field: Field = MPUtility::class.java.getDeclaredField("googleAdIdInfo")
-        field.apply {
-            isAccessible = true
-        }
-        field.set(instance, adIDInfo)
 
-        val method: Method = MPUtility::class.java.getDeclaredMethod(
-            "getGoogleAdIdInfo",
-            Context::class.java
-        )
-        method.isAccessible = true
-        val result = method.invoke(instance, mockContext)
-        val mpUtilityResult: AdIdInfo = result as AdIdInfo
-        assertNotNull(result)
-        TestCase.assertEquals("12345", mpUtilityResult.id)
-        TestCase.assertEquals(true, mpUtilityResult.isLimitAdTrackingEnabled)
-        TestCase.assertEquals(AdIdInfo.Advertiser.GOOGLE, mpUtilityResult.advertiser)
-    }
-
-    @Test
-    fun testGetGoogleAdIdInfo_WHEN_adIDInfo_IS_NULL() {
-        val adIDInfo: AdIdInfo? = null
-        val field: Field = MPUtility::class.java.getDeclaredField("googleAdIdInfo")
-        field.apply {
-            isAccessible = true
-        }
-        field.set(instance, adIDInfo)
-        val method: Method = MPUtility::class.java.getDeclaredMethod(
-            "getGoogleAdIdInfo",
-            Context::class.java
-        )
-        method.isAccessible = true
-        val result = method.invoke(instance, mockContext)
-        assertNull(result)
-    }
 
     @Test
     fun testGetOrientation() {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Move the code for retrieving the Google AD ID from a separate thread to the main thread. On some OS, running it in a separate thread causes the main thread to be delayed. (Revert Changes from PR #491 )
 

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Test with a sample app on Android os 14 and 15 using the simulator.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6594
