### PR TITLE
fix: Crash in KitConfiguration due to NumberFormatException

### DIFF
--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -921,12 +921,17 @@ public class KitConfiguration {
 
     protected SparseBooleanArray convertToSparseArray(JSONObject json) {
         SparseBooleanArray map = new SparseBooleanArray();
+        if (json == null) {
+            return map;
+        }
         for (Iterator<String> iterator = json.keys(); iterator.hasNext(); ) {
             try {
                 String key = iterator.next();
                 map.put(Integer.parseInt(key), json.getInt(key) == 1);
             } catch (JSONException jse) {
                 Logger.error("Issue while parsing kit configuration: " + jse.getMessage());
+            } catch (Exception e) {
+                Logger.error("Exception while parsing kit configuration: " + e.getMessage());
             }
         }
         return map;

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitConfigurationTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitConfigurationTest.kt
@@ -722,6 +722,15 @@ class KitConfigurationTest {
     }
 
     @Test
+    fun testConvertToSparseArray_When_JSON_IS_NULL() {
+        val kitConfiguration = MockKitConfiguration()
+        val method: Method = MockKitConfiguration::class.java.getDeclaredMethod("convertToSparseArray", JSONObject::class.java)
+        method.isAccessible = true
+        val result = method.invoke(kitConfiguration, null) as SparseBooleanArray
+        Assert.assertEquals(0, result.size())
+    }
+
+    @Test
     fun testConvertToSparseArray_When_JSON_Data_IS_INVALID() {
         val kitConfiguration = MockKitConfiguration()
         val jsn = """   

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitConfigurationTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitConfigurationTest.kt
@@ -1,5 +1,6 @@
 package com.mparticle.kits
 
+import android.util.SparseBooleanArray
 import com.mparticle.MParticle
 import com.mparticle.commerce.CommerceEvent
 import com.mparticle.commerce.Impression
@@ -19,6 +20,7 @@ import org.junit.Assert
 import org.junit.BeforeClass
 import org.junit.Test
 import org.mockito.Mockito
+import java.lang.reflect.Method
 
 class KitConfigurationTest {
     private val json =
@@ -674,6 +676,96 @@ class KitConfigurationTest {
                     .build()
             )
         )
+    }
+
+    @Test
+    fun testConvertToSparseArray() {
+        val kitConfiguration = MockKitConfiguration()
+        val jsonData = """   
+        {
+           "7456529": 0,
+          "10887805": 0,
+          "13992010": 0,
+          "15360852": 0,
+          "17455322": 0,
+          "18683141": 0,
+          "23029959": 0,
+          "41851400": 0,
+          "47355425": 0,
+          "54925556": 0,
+          "56409892": 0,
+          "66701264": 0
+         }
+        """.trimIndent()
+        val jsonConfiguration = JSONObject(jsonData)
+        val method: Method = MockKitConfiguration::class.java.getDeclaredMethod("convertToSparseArray", JSONObject::class.java)
+        method.isAccessible = true
+        val result = method.invoke(kitConfiguration, jsonConfiguration) as SparseBooleanArray
+        Assert.assertEquals(12, result.size())
+    }
+
+    @Test
+    fun testConvertToSparseArray_When_JSON_OBJECT_IS_NULL() {
+        val kitConfiguration = MockKitConfiguration()
+        val jsonData = """   
+        {
+          "ec": {
+         }
+         }
+        """
+        val method: Method = MockKitConfiguration::class.java.getDeclaredMethod("convertToSparseArray", JSONObject::class.java)
+        method.isAccessible = true
+        val jsonObject = JSONObject(jsonData)
+        val ecData = jsonObject.get("ec") as JSONObject
+        val result = method.invoke(kitConfiguration, ecData) as SparseBooleanArray
+        Assert.assertEquals(0, result.size())
+    }
+
+    @Test
+    fun testConvertToSparseArray_When_JSON_Data_IS_INVALID() {
+        val kitConfiguration = MockKitConfiguration()
+        val jsn = """   
+        {
+           "7456529": 0,
+          "10887805": 0,
+          "-36!037962": 0,
+          "15360852": 0,
+          "17455322": 0,
+          "18683141": 0,
+          "23029959": 0,
+          "41851400": 0,
+          "47355425": 0,
+          "54925556": 0,
+          "56409892": 0,
+          "66701264": 0
+         }
+        """.trimIndent()
+        val jsonConfiguration = JSONObject(jsn)
+        val method: Method = MockKitConfiguration::class.java.getDeclaredMethod("convertToSparseArray", JSONObject::class.java)
+        method.isAccessible = true
+
+        val result = method.invoke(kitConfiguration, jsonConfiguration) as SparseBooleanArray
+        Assert.assertEquals(11, result.size())
+    }
+
+    @Test
+    fun testConvertToSparseArray_When_JSON_OBJECT_IS_INVALID() {
+        val kitConfiguration = MockKitConfiguration()
+        val jsn = """   
+        {
+            "name": "John",
+             "age": "30"
+        }
+        """.trimIndent()
+        val jsonConfiguration = JSONObject(jsn)
+        val method: Method = MockKitConfiguration::class.java.getDeclaredMethod(
+            "convertToSparseArray",
+            JSONObject::class.java
+        )
+        method.isAccessible = true
+
+        val result = method.invoke(kitConfiguration, jsonConfiguration) as SparseBooleanArray
+        Assert.assertEquals(0, result.size())
     }
 
     @Test

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitConfigurationTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitConfigurationTest.kt
@@ -754,7 +754,8 @@ class KitConfigurationTest {
         val jsn = """   
         {
             "name": "John",
-             "age": "30"
+             "age": "30",
+             "18683141": 0
         }
         """.trimIndent()
         val jsonConfiguration = JSONObject(jsn)
@@ -765,7 +766,7 @@ class KitConfigurationTest {
         method.isAccessible = true
 
         val result = method.invoke(kitConfiguration, jsonConfiguration) as SparseBooleanArray
-        Assert.assertEquals(0, result.size())
+        Assert.assertEquals(1, result.size())
     }
 
     @Test

--- a/testutils/src/main/java/com/mparticle/mock/MockKitConfiguration.java
+++ b/testutils/src/main/java/com/mparticle/mock/MockKitConfiguration.java
@@ -44,12 +44,17 @@ public class MockKitConfiguration extends KitConfiguration {
     @Override
     protected SparseBooleanArray convertToSparseArray(JSONObject json) {
         SparseBooleanArray map = new MockSparseBooleanArray();
+        if (json == null) {
+            return map;
+        }
         for (Iterator<String> iterator = json.keys(); iterator.hasNext(); ) {
             try {
                 String key = iterator.next();
                 map.put(Integer.parseInt(key), json.getInt(key) == 1);
             } catch (JSONException jse) {
                 Logger.error("Issue while parsing kit configuration: " + jse.getMessage());
+            } catch (Exception e) {
+                Logger.error("Exception while parsing kit configuration: " + e.getMessage());
             }
         }
         return map;


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fix rare crash in KitConfiguration caused by NumberFormatException. Updated code to handle NumberFormatException and null cases.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with the sample application and could not reproduce the issue initially. However, after adding a unit test, I was able to reproduce the issue and address it.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6548
