### PR TITLE
refactor: Remove unused session history upload code

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/BatchSessionInfoTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/BatchSessionInfoTest.kt
@@ -19,16 +19,6 @@ class BatchSessionInfoTest : BaseCleanStartedEachTest() {
         return builder.logLevel(MParticle.LogLevel.INFO)
     }
 
-    override fun beforeSetup() {
-        // the condition described in the test only happened when `sessionHistory` is false,
-        // so set config to return `sessionHistory` == false
-        mServer.setupConfigResponse(
-            JSONObject()
-                .put(ConfigManager.KEY_INCLUDE_SESSION_HISTORY, false)
-                .toString()
-        )
-    }
-
     /**
      * This test is in response to a bug where, when many messages (> 1 batch worth)
      * are uploaded with for a Session other than the current Session, batches after the first

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/BatchSessionInfoTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/BatchSessionInfoTest.kt
@@ -6,7 +6,6 @@ import com.mparticle.MParticle
 import com.mparticle.MParticleOptions
 import com.mparticle.networking.Matcher
 import com.mparticle.testutils.BaseCleanStartedEachTest
-import org.json.JSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals

--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -58,7 +58,6 @@ public class ConfigManager {
     public static final String VALUE_APP_DEFINED = "appdefined";
     public static final String VALUE_CUE_CATCH = "forcecatch";
     public static final String PREFERENCES_FILE = "mp_preferences";
-    public static final String KEY_INCLUDE_SESSION_HISTORY = "inhd";
     private static final String KEY_DEVICE_PERFORMANCE_METRICS_DISABLED = "dpmd";
     public static final String WORKSPACE_TOKEN = "wst";
     static final String ALIAS_MAX_WINDOW = "alias_max_window";
@@ -98,7 +97,6 @@ public class ConfigManager {
     private long mInfluenceOpenTimeout = 3600 * 1000;
     private JSONArray mTriggerMessageMatches, mTriggerMessageHashes = null;
     private ExceptionHandler mExHandler;
-    private boolean mIncludeSessionHistory = false;
     private JSONObject mCurrentCookies;
     private String mDataplanId;
     private Integer mDataplanVersion;
@@ -453,7 +451,6 @@ public class ConfigManager {
             mInfluenceOpenTimeout = 30 * 60 * 1000;
         }
 
-        mIncludeSessionHistory = responseJSON.optBoolean(KEY_INCLUDE_SESSION_HISTORY, true);
         if (responseJSON.has(KEY_DEVICE_PERFORMANCE_METRICS_DISABLED)) {
             MessageManager.devicePerformanceMetricsDisabled = responseJSON.optBoolean(KEY_DEVICE_PERFORMANCE_METRICS_DISABLED, false);
         }
@@ -502,10 +499,6 @@ public class ConfigManager {
             builder.deleteCharAt(builder.length() - 1);
             return builder.toString();
         }
-    }
-
-    public boolean getIncludeSessionHistory() {
-        return mIncludeSessionHistory;
     }
 
     /**

--- a/android-core/src/main/java/com/mparticle/internal/Constants.java
+++ b/android-core/src/main/java/com/mparticle/internal/Constants.java
@@ -338,7 +338,6 @@ public class Constants {
         String ERROR_SESSION_COUNT = "sn";
         // uploading
         String MESSAGES = "msgs";
-        String HISTORY = "sh";
         String REPORTING = "fsr";
         String URL = "u";
         String METHOD = "m";

--- a/android-core/src/main/java/com/mparticle/internal/MParticleApiClientImpl.java
+++ b/android-core/src/main/java/com/mparticle/internal/MParticleApiClientImpl.java
@@ -343,12 +343,6 @@ public class MParticleApiClientImpl extends MParticleBaseClientImpl implements M
                 for (int i = 0; i < messages.length(); i++) {
                     Logger.verbose("Message type: " + ((JSONObject) messages.get(i)).getString(Constants.MessageKey.TYPE));
                 }
-            } else if (messageJson.has(Constants.MessageKey.HISTORY)) {
-                JSONArray messages = messageJson.getJSONArray(Constants.MessageKey.HISTORY);
-                Logger.verbose("Uploading session history batch...");
-                for (int i = 0; i < messages.length(); i++) {
-                    Logger.verbose("Message type: " + ((JSONObject) messages.get(i)).getString(Constants.MessageKey.TYPE) + " SID: " + ((JSONObject) messages.get(i)).optString(Constants.MessageKey.SESSION_ID));
-                }
             }
         } catch (JSONException jse) {
 

--- a/android-core/src/main/java/com/mparticle/internal/MessageBatch.java
+++ b/android-core/src/main/java/com/mparticle/internal/MessageBatch.java
@@ -100,16 +100,6 @@ public class MessageBatch extends JSONObject {
         }
     }
 
-    public void addSessionHistoryMessage(JSONObject message) {
-        try {
-            if (!has(Constants.MessageKey.HISTORY)) {
-                put(Constants.MessageKey.HISTORY, new JSONArray());
-            }
-            getJSONArray(Constants.MessageKey.HISTORY).put(message);
-        } catch (JSONException ignored) {
-        }
-    }
-
     public void addMessage(JSONObject message) {
         try {
             if (!has(Constants.MessageKey.MESSAGES)) {
@@ -155,14 +145,6 @@ public class MessageBatch extends JSONObject {
     public JSONObject getDeviceInfo() {
         try {
             return getJSONObject(Constants.MessageKey.DEVICE_INFO);
-        } catch (JSONException e) {
-            return null;
-        }
-    }
-
-    public JSONArray getSessionHistoryMessages() {
-        try {
-            return getJSONArray(Constants.MessageKey.HISTORY);
         } catch (JSONException e) {
             return null;
         }

--- a/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
@@ -275,6 +275,7 @@ public class MParticleDBManager {
                 }
 
                 UploadService.insertUpload(db, batch, configManager.getApiKey());
+                cleanSessions(currentSessionId);
             }
         }
     }

--- a/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
@@ -136,35 +136,12 @@ public class MParticleDBManager {
      * Prepare Messages for Upload.
      */
 
-    public void createSessionHistoryUploadMessage(ConfigManager configManager, DeviceAttributes deviceAttributes, String currentSessionId) throws JSONException {
-        MPDatabase db = getDatabase();
-        db.beginTransaction();
-        try {
-            List<MessageService.ReadyMessage> readyMessages = MessageService.getSessionHistory(db, currentSessionId);
-            if (readyMessages.size() <= 0) {
-                db.setTransactionSuccessful();
-                return;
-            }
-
-            HashMap<BatchId, MessageBatch> uploadMessagesByBatchId = getUploadMessageByBatchIdMap(readyMessages, db, configManager, true);
-
-            List<JSONObject> deviceInfos = SessionService.processSessions(db, uploadMessagesByBatchId);
-            for (JSONObject deviceInfo : deviceInfos) {
-                deviceAttributes.updateDeviceInfo(mContext, deviceInfo);
-            }
-            createUploads(uploadMessagesByBatchId, db, deviceAttributes, configManager, currentSessionId, true);
-            db.setTransactionSuccessful();
-        } finally {
-            db.endTransaction();
-        }
-    }
-
     public boolean hasMessagesForUpload() {
         MPDatabase db = getDatabase();
         return MessageService.hasMessagesForUpload(db);
     }
 
-    public void createMessagesForUploadMessage(ConfigManager configManager, DeviceAttributes deviceAttributes, String currentSessionId, boolean sessionHistoryEnabled) throws JSONException {
+    public void createMessagesForUploadMessage(ConfigManager configManager, DeviceAttributes deviceAttributes, String currentSessionId) throws JSONException {
         MPDatabase db = getDatabase();
         db.beginTransaction();
         try {
@@ -173,7 +150,7 @@ public class MParticleDBManager {
                 db.setTransactionSuccessful();
                 return;
             }
-            HashMap<BatchId, MessageBatch> uploadMessagesByBatchId = getUploadMessageByBatchIdMap(readyMessages, db, configManager, false, sessionHistoryEnabled);
+            HashMap<BatchId, MessageBatch> uploadMessagesByBatchId = getUploadMessageByBatchIdMap(readyMessages, db, configManager, false);
 
             List<ReportingService.ReportingMessage> reportingMessages = ReportingService.getReportingMessagesForUpload(db);
             for (ReportingService.ReportingMessage reportingMessage : reportingMessages) {
@@ -209,7 +186,7 @@ public class MParticleDBManager {
             for (JSONObject deviceInfo : deviceInfos) {
                 deviceAttributes.updateDeviceInfo(mContext, deviceInfo);
             }
-            createUploads(uploadMessagesByBatchId, db, deviceAttributes, configManager, currentSessionId, false, sessionHistoryEnabled);
+            createUploads(uploadMessagesByBatchId, db, deviceAttributes, configManager, currentSessionId);
             db.setTransactionSuccessful();
         } finally {
             db.endTransaction();
@@ -228,11 +205,11 @@ public class MParticleDBManager {
         }
     }
 
-    private HashMap<BatchId, MessageBatch> getUploadMessageByBatchIdMap(List<MessageService.ReadyMessage> readyMessages, MPDatabase db, ConfigManager configManager, boolean isHistory) throws JSONException {
-        return getUploadMessageByBatchIdMap(readyMessages, db, configManager, isHistory, false);
+    private HashMap<BatchId, MessageBatch> getUploadMessageByBatchIdMap(List<MessageService.ReadyMessage> readyMessages, MPDatabase db, ConfigManager configManager) throws JSONException {
+        return getUploadMessageByBatchIdMap(readyMessages, db, configManager, false);
     }
 
-    private HashMap<BatchId, MessageBatch> getUploadMessageByBatchIdMap(List<MessageService.ReadyMessage> readyMessages, MPDatabase db, ConfigManager configManager, boolean isHistory, boolean markAsUpload) throws JSONException {
+    private HashMap<BatchId, MessageBatch> getUploadMessageByBatchIdMap(List<MessageService.ReadyMessage> readyMessages, MPDatabase db, ConfigManager configManager, boolean markAsUpload) throws JSONException {
         HashMap<BatchId, MessageBatch> uploadMessagesByBatchId = new HashMap<BatchId, MessageBatch>();
         int highestUploadedMessageId = -1;
         for (MessageService.ReadyMessage readyMessage : readyMessages) {
@@ -247,11 +224,7 @@ public class MParticleDBManager {
             if (messageLength + uploadMessage.getMessageLengthBytes() > Constants.LIMIT_MAX_UPLOAD_SIZE) {
                 break;
             }
-            if (isHistory) {
-                uploadMessage.addSessionHistoryMessage(msgObject);
-            } else {
-                uploadMessage.addMessage(msgObject);
-            }
+            uploadMessage.addMessage(msgObject);
             InternalListenerManager.getListener().onCompositeObjects(readyMessage, uploadMessage);
             uploadMessage.incrementMessageLengthBytes(messageLength);
             highestUploadedMessageId = readyMessage.getMessageId();
@@ -266,11 +239,7 @@ public class MParticleDBManager {
         return uploadMessagesByBatchId;
     }
 
-    private void createUploads(Map<BatchId, MessageBatch> uploadMessagesByBatchId, MPDatabase db, DeviceAttributes deviceAttributes, ConfigManager configManager, String currentSessionId, boolean historyMessages) {
-        createUploads(uploadMessagesByBatchId, db, deviceAttributes, configManager, currentSessionId, historyMessages, false);
-    }
-
-    private void createUploads(Map<BatchId, MessageBatch> uploadMessagesByBatchId, MPDatabase db, DeviceAttributes deviceAttributes, ConfigManager configManager, String currentSessionId, boolean historyMessages, boolean sessionHistoryEnabled) {
+    private void createUploads(Map<BatchId, MessageBatch> uploadMessagesByBatchId, MPDatabase db, DeviceAttributes deviceAttributes, ConfigManager configManager, String currentSessionId) {
         for (Map.Entry<BatchId, MessageBatch> messageBatchEntry : uploadMessagesByBatchId.entrySet()) {
             BatchId batchId = messageBatchEntry.getKey();
             MessageBatch uploadMessage = messageBatchEntry.getValue();
@@ -284,12 +253,7 @@ public class MParticleDBManager {
                 if (uploadMessage.getDeviceInfo() == null || sessionId.equals(currentSessionId)) {
                     uploadMessage.setDeviceInfo(deviceAttributes.getDeviceInfo(mContext));
                 }
-                JSONArray messages;
-                if (historyMessages) {
-                    messages = uploadMessage.getSessionHistoryMessages();
-                } else {
-                    messages = uploadMessage.getMessages();
-                }
+                JSONArray messages = uploadMessage.getMessages();
                 JSONArray identities = findIdentityState(configManager, messages, batchId.getMpid());
                 uploadMessage.setIdentities(identities);
                 JSONObject userAttributes = findUserAttributeState(messages, batchId.getMpid());
@@ -311,12 +275,6 @@ public class MParticleDBManager {
                 }
 
                 UploadService.insertUpload(db, batch, configManager.getApiKey());
-                //if this was to process session history, or
-                //if we're never going to process history AND
-                //this batch contains a previous session, then delete the session.
-                if (!historyMessages && !sessionHistoryEnabled) {
-                    cleanSessions(currentSessionId);
-                }
             }
         }
     }

--- a/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
@@ -461,28 +461,6 @@ class ConfigManagerTest {
 
     @Test
     @Throws(Exception::class)
-    fun testDefaultIncludeSessionHistory() {
-        Assert.assertTrue(manager.includeSessionHistory)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testIncludeSessionHistoryUpdateFromServer() {
-        Assert.assertTrue(manager.includeSessionHistory)
-        val config = JSONObject()
-        config.put("inhd", false)
-        manager.updateConfig(config)
-        Assert.assertFalse(manager.includeSessionHistory)
-        config.put("inhd", true)
-        manager.updateConfig(config)
-        Assert.assertTrue(manager.includeSessionHistory)
-        config.put("inhd", "false")
-        manager.updateConfig(config)
-        Assert.assertFalse(manager.includeSessionHistory)
-    }
-
-    @Test
-    @Throws(Exception::class)
     fun testSaveUserIdentityJson() {
         manager.saveUserIdentityJson(JSONArray())
         Assert.assertEquals(0, manager.userIdentityJson.length().toLong())

--- a/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
@@ -144,43 +144,6 @@ class UploadHandlerTest {
     }
 
     @Test
-    @Throws(Exception::class)
-    fun testDontUploadSessionHistory() {
-        handler.handleMessage(Message())
-        Mockito.`when`(mConfigManager.includeSessionHistory).thenReturn(false)
-        val mockCursor = Mockito.mock(
-            Cursor::class.java
-        )
-        Mockito.`when`(mockCursor.moveToNext()).thenReturn(true, false)
-        Mockito.`when`(mockCursor.getInt(Mockito.anyInt())).thenReturn(123)
-        Mockito.`when`(mockCursor.getString(Mockito.anyInt())).thenReturn("cool message batch!")
-        handler.upload(true)
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun testUploadSessionHistory() {
-        handler.handleMessage(Message())
-        val mockCursor = Mockito.mock(
-            Cursor::class.java
-        )
-        Mockito.`when`(handler.mParticleDBManager.readyUploads)
-            .thenReturn(object : ArrayList<ReadyUpload?>() {
-                init {
-                    add(ReadyUpload(123, false, "a message batch"))
-                }
-            })
-        val mockApiClient = Mockito.mock(
-            MParticleApiClient::class.java
-        )
-        handler.setApiClient(mockApiClient)
-        Mockito.`when`(mConfigManager.includeSessionHistory).thenReturn(true)
-        Mockito.`when`(mockCursor.moveToNext()).thenReturn(true, false)
-        handler.upload(true)
-        Mockito.verify(mockApiClient).sendMessageBatch(Mockito.eq("a message batch"))
-    }
-
-    @Test
     @Throws(
         IOException::class,
         MPThrottleException::class,
@@ -443,13 +406,12 @@ class UploadHandlerTest {
         var messageDelay: Long? = null
         var uploadCalledCount = 0
         var prepareMessageUploadsCalledCount = 0
-        override fun upload(history: Boolean): Boolean {
+        override fun upload() {
             uploadCalledCount++
-            return false
         }
 
         @Throws(Exception::class)
-        override fun prepareMessageUploads(history: Boolean) {
+        override fun prepareMessageUploads() {
             prepareMessageUploadsCalledCount++
         }
 

--- a/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
@@ -1,7 +1,6 @@
 package com.mparticle.internal
 
 import android.content.Context
-import android.database.Cursor
 import android.os.Message
 import com.mparticle.MParticle
 import com.mparticle.MockMParticle
@@ -12,7 +11,6 @@ import com.mparticle.internal.MParticleApiClientImpl.MPRampException
 import com.mparticle.internal.MParticleApiClientImpl.MPThrottleException
 import com.mparticle.internal.database.MPDatabase
 import com.mparticle.internal.database.services.MParticleDBManager
-import com.mparticle.internal.database.services.MParticleDBManager.ReadyUpload
 import com.mparticle.internal.messages.MPAliasMessage
 import com.mparticle.mock.MockContext
 import com.mparticle.testutils.AndroidUtils


### PR DESCRIPTION
 ## Summary
 Remove unused session history upload code. Confirmed that this hasn't been used for years and can be safely removed.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - All unit tests pass and E2E tested in a sample app to see batches still uploading correctly.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6788
