### PR TITLE
 feat: Identity Api response caching

### DIFF
--- a/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
@@ -21,6 +21,8 @@ import com.mparticle.internal.MPUtility;
 import com.mparticle.internal.MessageManager;
 import com.mparticle.internal.listeners.ApiClass;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -346,6 +348,26 @@ public class IdentityApi {
             mMainHandler.disable(true);
             mMainHandler.removeCallbacksAndMessages(null);
         }
+    }
+
+    private  String generateHash(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(input.getBytes());
+
+            // Convert byte array to hex string
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashBytes) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            //throw new RuntimeException("Hashing algorithm not found", e);
+        }
+        return null;
+
     }
 
     private BaseIdentityTask makeIdentityRequest(IdentityApiRequest request, final IdentityNetworkRequestRunnable networkRequest) {

--- a/android-core/src/main/java/com/mparticle/identity/IdentityHttpResponse.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityHttpResponse.java
@@ -135,4 +135,31 @@ public final class IdentityHttpResponse {
         }
         return builder.toString();
     }
+
+    public static IdentityHttpResponse fromJson(@NonNull JSONObject jsonObject) throws JSONException {
+        int httpCode = jsonObject.optInt("http_code", 0);
+        return new IdentityHttpResponse(httpCode, jsonObject);
+    }
+
+    @NonNull
+    public JSONObject toJson() throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("http_code", httpCode);
+        jsonObject.put(MPID, mpId);
+        jsonObject.put(CONTEXT, context);
+        jsonObject.put(LOGGED_IN, loggedIn);
+
+        if (!errors.isEmpty()) {
+            JSONArray errorsArray = new JSONArray();
+            for (Error error : errors) {
+                JSONObject errorObject = new JSONObject();
+                errorObject.put(CODE, error.code);
+                errorObject.put(MESSAGE, error.message);
+                errorsArray.put(errorObject);
+            }
+            jsonObject.put(ERRORS, errorsArray);
+        }
+
+        return jsonObject;
+    }
 }

--- a/android-core/src/main/java/com/mparticle/identity/MParticleIdentityClientImpl.java
+++ b/android-core/src/main/java/com/mparticle/identity/MParticleIdentityClientImpl.java
@@ -2,6 +2,8 @@ package com.mparticle.identity;
 
 import android.content.Context;
 
+import androidx.collection.ArrayMap;
+
 import com.mparticle.BuildConfig;
 import com.mparticle.MParticle;
 import com.mparticle.SdkListener;
@@ -24,13 +26,13 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
 public class MParticleIdentityClientImpl extends MParticleBaseClientImpl implements MParticleIdentityClient {
-    private Context mContext;
-    private ConfigManager mConfigManager;
-
+    public static final String LOGIN_CALL = "login";
+    public static final String IDENTIFY_CALL = "identify";
     static final String LOGIN_PATH = "login";
     static final String LOGOUT_PATH = "logout";
     static final String IDENTIFY_PATH = "identify";
@@ -62,250 +64,20 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
 
     static final String PLATFORM_ANDROID = "android";
     static final String PLATFORM_FIRE = "fire";
-
+    static final String IDENTITY_HEADER_TIMEOUT = "X-MP-Max-Age";
     private static final String SERVICE_VERSION_1 = "/v1";
-    private MParticle.OperatingSystem mOperatingSystem;
+    static Long maxAgeTimeForIdentityCache = 0L;
+    static Long identityCacheTime = 0L;
+    private final Context mContext;
+    private final ConfigManager mConfigManager;
+    private final MParticle.OperatingSystem mOperatingSystem;
+    ArrayMap<String, IdentityHttpResponse> identityCacheArray = new ArrayMap<>();
 
     public MParticleIdentityClientImpl(Context context, ConfigManager configManager, MParticle.OperatingSystem operatingSystem) {
         super(context, configManager);
         this.mContext = context;
         this.mConfigManager = configManager;
         this.mOperatingSystem = operatingSystem;
-    }
-
-    public IdentityHttpResponse login(IdentityApiRequest request) throws JSONException, IOException {
-        JSONObject jsonObject = getStateJson(request);
-        Logger.verbose("Identity login request: " + jsonObject.toString());
-        MPConnection connection = getPostConnection(LOGIN_PATH, jsonObject.toString());
-        String url = connection.getURL().toString();
-        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_LOGIN, url, jsonObject, request);
-        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
-        int responseCode = connection.getResponseCode();
-        JSONObject response = MPUtility.getJsonResponse(connection);
-        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_LOGIN, url, response, responseCode);
-        return parseIdentityResponse(responseCode, response);
-    }
-
-    public IdentityHttpResponse logout(IdentityApiRequest request) throws JSONException, IOException {
-        JSONObject jsonObject = getStateJson(request);
-        Logger.verbose("Identity logout request: \n" + jsonObject.toString());
-        MPConnection connection = getPostConnection(LOGOUT_PATH, jsonObject.toString());
-        String url = connection.getURL().toString();
-        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_LOGOUT, url, jsonObject, request);
-        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
-        int responseCode = connection.getResponseCode();
-        JSONObject response = MPUtility.getJsonResponse(connection);
-        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_LOGOUT, url, response, responseCode);
-        return parseIdentityResponse(responseCode, response);
-    }
-
-    public IdentityHttpResponse identify(IdentityApiRequest request) throws JSONException, IOException {
-        JSONObject jsonObject = getStateJson(request);
-        Logger.verbose("Identity identify request: \n" + jsonObject.toString());
-        MPConnection connection = getPostConnection(IDENTIFY_PATH, jsonObject.toString());
-        String url = connection.getURL().toString();
-        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, jsonObject, request);
-        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
-        int responseCode = connection.getResponseCode();
-        JSONObject response = MPUtility.getJsonResponse(connection);
-        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, response, responseCode);
-        return parseIdentityResponse(responseCode, response);
-    }
-
-    public IdentityHttpResponse modify(IdentityApiRequest request) throws JSONException, IOException {
-        JSONObject jsonObject = getChangeJson(request);
-        Logger.verbose("Identity modify request: \n" + jsonObject.toString());
-        JSONArray identityChanges = jsonObject.optJSONArray("identity_changes");
-        if (identityChanges != null && identityChanges.length() == 0) {
-            return new IdentityHttpResponse(200, request.mpid, "", null);
-        }
-        MPConnection connection = getPostConnection(request.mpid, MODIFY_PATH, jsonObject.toString());
-        String url = connection.getURL().toString();
-        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_MODIFY, url, jsonObject, request);
-        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
-        int responseCode = connection.getResponseCode();
-        JSONObject response = MPUtility.getJsonResponse(connection);
-        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_MODIFY, url, response, responseCode);
-        return parseIdentityResponse(responseCode, response);
-    }
-
-    private JSONObject getBaseJson() throws JSONException {
-        JSONObject clientSdkObject = new JSONObject();
-        clientSdkObject.put(PLATFORM, getOperatingSystemString());
-        clientSdkObject.put(SDK_VENDOR, "mparticle");
-        clientSdkObject.put(SDK_VERSION, BuildConfig.VERSION_NAME);
-
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put(CLIENT_SDK, clientSdkObject);
-        String context = mConfigManager.getIdentityApiContext();
-        if (context != null) {
-            jsonObject.put(CONTEXT, context);
-        }
-        String environment = getStringValue(mConfigManager.getEnvironment());
-        if (!MPUtility.isEmpty(environment)) {
-            jsonObject.put(ENVIRONMENT, environment);
-        }
-        jsonObject.put(REQUEST_TIMESTAMP_MS, System.currentTimeMillis());
-        jsonObject.put(REQUEST_ID, UUID.randomUUID().toString());
-        return jsonObject;
-    }
-
-    private JSONObject getStateJson(IdentityApiRequest request) throws JSONException {
-        JSONObject jsonObject = getBaseJson();
-
-        JSONObject identitiesJson = new JSONObject();
-        MPUtility.AdIdInfo adIdInfo = MPUtility.getAdIdInfo(mContext);
-        if (adIdInfo != null && !adIdInfo.isLimitAdTrackingEnabled) {
-            switch (adIdInfo.advertiser) {
-                case AMAZON:
-                    identitiesJson.put(FIRE_AID, adIdInfo.id);
-                    break;
-                case GOOGLE:
-                    identitiesJson.put(ANDROID_AAID, adIdInfo.id);
-                    break;
-            }
-        }
-        String pushToken = mConfigManager.getPushInstanceId();
-        if (!MPUtility.isEmpty(pushToken)) {
-            identitiesJson.put(PUSH_TOKEN, pushToken);
-        }
-        String androidId = MPUtility.getAndroidID(mContext);
-        if (!MPUtility.isEmpty(androidId)) {
-            identitiesJson.put(ANDROID_UUID, androidId);
-        }
-        String das = mConfigManager.getDeviceApplicationStamp();
-        if (!MPUtility.isEmpty(das)) {
-            identitiesJson.put(DEVICE_APPLICATION_STAMP, das);
-        }
-        if (request != null) {
-            if (!MPUtility.isEmpty(request.getUserIdentities())) {
-                for (Map.Entry<MParticle.IdentityType, String> entry : request.getUserIdentities().entrySet()) {
-                    String idTypeString = getStringValue(entry.getKey());
-                    if (!MPUtility.isEmpty(idTypeString)) {
-                        identitiesJson.put(idTypeString, entry.getValue());
-                    }
-                }
-            }
-        }
-        jsonObject.put(KNOWN_IDENTITIES, identitiesJson);
-
-        Long mpId = mConfigManager.getMpid();
-        if (!mpId.equals(Constants.TEMPORARY_MPID)) {
-            jsonObject.put(PREVIOUS_MPID, mpId);
-        }
-        return jsonObject;
-    }
-
-    private JSONObject getChangeJson(IdentityApiRequest request) throws JSONException {
-        if (request.mpid == null) {
-            request.mpid = mConfigManager.getMpid();
-        }
-        JSONObject jsonObject = getBaseJson();
-        JSONArray changesJson = new JSONArray();
-        Map<MParticle.IdentityType, String> userIdentities = request.getUserIdentities();
-        Map<MParticle.IdentityType, String> previousIdentities = mConfigManager.getUserIdentities(request.mpid);
-
-        Set<MParticle.IdentityType> identityTypes = new HashSet<MParticle.IdentityType>(userIdentities.keySet());
-        identityTypes.addAll(userIdentities.keySet());
-
-        for (MParticle.IdentityType identityType : identityTypes) {
-            String idTypeString = getStringValue(identityType);
-            if (!MPUtility.isEmpty(idTypeString)) {
-                JSONObject changeJson = new JSONObject();
-                String newValue = userIdentities.get(identityType);
-                String oldValue = previousIdentities.get(identityType);
-                if (newValue != oldValue && (newValue == null || !newValue.equals(oldValue))) {
-                    changeJson.put(NEW_VALUE, newValue == null ? JSONObject.NULL : newValue);
-                    changeJson.put(OLD_VALUE, oldValue == null ? JSONObject.NULL : oldValue);
-                    changeJson.put(IDENTITY_TYPE, idTypeString);
-                    changesJson.put(changeJson);
-                }
-            }
-        }
-        for (Map.Entry<String, String> otherIdentities : request.getOtherNewIdentities().entrySet()) {
-            String identityType = otherIdentities.getKey();
-            String newValue = otherIdentities.getValue();
-            String oldValue = request.getOtherOldIdentities().get(identityType);
-            JSONObject changeJson = new JSONObject();
-            if (newValue != oldValue && (newValue == null || !newValue.equals(oldValue))) {
-                changeJson.put(NEW_VALUE, newValue == null ? JSONObject.NULL : newValue);
-                changeJson.put(OLD_VALUE, oldValue == null ? JSONObject.NULL : oldValue);
-                changeJson.put(IDENTITY_TYPE, identityType);
-                changesJson.put(changeJson);
-            }
-        }
-        jsonObject.put(IDENTITY_CHANGES, changesJson);
-        return jsonObject;
-    }
-
-    private IdentityHttpResponse parseIdentityResponse(int httpCode, JSONObject jsonObject) {
-        try {
-            Logger.verbose("Identity response code: " + httpCode);
-            if (jsonObject != null) {
-                Logger.verbose("Identity result: " + jsonObject.toString());
-            }
-            IdentityHttpResponse httpResponse = new IdentityHttpResponse(httpCode, jsonObject);
-            if (!MPUtility.isEmpty(httpResponse.getContext())) {
-                mConfigManager.setIdentityApiContext(httpResponse.getContext());
-            }
-            return httpResponse;
-        } catch (JSONException e) {
-            return new IdentityHttpResponse(httpCode, e.getMessage());
-        }
-    }
-
-    private MPConnection getPostConnection(Long mpId, String endpoint, String message) throws IOException {
-        MPUrl url;
-        if (mpId == null) {
-            url = getUrl(endpoint);
-        } else {
-            url = getUrl(mpId, endpoint);
-        }
-        MPConnection connection = url.openConnection();
-        connection.setConnectTimeout(mConfigManager.getIdentityConnectionTimeout());
-        connection.setReadTimeout(mConfigManager.getIdentityConnectionTimeout());
-        connection.setRequestMethod("POST");
-        connection.setDoOutput(true);
-        connection.setRequestProperty("Content-Encoding", "gzip");
-        connection.setRequestProperty(X_MP_KEY, getApiKey());
-        connection.setRequestProperty("Content-Type", "application/json");
-        String date = getHeaderDateString();
-        connection.setRequestProperty("Date", date);
-        try {
-            connection.setRequestProperty(X_MP_SIGNATURE, getHeaderHashString(connection, date, message, getApiSecret()));
-        } catch (NoSuchAlgorithmException e) {
-            Logger.error("Error signing message.");
-        } catch (InvalidKeyException e) {
-            Logger.error("Error signing message.");
-        }
-        return connection;
-    }
-
-    private MPConnection getPostConnection(String endpoint, String message) throws IOException {
-        return getPostConnection(null, endpoint, message);
-    }
-
-
-    MPUrl getUrl(long mpId, String endpoint) throws MalformedURLException {
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(mpId);
-        if (endpoint.indexOf("/") != 0) {
-            stringBuilder.append("/");
-        }
-        stringBuilder.append(endpoint);
-        return getUrl(stringBuilder.toString());
-    }
-
-    MPUrl getUrl(String endpoint) throws MalformedURLException {
-        return getUrl(Endpoint.IDENTITY, endpoint);
-    }
-
-    private String getApiKey() {
-        return mConfigManager.getApiKey();
-    }
-
-    private String getApiSecret() {
-        return mConfigManager.getApiSecret();
     }
 
     public static String getStringValue(MParticle.IdentityType identityType) {
@@ -406,6 +178,309 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
             return MParticle.IdentityType.PhoneNumber3;
         }
         return null;
+    }
+
+    public IdentityHttpResponse login(IdentityApiRequest request) throws JSONException, IOException {
+        IdentityHttpResponse existsResponse = checkIfExists(request, LOGIN_CALL);
+        if (existsResponse != null) {
+            return existsResponse;
+        }
+        JSONObject jsonObject = getStateJson(request);
+        Logger.verbose("Identity login request: " + jsonObject);
+        MPConnection connection = getPostConnection(LOGIN_PATH, jsonObject.toString());
+        String url = connection.getURL().toString();
+        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_LOGIN, url, jsonObject, request);
+        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
+        int responseCode = connection.getResponseCode();
+        Long maxAgeTime = Long.valueOf(connection.getHeaderField(IDENTITY_HEADER_TIMEOUT));
+        maxAgeTimeForIdentityCache = maxAgeTime;
+
+        JSONObject response = MPUtility.getJsonResponse(connection);
+        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_LOGIN, url, response, responseCode);
+        IdentityHttpResponse loginHttpResponse = parseIdentityResponse(responseCode, response);
+        catchRequest(request, loginHttpResponse, LOGIN_CALL, maxAgeTime);
+        return loginHttpResponse;
+    }
+
+    public IdentityHttpResponse logout(IdentityApiRequest request) throws JSONException, IOException {
+        clearCatch();
+        JSONObject jsonObject = getStateJson(request);
+        Logger.verbose("Identity logout request: \n" + jsonObject);
+        MPConnection connection = getPostConnection(LOGOUT_PATH, jsonObject.toString());
+        String url = connection.getURL().toString();
+        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_LOGOUT, url, jsonObject, request);
+        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
+        int responseCode = connection.getResponseCode();
+        JSONObject response = MPUtility.getJsonResponse(connection);
+        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_LOGOUT, url, response, responseCode);
+        return parseIdentityResponse(responseCode, response);
+    }
+
+    public IdentityHttpResponse identify(IdentityApiRequest request) throws JSONException, IOException {
+        IdentityHttpResponse existsResponse = checkIfExists(request, IDENTIFY_CALL);
+        if (existsResponse != null) {
+            return existsResponse;
+        }
+        JSONObject jsonObject = getStateJson(request);
+        Logger.verbose("Identity identify request: \n" + jsonObject);
+        MPConnection connection = getPostConnection(IDENTIFY_PATH, jsonObject.toString());
+        String url = connection.getURL().toString();
+        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, jsonObject, request);
+        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
+        int responseCode = connection.getResponseCode();
+        Long maxAgeTime = Long.valueOf(connection.getHeaderField(IDENTITY_HEADER_TIMEOUT));
+        maxAgeTimeForIdentityCache = maxAgeTime;
+        JSONObject response = MPUtility.getJsonResponse(connection);
+        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, response, responseCode);
+        IdentityHttpResponse identityHttpResponse = parseIdentityResponse(responseCode, response);
+        catchRequest(request, identityHttpResponse, IDENTIFY_CALL, maxAgeTime);
+        return identityHttpResponse;
+    }
+
+    public IdentityHttpResponse modify(IdentityApiRequest request) throws JSONException, IOException {
+        clearCatch();
+        JSONObject jsonObject = getChangeJson(request);
+        Logger.verbose("Identity modify request: \n" + jsonObject);
+        JSONArray identityChanges = jsonObject.optJSONArray("identity_changes");
+        if (identityChanges != null && identityChanges.length() == 0) {
+            return new IdentityHttpResponse(200, request.mpid, "", null);
+        }
+        MPConnection connection = getPostConnection(request.mpid, MODIFY_PATH, jsonObject.toString());
+        String url = connection.getURL().toString();
+        InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_MODIFY, url, jsonObject, request);
+        connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
+        int responseCode = connection.getResponseCode();
+        JSONObject response = MPUtility.getJsonResponse(connection);
+        InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_MODIFY, url, response, responseCode);
+        return parseIdentityResponse(responseCode, response);
+    }
+
+    private JSONObject getBaseJson() throws JSONException {
+        JSONObject clientSdkObject = new JSONObject();
+        clientSdkObject.put(PLATFORM, getOperatingSystemString());
+        clientSdkObject.put(SDK_VENDOR, "mparticle");
+        clientSdkObject.put(SDK_VERSION, BuildConfig.VERSION_NAME);
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(CLIENT_SDK, clientSdkObject);
+        String context = mConfigManager.getIdentityApiContext();
+        if (context != null) {
+            jsonObject.put(CONTEXT, context);
+        }
+        String environment = getStringValue(ConfigManager.getEnvironment());
+        if (!MPUtility.isEmpty(environment)) {
+            jsonObject.put(ENVIRONMENT, environment);
+        }
+        jsonObject.put(REQUEST_TIMESTAMP_MS, System.currentTimeMillis());
+        jsonObject.put(REQUEST_ID, UUID.randomUUID().toString());
+        return jsonObject;
+    }
+
+    private JSONObject getStateJson(IdentityApiRequest request) throws JSONException {
+        JSONObject jsonObject = getBaseJson();
+
+        JSONObject identitiesJson = new JSONObject();
+        MPUtility.AdIdInfo adIdInfo = MPUtility.getAdIdInfo(mContext);
+        if (adIdInfo != null && !adIdInfo.isLimitAdTrackingEnabled) {
+            switch (adIdInfo.advertiser) {
+                case AMAZON:
+                    identitiesJson.put(FIRE_AID, adIdInfo.id);
+                    break;
+                case GOOGLE:
+                    identitiesJson.put(ANDROID_AAID, adIdInfo.id);
+                    break;
+            }
+        }
+        String pushToken = mConfigManager.getPushInstanceId();
+        if (!MPUtility.isEmpty(pushToken)) {
+            identitiesJson.put(PUSH_TOKEN, pushToken);
+        }
+        String androidId = MPUtility.getAndroidID(mContext);
+        if (!MPUtility.isEmpty(androidId)) {
+            identitiesJson.put(ANDROID_UUID, androidId);
+        }
+        String das = mConfigManager.getDeviceApplicationStamp();
+        if (!MPUtility.isEmpty(das)) {
+            identitiesJson.put(DEVICE_APPLICATION_STAMP, das);
+        }
+        if (request != null) {
+            if (!MPUtility.isEmpty(request.getUserIdentities())) {
+                for (Map.Entry<MParticle.IdentityType, String> entry : request.getUserIdentities().entrySet()) {
+                    String idTypeString = getStringValue(entry.getKey());
+                    if (!MPUtility.isEmpty(idTypeString)) {
+                        identitiesJson.put(idTypeString, entry.getValue());
+                    }
+                }
+            }
+        }
+        jsonObject.put(KNOWN_IDENTITIES, identitiesJson);
+
+        Long mpId = mConfigManager.getMpid();
+        if (!mpId.equals(Constants.TEMPORARY_MPID)) {
+            jsonObject.put(PREVIOUS_MPID, mpId);
+        }
+        return jsonObject;
+    }
+
+    private JSONObject getChangeJson(IdentityApiRequest request) throws JSONException {
+        if (request.mpid == null) {
+            request.mpid = mConfigManager.getMpid();
+        }
+        JSONObject jsonObject = getBaseJson();
+        JSONArray changesJson = new JSONArray();
+        Map<MParticle.IdentityType, String> userIdentities = request.getUserIdentities();
+        Map<MParticle.IdentityType, String> previousIdentities = mConfigManager.getUserIdentities(request.mpid);
+
+        Set<MParticle.IdentityType> identityTypes = new HashSet<MParticle.IdentityType>(userIdentities.keySet());
+        identityTypes.addAll(userIdentities.keySet());
+
+        for (MParticle.IdentityType identityType : identityTypes) {
+            String idTypeString = getStringValue(identityType);
+            if (!MPUtility.isEmpty(idTypeString)) {
+                JSONObject changeJson = new JSONObject();
+                String newValue = userIdentities.get(identityType);
+                String oldValue = previousIdentities.get(identityType);
+                if (!Objects.equals(newValue, oldValue)) {
+                    changeJson.put(NEW_VALUE, newValue == null ? JSONObject.NULL : newValue);
+                    changeJson.put(OLD_VALUE, oldValue == null ? JSONObject.NULL : oldValue);
+                    changeJson.put(IDENTITY_TYPE, idTypeString);
+                    changesJson.put(changeJson);
+                }
+            }
+        }
+        for (Map.Entry<String, String> otherIdentities : request.getOtherNewIdentities().entrySet()) {
+            String identityType = otherIdentities.getKey();
+            String newValue = otherIdentities.getValue();
+            String oldValue = request.getOtherOldIdentities().get(identityType);
+            JSONObject changeJson = new JSONObject();
+            if (!Objects.equals(newValue, oldValue)) {
+                changeJson.put(NEW_VALUE, newValue == null ? JSONObject.NULL : newValue);
+                changeJson.put(OLD_VALUE, oldValue == null ? JSONObject.NULL : oldValue);
+                changeJson.put(IDENTITY_TYPE, identityType);
+                changesJson.put(changeJson);
+            }
+        }
+        jsonObject.put(IDENTITY_CHANGES, changesJson);
+        return jsonObject;
+    }
+
+    private void catchRequest(IdentityApiRequest request, IdentityHttpResponse identityHttpResponse, String callType, Long maxAgeTime) throws JSONException {
+        if (mConfigManager.isIdentityCacheFlagEnabled()) {
+            try {
+                if (identityCacheTime <= 0L) {
+                    identityCacheTime = System.currentTimeMillis();
+                    mConfigManager.saveIdentityCacheTime(identityCacheTime);
+                }
+                String key = request.objectToHash() + callType;
+
+                identityCacheArray.put(key, identityHttpResponse);
+                mConfigManager.saveIdentityCache(key, identityHttpResponse);
+                mConfigManager.saveIdentityMaxAge(maxAgeTime);
+            } catch (Exception e) {
+                Logger.error("Exception while processing Identity caching " + e);
+            }
+        }
+    }
+
+    private void clearCatch() {
+        identityCacheArray.clear();
+        mConfigManager.clearIdentityCatch();
+    }
+
+    private IdentityHttpResponse checkIfExists(IdentityApiRequest request, String callType) {
+        if (mConfigManager.isIdentityCacheFlagEnabled()) {
+            try {
+                String key = request.objectToHash() + callType;
+                if (identityCacheTime <= 0L) {
+                    identityCacheTime = mConfigManager.getIdentityCacheTime();
+                }
+                if (maxAgeTimeForIdentityCache <= 0L) {
+                    maxAgeTimeForIdentityCache = mConfigManager.getIdentityMaxAge();
+                }
+                if (identityCacheArray.isEmpty()) {
+                    identityCacheArray = mConfigManager.fetchIdentityCache();
+                }
+                if ((((System.currentTimeMillis() - identityCacheTime) / 1000) <= maxAgeTimeForIdentityCache) && identityCacheArray.containsKey(key)) {
+                    return identityCacheArray.get(key);
+                } else {
+                    return null;
+
+                }
+            } catch (Exception e) {
+                Logger.error("Exception  " + e);
+
+            }
+        }
+        return null;
+    }
+
+    private IdentityHttpResponse parseIdentityResponse(int httpCode, JSONObject jsonObject) {
+        try {
+            Logger.verbose("Identity response code: " + httpCode);
+            if (jsonObject != null) {
+                Logger.verbose("Identity result: " + jsonObject);
+            }
+            IdentityHttpResponse httpResponse = new IdentityHttpResponse(httpCode, jsonObject);
+            if (!MPUtility.isEmpty(httpResponse.getContext())) {
+                mConfigManager.setIdentityApiContext(httpResponse.getContext());
+            }
+            return httpResponse;
+        } catch (JSONException e) {
+            return new IdentityHttpResponse(httpCode, e.getMessage());
+        }
+    }
+
+    private MPConnection getPostConnection(Long mpId, String endpoint, String message) throws IOException {
+        MPUrl url;
+        if (mpId == null) {
+            url = getUrl(endpoint);
+        } else {
+            url = getUrl(mpId, endpoint);
+        }
+        MPConnection connection = url.openConnection();
+        connection.setConnectTimeout(mConfigManager.getIdentityConnectionTimeout());
+        connection.setReadTimeout(mConfigManager.getIdentityConnectionTimeout());
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-Encoding", "gzip");
+        connection.setRequestProperty(X_MP_KEY, getApiKey());
+        connection.setRequestProperty("Content-Type", "application/json");
+        String date = getHeaderDateString();
+        connection.setRequestProperty("Date", date);
+        try {
+            connection.setRequestProperty(X_MP_SIGNATURE, getHeaderHashString(connection, date, message, getApiSecret()));
+        } catch (NoSuchAlgorithmException e) {
+            Logger.error("Error signing message.");
+        } catch (InvalidKeyException e) {
+            Logger.error("Error signing message.");
+        }
+        return connection;
+    }
+
+    private MPConnection getPostConnection(String endpoint, String message) throws IOException {
+        return getPostConnection(null, endpoint, message);
+    }
+
+    MPUrl getUrl(long mpId, String endpoint) throws MalformedURLException {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(mpId);
+        if (endpoint.indexOf("/") != 0) {
+            stringBuilder.append("/");
+        }
+        stringBuilder.append(endpoint);
+        return getUrl(stringBuilder.toString());
+    }
+
+    MPUrl getUrl(String endpoint) throws MalformedURLException {
+        return getUrl(Endpoint.IDENTITY, endpoint);
+    }
+
+    private String getApiKey() {
+        return mConfigManager.getApiKey();
+    }
+
+    private String getApiSecret() {
+        return mConfigManager.getApiSecret();
     }
 
     private String getStringValue(MParticle.Environment environment) {

--- a/android-core/src/main/java/com/mparticle/internal/Constants.java
+++ b/android-core/src/main/java/com/mparticle/internal/Constants.java
@@ -585,6 +585,9 @@ public class Constants {
         String SESSION_TIMEOUT = "mp::sessionTimeout";
         String REPORT_UNCAUGHT_EXCEPTIONS = "mp::reportUncaughtExceptions";
         String ENVIRONMENT = "mp::environment";
+        String IDENTITY_API_REQUEST ="mp::identity::api::request";
+        String IDENTITY_API_CACHE_TIME ="mp::identity::cache::time";
+        String IDENTITY_MAX_AGE ="mp::max:age::time";
     }
 
     public interface MiscStorageKeys {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds caching of identify and login calls and Clears that cache on modify and logout calls.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 -Tested with sample application. And currently Executed below Test cases:
 1)Login with same user on same session and on cold launch.
 2)Login with two different user on same session and on cold launch.
 3)Call Identity with same details as login details.
 4)Call Identity with same user details on same session and on cold launch.
 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6673
