### PR TITLE
fix: previous Google ad Id from being null on cold launch

### DIFF
--- a/android-core/build.gradle
+++ b/android-core/build.gradle
@@ -159,6 +159,7 @@ dependencies {
     testImplementation project(':testutils')
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_version"
 
     androidTestImplementation project(':testutils')
     if (useOrchestrator()) {
@@ -167,6 +168,7 @@ dependencies {
     }
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_version"
 }
 
 

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/AppStateManagerInstrumentedTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/AppStateManagerInstrumentedTest.kt
@@ -8,6 +8,8 @@ import com.mparticle.internal.database.services.AccessUtils
 import com.mparticle.internal.database.services.MParticleDBManager
 import com.mparticle.testutils.BaseCleanStartedEachTest
 import com.mparticle.testutils.MPLatch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.junit.Assert
 import org.junit.Before
@@ -104,7 +106,7 @@ class AppStateManagerInstrumentedTest : BaseCleanStartedEachTest() {
 
     @Test
     @Throws(InterruptedException::class)
-    fun testOnApplicationForeground() {
+    fun testOnApplicationForeground() = runTest(StandardTestDispatcher()) {
         val latch: CountDownLatch = MPLatch(2)
         val kitManagerTester = KitManagerTester(mContext, latch)
         com.mparticle.AccessUtils.setKitManager(kitManagerTester)

--- a/android-core/src/main/java/com/mparticle/internal/MPUtility.java
+++ b/android-core/src/main/java/com/mparticle/internal/MPUtility.java
@@ -70,6 +70,7 @@ public class MPUtility {
     private static String sOpenUDID;
     private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
     private static final String TAG = MPUtility.class.toString();
+    private static AdIdInfo infoId = null;
 
     public static long getAvailableMemory(Context context) {
         ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
@@ -122,18 +123,21 @@ public class MPUtility {
     @WorkerThread
     @Nullable
     public static AdIdInfo getAdIdInfo(Context context) {
+        if (infoId != null) {
+            return infoId;
+        }
         String packageName = context.getPackageName();
         PackageManager packageManager = context.getPackageManager();
         String installerName = packageManager.getInstallerPackageName(packageName);
         if ((installerName != null && installerName.contains("com.amazon.venezia")) ||
                 "Amazon".equals(android.os.Build.MANUFACTURER)) {
-            AdIdInfo infoId = getAmazonAdIdInfo(context);
+            infoId = getAmazonAdIdInfo(context);
             if (infoId == null) {
                 return getGoogleAdIdInfo(context);
             }
             return infoId;
         } else {
-            AdIdInfo infoId = getGoogleAdIdInfo(context);
+            infoId = getGoogleAdIdInfo(context);
             if (infoId == null) {
                 return getAmazonAdIdInfo(context);
             }

--- a/android-core/src/main/java/com/mparticle/internal/MPUtility.java
+++ b/android-core/src/main/java/com/mparticle/internal/MPUtility.java
@@ -70,7 +70,7 @@ public class MPUtility {
     private static String sOpenUDID;
     private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
     private static final String TAG = MPUtility.class.toString();
-    private static AdIdInfo infoId = null;
+    private static AdIdInfo adInfoId = null;
 
     public static long getAvailableMemory(Context context) {
         ActivityManager.MemoryInfo mi = new ActivityManager.MemoryInfo();
@@ -123,25 +123,25 @@ public class MPUtility {
     @WorkerThread
     @Nullable
     public static AdIdInfo getAdIdInfo(Context context) {
-        if (infoId != null) {
-            return infoId;
+        if (adInfoId != null) {
+            return adInfoId;
         }
         String packageName = context.getPackageName();
         PackageManager packageManager = context.getPackageManager();
         String installerName = packageManager.getInstallerPackageName(packageName);
         if ((installerName != null && installerName.contains("com.amazon.venezia")) ||
                 "Amazon".equals(android.os.Build.MANUFACTURER)) {
-            infoId = getAmazonAdIdInfo(context);
-            if (infoId == null) {
+            adInfoId = getAmazonAdIdInfo(context);
+            if (adInfoId == null) {
                 return getGoogleAdIdInfo(context);
             }
-            return infoId;
+            return adInfoId;
         } else {
-            infoId = getGoogleAdIdInfo(context);
-            if (infoId == null) {
+            adInfoId = getGoogleAdIdInfo(context);
+            if (adInfoId == null) {
                 return getAmazonAdIdInfo(context);
             }
-            return infoId;
+            return adInfoId;
         }
     }
 

--- a/android-core/src/main/kotlin/com/mparticle/internal/AppStateManager.kt
+++ b/android-core/src/main/kotlin/com/mparticle/internal/AppStateManager.kt
@@ -17,6 +17,9 @@ import com.mparticle.identity.IdentityApi.SingleUserIdentificationCallback
 import com.mparticle.identity.IdentityApiRequest
 import com.mparticle.identity.MParticleUser
 import com.mparticle.internal.listeners.InternalListenerManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicInteger
@@ -166,6 +169,9 @@ open class AppStateManager @JvmOverloads constructor(
                     interruptions
                 )
             }
+            CoroutineScope(Dispatchers.IO).launch {
+                mConfigManager?.setPreviousAdId()
+            }
             mLastForegroundTime = time
 
             if (currentActivity != null) {
@@ -207,7 +213,6 @@ open class AppStateManager @JvmOverloads constructor(
                         if (isBackgrounded()) {
                             checkSessionTimeout()
                             logBackgrounded()
-                            mConfigManager?.setPreviousAdId()
                         }
                     } catch (e: Exception) {
                         e.printStackTrace()
@@ -421,7 +426,9 @@ open class AppStateManager @JvmOverloads constructor(
     internal class CheckAdIdRunnable(var configManager: ConfigManager?) : Runnable {
         override fun run() {
             val adIdInfo =
-                MPUtility.getAdIdInfo(MParticle.getInstance()?.Internal()?.appStateManager?.mContext)
+                MPUtility.getAdIdInfo(
+                    MParticle.getInstance()?.Internal()?.appStateManager?.mContext
+                )
             val currentAdId =
                 (if (adIdInfo == null) null else (if (adIdInfo.isLimitAdTrackingEnabled) null else adIdInfo.id))
             val previousAdId = configManager?.previousAdId

--- a/android-core/src/test/kotlin/com/mparticle/internal/AppStateManagerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/AppStateManagerTest.kt
@@ -11,6 +11,8 @@ import com.mparticle.mock.MockApplication
 import com.mparticle.mock.MockContext
 import com.mparticle.mock.MockSharedPreferences
 import com.mparticle.testutils.AndroidUtils
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -132,7 +134,7 @@ class AppStateManagerTest {
      */
     @Test
     @Throws(Exception::class)
-    fun testSecondActivityStart() {
+    fun testSecondActivityStart() = runTest(StandardTestDispatcher()) {
         manager.onActivityPaused(activity)
         Thread.sleep(1000)
         Assert.assertEquals(true, manager.isBackgrounded())


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fix a bug where the previous Google app ID is null when the app is relaunched. This happened because the app ID was stored when the app paused; now, the code has been moved to when the app is in the foreground.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app and Executed unit test cases

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6830
