### PR TITLE
ci: Update cross-platform-tests.yml

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   cross-platform-tests:
     timeout-minutes: 30
-    runs-on: macOS-12
+    runs-on: macOS-15
     steps:
       - name: "Checkout Cross Platform Tests Repo"
         uses: actions/checkout@v3


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
It looks like macos-12 has been deprecated, per the error here https://github.com/mParticle/mparticle-android-sdk/actions/runs/12261598641/job/34492232250?pr=526

![image](https://github.com/user-attachments/assets/e3f31c57-5f3d-4308-838c-402f3aa09f21)


 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
