### PR TITLE
fix: Disable location tracking to stop setting location updates

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/MParticleTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/MParticleTest.kt
@@ -2,6 +2,7 @@ package com.mparticle
 
 import android.content.Context
 import android.location.Location
+import android.location.LocationManager
 import android.os.Handler
 import android.os.Looper
 import android.webkit.WebView
@@ -327,6 +328,27 @@ class MParticleTest : BaseCleanStartedEachTest() {
         Assert.assertEquals(location, MParticle.getInstance()!!.mMessageManager.location)
         MParticle.getInstance()!!.setLocation(null)
         Assert.assertNull(MParticle.getInstance()!!.mMessageManager.location)
+    }
+
+    @Test
+    fun testEnableLocationTracking() {
+        val location = Location("")
+        val mp = MParticle.getInstance()
+        mp!!.enableLocationTracking(LocationManager.NETWORK_PROVIDER, 30 * 1000, 1000)
+        mp!!.setLocation(location)
+        Assert.assertEquals(location, mp!!.mMessageManager.location)
+        Assert.assertNotNull(mp.mMessageManager.location)
+    }
+
+    @Test
+    fun testEnableLocationTrackingAndDisableLocationTracking() {
+        val location = Location("")
+        val mp = MParticle.getInstance()
+        mp!!.enableLocationTracking(LocationManager.NETWORK_PROVIDER, 30 * 1000, 1000)
+        mp!!.setLocation(location)
+        Assert.assertEquals(location, mp!!.mMessageManager.location)
+        mp.disableLocationTracking()
+        Assert.assertNull(mp.mMessageManager.location)
     }
 
     @Throws(JSONException::class, InterruptedException::class)

--- a/android-core/src/androidTest/kotlin/com.mparticle/MParticleTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/MParticleTest.kt
@@ -348,6 +348,7 @@ class MParticleTest : BaseCleanStartedEachTest() {
         mp!!.setLocation(location)
         Assert.assertEquals(location, mp!!.mMessageManager.location)
         mp.disableLocationTracking()
+        mp.setLocation(null)
         Assert.assertNull(mp.mMessageManager.location)
     }
 

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -722,6 +722,7 @@ public class MParticle {
                     }
                 }
                 mLocationListener = null;
+                setLocation(null);
                 SharedPreferences.Editor editor = mPreferences.edit();
                 editor.remove(PrefKeys.LOCATION_PROVIDER)
                         .remove(PrefKeys.LOCATION_MINTIME)


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fix issue where previous location details were still being sent after calling disableLocationTracking(). Now, setLocation is set to null to clear the previous location.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7031
