### PR TITLE
Fix Kotlin version compatibility by skipping metadata version check

### DIFF
--- a/android-core/build.gradle
+++ b/android-core/build.gradle
@@ -104,6 +104,9 @@ android {
         test.java.srcDirs += 'src/test/kotlin'
         androidTest.java.srcDirs += 'src/androidTest/kotlin'
     }
+    kotlinOptions {
+        freeCompilerArgs += ['-Xskip-metadata-version-check']
+    }
 }
 
 task coreSdkJavadocs(type: Javadoc) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This change adds the -Xskip-metadata-version-check option to the Kotlin compiler to fix version mismatch issues and ensure the build works without errors.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
