### PR TITLE
ci: Downgrade API level to 28 for daily yml file

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -84,7 +84,7 @@ jobs:
       - name: "Run Instrumented Tests"
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
-          api-level: 29
+          api-level: 28
           #script: ./gradlew :android-core:cAT :android-kit-base:cAT --stacktrace
           script: |
             #Disable benchmark tests as they do not work on emulators
@@ -117,7 +117,7 @@ jobs:
       - name: "Run Instrumented Orchestrator Tests"
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d #v2.33.0
         with:
-          api-level: 29
+          api-level: 28
           script: ./gradlew -Porchestrator=true :android-core:cAT --stacktrace
       - name: "Archive Instrumented Orchestrator Tests Results"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Downgraded API level to 28 to resolve java.lang.IllegalAccessError caused by com.android.library with API level 29 and above in Android Gradle 7

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
