### PR TITLE
ci: Remove manual build variant detection via isRelease flag

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -252,7 +252,7 @@ jobs:
       - name: "Build Android Core"
         run: ./gradlew -PisRelease=true clean publishReleaseLocal
       - name: "Test Kits"
-        run: ./gradlew -PisRelease=true clean testRelease publishReleaseLocal -c settings-kits.gradle
+        run: ./gradlew clean testRelease publishReleaseLocal -c settings-kits.gradle
 
   semantic-release-dryrun:
     name: "Test Semantic Release - Dry Run"


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This change removes the need to pass -PisRelease=true when running Gradle commands.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
