### PR TITLE
ci: Remove need for -PisRelease=true flag in Gradle command

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -250,7 +250,7 @@ jobs:
           java-version: "17"
           cache: "gradle"
       - name: "Build Android Core"
-        run: ./gradlew -PisRelease=true clean publishReleaseLocal
+        run: ./gradlew clean publishReleaseLocal
       - name: "Test Kits"
         run: ./gradlew clean testRelease publishReleaseLocal -c settings-kits.gradle
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This change makes it so you no longer need to add -PisRelease=true when running build commands.
 
 
 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
