### PR TITLE
fix: Rokt Submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,8 +81,7 @@
 	url = git@github.com:mparticle-integrations/mparticle-android-integration-revealmobile.git
 [submodule "kits/rokt-kit"]
 	path = kits/rokt-kit
-	url = https://github.com/mparticle-integrations/mparticle-android-integration-rokt.git
-	branch = main
+	url = git@github.com:mparticle-integrations/mparticle-android-integration-rokt.git
 [submodule "kits/singular-kit"]
 	path = kits/singular-kit
 	url = git@github.com:mparticle-integrations/mparticle-android-integration-singular.git


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fix Git submodule error related to Rokt Kit integration

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
