### PR TITLE
fix: Add a rule to make sure RoktEmbeddedView and related classes are not removed in release builds

### DIFF
--- a/android-core/proguard.pro
+++ b/android-core/proguard.pro
@@ -191,6 +191,13 @@
     *;
 }
 
+-keep public class com.mparticle.rokt.* {
+    *;
+}
+-keep public class com.mparticle.audience.* {
+    *;
+}
+
 -keepclassmembernames class * {
     java.lang.Class class$(java.lang.String);
     java.lang.Class class$(java.lang.String, boolean);


### PR DESCRIPTION
… not removed in release builds

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - nit test failed to compile because ProGuard removed a required class in the release build. Add a rule to keep RoktEmbeddedView and related classes.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed that the class is included in the local release build

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
