### PR TITLE
feat: Add kit filtering to MParticleOptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -55,6 +55,7 @@ public class MParticleOptions {
     private DataplanOptions mDataplanOptions;
     private Map<Class, List<Configuration>> mConfigurations = new HashMap();
     private List<SideloadedKit> sideloadedKits = new ArrayList<>();
+    private List<Integer> filteredKits = new ArrayList<>();
 
     private MParticleOptions() {
     }
@@ -147,6 +148,7 @@ public class MParticleOptions {
         this.mDataplanOptions = builder.dataplanOptions;
         this.mConfigurations = builder.configurations;
         this.sideloadedKits = builder.sideloadedKits;
+        this.filteredKits = builder.filteredKits;
     }
 
     /**
@@ -189,6 +191,16 @@ public class MParticleOptions {
     @NonNull
     public List<SideloadedKit> getSideloadedKits() {
         return sideloadedKits;
+    }
+
+    /**
+     * Get list of filtered kits
+     *
+     * @return
+     */
+    @NonNull
+    public List<Integer> getFilteredKits() {
+        return filteredKits;
     }
 
     /**
@@ -400,6 +412,7 @@ public class MParticleOptions {
         private Map<Class, List<Configuration>> configurations = new HashMap();
         private boolean isAppDebuggable;
         private List<SideloadedKit> sideloadedKits = new ArrayList<>();
+        private List<Integer> filteredKits = new ArrayList<>();
 
         private Builder(Context context) {
             this.context = context;
@@ -451,6 +464,18 @@ public class MParticleOptions {
                 }
             }
             this.sideloadedKits = _kits;
+            return this;
+        }
+
+        /**
+         * Add filtered kits
+         *
+         * @param kits
+         * @return
+         */
+        @NonNull
+        public Builder filteredKits(@NonNull List<Integer> kits) {
+            filteredKits.addAll(kits);
             return this;
         }
 

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
@@ -1,5 +1,7 @@
 package com.mparticle.kits;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.mparticle.MParticle;
 import com.mparticle.MParticleOptions;
 import com.mparticle.internal.Logger;
@@ -15,8 +17,10 @@ import java.util.Set;
 public class KitIntegrationFactory {
 
     final Map<Integer, Class> supportedKits = new HashMap<>();
-    private Map<Integer, String> knownIntegrations = new HashMap<Integer, String>();
-    private Map<Integer, MPSideloadedKit> sideloadedKitMap = new HashMap<>();
+    @VisibleForTesting
+    public Map<Integer, String> knownIntegrations = new HashMap<Integer, String>();
+    @VisibleForTesting
+    public Map<Integer, MPSideloadedKit> sideloadedKitMap = new HashMap<>();
 
     public KitIntegrationFactory(MParticleOptions options) {
         supportedKits.clear();
@@ -109,6 +113,7 @@ public class KitIntegrationFactory {
     }
 
     private void loadIntegrations(MParticleOptions options) {
+        filterKits(options);
         loadSideloadedIntegrations(options);
         for (Map.Entry<Integer, String> entry : knownIntegrations.entrySet()) {
             Class kitClass = loadKit(entry.getValue());
@@ -126,6 +131,13 @@ public class KitIntegrationFactory {
             Logger.verbose("Kit not bundled: ", className);
         }
         return null;
+    }
+
+    private void filterKits(MParticleOptions options) {
+        for (Integer filteredKit : options.getFilteredKits()) {
+            Logger.verbose("Filtering kit: " + knownIntegrations.get(filteredKit));
+            knownIntegrations.remove(filteredKit);
+        }
     }
 
     public void addSupportedKit(int kitId, Class<? extends KitIntegration> kitIntegration) {

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -603,6 +603,27 @@ class KitManagerImplTest {
     }
 
     @Test
+    fun shouldFilterKitsFromKnownIntegrations() {
+        val options = MParticleOptions.builder(MockContext()).build()
+        val filteredKitOptions = MParticleOptions.builder(MockContext())
+            .filteredKits(listOf(MParticle.ServiceProviders.ADJUST))
+            .build()
+
+        val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
+        val kitIntegrationFactory = KitIntegrationFactory(options)
+
+        val knownKitsSize = kitIntegrationFactory.knownIntegrations.size
+        val filteredKnownKitsSize = filteredKitIntegrationFactory.knownIntegrations.size
+        Assert.assertEquals(knownKitsSize - 1, filteredKnownKitsSize)
+        Assert.assertNotNull(
+            kitIntegrationFactory.knownIntegrations[MParticle.ServiceProviders.ADJUST]
+        )
+        Assert.assertNull(
+            filteredKitIntegrationFactory.knownIntegrations[MParticle.ServiceProviders.ADJUST]
+        )
+    }
+
+    @Test
     @Throws(Exception::class)
     fun testShouldEnableKitOnOptIn() {
         val mockUser = Mockito.mock(MParticleUser::class.java)


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 -  introduces a new feature to the MParticleOptions class that allows you to specify a list of kit integration IDs (as Integers) that should be excluded or filtered out during SDK initialization
 - checks the filteredKits list in KitIntegrationFactory

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
