### PR TITLE
feat: Add option to disable kits in MParticleOptions

### DIFF
--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -194,7 +194,7 @@ public class MParticleOptions {
     }
 
     /**
-     * Get list of filteredKits kits
+     * Get list of disabled kits
      *
      * @return
      * */
@@ -481,7 +481,7 @@ public class MParticleOptions {
         }
 
         /**
-         * Add Filter kits options
+         * Add disable kits option
          *
          * @param kits
          * @return

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -55,7 +55,7 @@ public class MParticleOptions {
     private DataplanOptions mDataplanOptions;
     private Map<Class, List<Configuration>> mConfigurations = new HashMap();
     private List<SideloadedKit> sideloadedKits = new ArrayList<>();
-    private List<Integer> filteredKits = new ArrayList<>();
+    private List<Integer> disabledKits = new ArrayList<>();
 
     private MParticleOptions() {
     }
@@ -148,7 +148,7 @@ public class MParticleOptions {
         this.mDataplanOptions = builder.dataplanOptions;
         this.mConfigurations = builder.configurations;
         this.sideloadedKits = builder.sideloadedKits;
-        this.filteredKits = builder.filteredKits;
+        this.disabledKits = builder.disabledKits;
     }
 
     /**
@@ -199,8 +199,8 @@ public class MParticleOptions {
      * @return
      * */
     @NonNull
-    public List<Integer> getFilteredKits() {
-        return filteredKits;
+    public List<Integer> getDisabledKits() {
+        return disabledKits;
     }
 
     /**
@@ -412,7 +412,7 @@ public class MParticleOptions {
         private Map<Class, List<Configuration>> configurations = new HashMap();
         private boolean isAppDebuggable;
         private List<SideloadedKit> sideloadedKits = new ArrayList<>();
-        private List<Integer> filteredKits = new ArrayList<>();
+        private List<Integer> disabledKits = new ArrayList<>();
 
         private Builder(Context context) {
             this.context = context;
@@ -487,8 +487,8 @@ public class MParticleOptions {
          * @return
          */
         @NonNull
-        public Builder filteredKits(@NonNull List<Integer> kits) {
-            filteredKits.addAll(kits);
+        public Builder disableKits(@NonNull List<Integer> kits) {
+            disabledKits.addAll(kits);
             return this;
         }
 

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -55,6 +55,7 @@ public class MParticleOptions {
     private DataplanOptions mDataplanOptions;
     private Map<Class, List<Configuration>> mConfigurations = new HashMap();
     private List<SideloadedKit> sideloadedKits = new ArrayList<>();
+    private List<Integer> filteredKits = new ArrayList<>();
 
     private MParticleOptions() {
     }
@@ -147,6 +148,7 @@ public class MParticleOptions {
         this.mDataplanOptions = builder.dataplanOptions;
         this.mConfigurations = builder.configurations;
         this.sideloadedKits = builder.sideloadedKits;
+        this.filteredKits = builder.filteredKits;
     }
 
     /**
@@ -189,6 +191,16 @@ public class MParticleOptions {
     @NonNull
     public List<SideloadedKit> getSideloadedKits() {
         return sideloadedKits;
+    }
+
+    /**
+     * Get list of filteredKits kits
+     *
+     * @return
+     * */
+    @NonNull
+    public List<Integer> getFilteredKits() {
+        return filteredKits;
     }
 
     /**
@@ -400,6 +412,7 @@ public class MParticleOptions {
         private Map<Class, List<Configuration>> configurations = new HashMap();
         private boolean isAppDebuggable;
         private List<SideloadedKit> sideloadedKits = new ArrayList<>();
+        private List<Integer> filteredKits = new ArrayList<>();
 
         private Builder(Context context) {
             this.context = context;
@@ -464,6 +477,18 @@ public class MParticleOptions {
         @NonNull
         public Builder environment(@NonNull MParticle.Environment environment) {
             this.environment = environment;
+            return this;
+        }
+
+        /**
+         * Add Filter kits options
+         *
+         * @param kits
+         * @return
+         */
+        @NonNull
+        public Builder filteredKits(@NonNull List<Integer> kits) {
+            filteredKits.addAll(kits);
             return this;
         }
 

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
@@ -121,7 +121,7 @@ public class KitIntegrationFactory {
     }
 
     private void filterKits(MParticleOptions options) {
-        for (Integer filteredKit : options.getFilteredKits()) {
+        for (Integer filteredKit : options.getDisabledKits()) {
             Logger.verbose("Filtering kit: " + knownIntegrations.get(filteredKit));
             knownIntegrations.remove(filteredKit);
         }

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitIntegrationFactory.java
@@ -109,6 +109,7 @@ public class KitIntegrationFactory {
     }
 
     private void loadIntegrations(MParticleOptions options) {
+        filterKits(options);
         loadSideloadedIntegrations(options);
         for (Map.Entry<Integer, String> entry : knownIntegrations.entrySet()) {
             Class kitClass = loadKit(entry.getValue());
@@ -116,6 +117,13 @@ public class KitIntegrationFactory {
                 supportedKits.put(entry.getKey(), kitClass);
                 Logger.debug(entry.getValue().substring(entry.getValue().lastIndexOf(".") + 1) + " detected.");
             }
+        }
+    }
+
+    private void filterKits(MParticleOptions options) {
+        for (Integer filteredKit : options.getFilteredKits()) {
+            Logger.verbose("Filtering kit: " + knownIntegrations.get(filteredKit));
+            knownIntegrations.remove(filteredKit);
         }
     }
 

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -633,7 +633,6 @@ class KitManagerImplTest {
         Assert.assertNull(filteredKitIntegrations[MParticle.ServiceProviders.CLEVERTAP])
     }
 
-
     @Test
     fun shouldFilterKitsFromKnownIntegrations_When_filter_Is_Empty() {
         val options = MParticleOptions.builder(MockContext()).build()

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -26,6 +26,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import java.util.Arrays
 import java.util.LinkedList
 
 class KitManagerImplTest {
@@ -584,9 +585,7 @@ class KitManagerImplTest {
         val sideloadedKit = Mockito.mock(KitIntegration::class.java)
         Mockito.`when`(sideloadedKit.isDisabled).thenReturn(false)
         Mockito.`when`(sideloadedKit.configuration).thenReturn(
-            Mockito.mock(
-                KitConfiguration::class.java
-            )
+            Mockito.mock(KitConfiguration::class.java)
         )
         Mockito.`when`(
             factory.createInstance(
@@ -606,9 +605,13 @@ class KitManagerImplTest {
     fun shouldFilterKitsFromKnownIntegrations() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .disableKits(listOf(MParticle.ServiceProviders.ADJUST))
-            .disableKits(listOf(MParticle.ServiceProviders.APPBOY))
-            .disableKits(listOf(MParticle.ServiceProviders.CLEVERTAP))
+            .disableKits(
+                Arrays.asList(
+                    MParticle.ServiceProviders.ADJUST,
+                    MParticle.ServiceProviders.APPBOY,
+                    MParticle.ServiceProviders.CLEVERTAP
+                )
+            )
             .build()
 
         val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
@@ -634,7 +637,7 @@ class KitManagerImplTest {
     }
 
     @Test
-    fun shouldFilterKitsFromKnownIntegrations_When_filter_Is_Empty() {
+    fun shouldNotFilterKitsFromKnownIntegrationsWhenFilterIsEmpty() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
             .disableKits(emptyList())
@@ -685,7 +688,7 @@ class KitManagerImplTest {
         val field = KitIntegrationFactory::class.java.getDeclaredField("knownIntegrations")
         field.isAccessible = true
         val knownIntegrations = field.get(factory) as Map<*, *>
-
+        Assert.assertNull(knownIntegrations[MParticle.ServiceProviders.ADJUST])
         // Verify that a different kit is still present
         Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.APPBOY])
         Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.URBAN_AIRSHIP])

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -603,6 +603,128 @@ class KitManagerImplTest {
     }
 
     @Test
+    fun shouldFilterKitsFromKnownIntegrations() {
+        val options = MParticleOptions.builder(MockContext()).build()
+        val filteredKitOptions = MParticleOptions.builder(MockContext())
+            .filteredKits(listOf(MParticle.ServiceProviders.ADJUST))
+            .filteredKits(listOf(MParticle.ServiceProviders.APPBOY))
+            .filteredKits(listOf(MParticle.ServiceProviders.CLEVERTAP))
+            .build()
+
+        val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
+        val kitIntegrationFactory = KitIntegrationFactory(options)
+        val knownIntegrationsField = KitIntegrationFactory::class.java.getDeclaredField("knownIntegrations")
+        knownIntegrationsField.isAccessible = true
+
+        val withoutFilterIntegration = knownIntegrationsField.get(kitIntegrationFactory) as Map<*, *>
+        val filteredKitIntegrations = knownIntegrationsField.get(filteredKitIntegrationFactory) as Map<*, *>
+
+        val knownKitsSize = withoutFilterIntegration.size
+        val filteredKnownKitsSize = filteredKitIntegrations.size
+        Assert.assertEquals(knownKitsSize - 3, filteredKnownKitsSize)
+        // list of All the kits without Filter
+        Assert.assertNotNull(withoutFilterIntegration[MParticle.ServiceProviders.ADJUST])
+        Assert.assertNotNull(withoutFilterIntegration[MParticle.ServiceProviders.APPBOY])
+        Assert.assertNotNull(withoutFilterIntegration[MParticle.ServiceProviders.CLEVERTAP])
+
+        // Filtered kits; the specified kit should not be present (should be null)
+        Assert.assertNull(filteredKitIntegrations[MParticle.ServiceProviders.ADJUST])
+        Assert.assertNull(filteredKitIntegrations[MParticle.ServiceProviders.APPBOY])
+        Assert.assertNull(filteredKitIntegrations[MParticle.ServiceProviders.CLEVERTAP])
+    }
+
+
+    @Test
+    fun shouldFilterKitsFromKnownIntegrations_When_filter_Is_Empty() {
+        val options = MParticleOptions.builder(MockContext()).build()
+        val filteredKitOptions = MParticleOptions.builder(MockContext())
+            .filteredKits(emptyList())
+            .build()
+
+        val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
+        val kitIntegrationFactory = KitIntegrationFactory(options)
+        val knownIntegrationsField = KitIntegrationFactory::class.java.getDeclaredField("knownIntegrations")
+        knownIntegrationsField.isAccessible = true
+
+        val knownIntegrations = knownIntegrationsField.get(kitIntegrationFactory) as Map<*, *>
+        val filteredKnownIntegrations = knownIntegrationsField.get(filteredKitIntegrationFactory) as Map<*, *>
+
+        val knownKitsSize = knownIntegrations.size
+        val filteredKnownKitsSize = filteredKnownIntegrations.size
+        Assert.assertEquals(knownKitsSize, filteredKnownKitsSize)
+    }
+
+    @Test
+    fun shouldIgnoreUnknownKitInFilter() {
+        val options = MParticleOptions.builder(MockContext()).build()
+        val filteredKitOptions = MParticleOptions.builder(MockContext())
+            .filteredKits(listOf(1231, 132132))
+            .build()
+
+        val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
+        val kitIntegrationFactory = KitIntegrationFactory(options)
+        val knownIntegrationsField = KitIntegrationFactory::class.java.getDeclaredField("knownIntegrations")
+        knownIntegrationsField.isAccessible = true
+
+        val knownIntegrations = knownIntegrationsField.get(kitIntegrationFactory) as Map<*, *>
+        val filteredKnownIntegrations = knownIntegrationsField.get(filteredKitIntegrationFactory) as Map<*, *>
+
+        val knownKitsSize = knownIntegrations.size
+        val filteredKnownKitsSize = filteredKnownIntegrations.size
+        Assert.assertEquals(knownKitsSize, filteredKnownKitsSize)
+    }
+
+    @Test
+    fun shouldRetainUnfilteredKits() {
+        val filteredKitId = MParticle.ServiceProviders.ADJUST
+        val options = MParticleOptions.builder(MockContext())
+            .filteredKits(listOf(filteredKitId))
+            .build()
+
+        val factory = KitIntegrationFactory(options)
+
+        val field = KitIntegrationFactory::class.java.getDeclaredField("knownIntegrations")
+        field.isAccessible = true
+        val knownIntegrations = field.get(factory) as Map<*, *>
+
+        // Verify that a different kit is still present
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.APPBOY])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.URBAN_AIRSHIP])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.TUNE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.KOCHAVA])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.COMSCORE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.FORESEE_ID])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.BRANCH_METRICS])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.FLURRY])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.LOCALYTICS])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.CRITTERCISM])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.WOOTRIC])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.APPSFLYER])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.APPTENTIVE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.APPTIMIZE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.BUTTON])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.LEANPLUM])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.REVEAL_MOBILE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.RADAR])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.ITERABLE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.SKYHOOK])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.SINGULAR])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.ADOBE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.TAPLYTICS])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.OPTIMIZELY])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.RESPONSYS])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.CLEVERTAP])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.ONETRUST])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.GOOGLE_ANALYTICS_FIREBASE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.GOOGLE_ANALYTICS_FIREBASE_GA4])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.PILGRIM])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.SWRVE])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.BLUESHIFT])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.NEURA])
+        Assert.assertNotNull(knownIntegrations[MParticle.ServiceProviders.ROKT])
+    }
+
+    @Test
     @Throws(Exception::class)
     fun testShouldEnableKitOnOptIn() {
         val mockUser = Mockito.mock(MParticleUser::class.java)

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -606,9 +606,9 @@ class KitManagerImplTest {
     fun shouldFilterKitsFromKnownIntegrations() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .filteredKits(listOf(MParticle.ServiceProviders.ADJUST))
-            .filteredKits(listOf(MParticle.ServiceProviders.APPBOY))
-            .filteredKits(listOf(MParticle.ServiceProviders.CLEVERTAP))
+            .disableKits(listOf(MParticle.ServiceProviders.ADJUST))
+            .disableKits(listOf(MParticle.ServiceProviders.APPBOY))
+            .disableKits(listOf(MParticle.ServiceProviders.CLEVERTAP))
             .build()
 
         val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
@@ -637,7 +637,7 @@ class KitManagerImplTest {
     fun shouldFilterKitsFromKnownIntegrations_When_filter_Is_Empty() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .filteredKits(emptyList())
+            .disableKits(emptyList())
             .build()
 
         val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
@@ -657,7 +657,7 @@ class KitManagerImplTest {
     fun shouldIgnoreUnknownKitInFilter() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .filteredKits(listOf(1231, 132132))
+            .disableKits(listOf(1231, 132132))
             .build()
 
         val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
@@ -677,7 +677,7 @@ class KitManagerImplTest {
     fun shouldRetainUnfilteredKits() {
         val filteredKitId = MParticle.ServiceProviders.ADJUST
         val options = MParticleOptions.builder(MockContext())
-            .filteredKits(listOf(filteredKitId))
+            .disableKits(listOf(filteredKitId))
             .build()
 
         val factory = KitIntegrationFactory(options)


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR introduces a new option in MParticleOptions that allows users to disable specific kits. When a kit is disabled, it will not be initialized, and no events will be sent from that kit.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally using a release build and executed the unit test cases.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7219
