### PR TITLE
fix: Add ProGuard rule to preserve method visibility

### DIFF
--- a/android-core/proguard.pro
+++ b/android-core/proguard.pro
@@ -94,6 +94,7 @@
 -keep class com.mparticle.MParticle$UserAttributes { *; }
 -keep class com.mparticle.MParticle$ResetListener { *; }
 -keep class com.mparticle.MParticle$OperatingSystem { *; }
+-keep class com.mparticle.MParticle$Rokt { *; }
 
 
 -keep class com.mparticle.Session { *; }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This commit adds a ProGuard rule to preserve the visibility of specific methods during the release build.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - Tested with local release build with sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
