### PR TITLE
fix: Rename disabled kit method name

### DIFF
--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -487,7 +487,7 @@ public class MParticleOptions {
          * @return
          */
         @NonNull
-        public Builder disableKits(@NonNull List<Integer> kits) {
+        public Builder disabledKits(@NonNull List<Integer> kits) {
             disabledKits.addAll(kits);
             return this;
         }

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -605,7 +605,7 @@ class KitManagerImplTest {
     fun shouldFilterKitsFromKnownIntegrations() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .disableKits(
+            .disabledKits(
                 Arrays.asList(
                     MParticle.ServiceProviders.ADJUST,
                     MParticle.ServiceProviders.APPBOY,
@@ -640,7 +640,7 @@ class KitManagerImplTest {
     fun shouldNotFilterKitsFromKnownIntegrationsWhenFilterIsEmpty() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .disableKits(emptyList())
+            .disabledKits(emptyList())
             .build()
 
         val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
@@ -660,7 +660,7 @@ class KitManagerImplTest {
     fun shouldIgnoreUnknownKitInFilter() {
         val options = MParticleOptions.builder(MockContext()).build()
         val filteredKitOptions = MParticleOptions.builder(MockContext())
-            .disableKits(listOf(1231, 132132))
+            .disabledKits(listOf(1231, 132132))
             .build()
 
         val filteredKitIntegrationFactory = KitIntegrationFactory(filteredKitOptions)
@@ -680,7 +680,7 @@ class KitManagerImplTest {
     fun shouldRetainUnfilteredKits() {
         val filteredKitId = MParticle.ServiceProviders.ADJUST
         val options = MParticleOptions.builder(MockContext())
-            .disableKits(listOf(filteredKitId))
+            .disabledKits(listOf(filteredKitId))
             .build()
 
         val factory = KitIntegrationFactory(options)


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Rename the method from disableKits to disabledKits to match the naming used in iOS.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7219
