### PR TITLE
feat: Add user attributes mapping logic in Rokt execute flow

### DIFF
--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -61,6 +61,7 @@ public class KitConfiguration {
     private final static String KEY_CONSENT_FORWARDING_RULES_VALUE_CONSENTED = "c";
     private final static String KEY_CONSENT_FORWARDING_RULES_VALUE_HASH = "h";
     private final static String KEY_EXCLUDE_ANONYMOUS_USERS = "eau";
+    private final static String KEY_PLACEMENT_ATTRIBUTES = "placementAttributes";
 
     //If set to true, our sdk honor user's optout wish. If false, we still collect data on opt-ed out users, but only for reporting.
     private final static String HONOR_OPT_OUT = "honorOptOut";
@@ -984,6 +985,14 @@ public class KitConfiguration {
             return Boolean.parseBoolean(optOut);
         }
         return true;
+    }
+
+    public JSONArray getPlacementAttributes() throws JSONException {
+        if (!settings.containsKey(KEY_PLACEMENT_ATTRIBUTES)) {
+            return new JSONArray();
+        }
+        String jsonArrayStr = settings.get(KEY_PLACEMENT_ATTRIBUTES);
+        return new JSONArray(jsonArrayStr);
     }
 
     boolean shouldSetIdentity(MParticle.IdentityType identityType) {

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitConfiguration.java
@@ -61,7 +61,7 @@ public class KitConfiguration {
     private final static String KEY_CONSENT_FORWARDING_RULES_VALUE_CONSENTED = "c";
     private final static String KEY_CONSENT_FORWARDING_RULES_VALUE_HASH = "h";
     private final static String KEY_EXCLUDE_ANONYMOUS_USERS = "eau";
-    private final static String KEY_PLACEMENT_ATTRIBUTES = "placementAttributes";
+    private final static String KEY_PLACEMENT_ATTRIBUTES_MAPPING = "placementAttributesMapping";
 
     //If set to true, our sdk honor user's optout wish. If false, we still collect data on opt-ed out users, but only for reporting.
     private final static String HONOR_OPT_OUT = "honorOptOut";
@@ -987,11 +987,11 @@ public class KitConfiguration {
         return true;
     }
 
-    public JSONArray getPlacementAttributes() throws JSONException {
-        if (!settings.containsKey(KEY_PLACEMENT_ATTRIBUTES)) {
+    public JSONArray getPlacementAttributesMapping() throws JSONException {
+        if (!settings.containsKey(KEY_PLACEMENT_ATTRIBUTES_MAPPING)) {
             return new JSONArray();
         }
-        String jsonArrayStr = settings.get(KEY_PLACEMENT_ATTRIBUTES);
+        String jsonArrayStr = settings.get(KEY_PLACEMENT_ATTRIBUTES_MAPPING);
         return new JSONArray(jsonArrayStr);
     }
 

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -1334,18 +1334,23 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
             try {
                 if (provider instanceof KitIntegration.RoktListener && !provider.isDisabled()) {
                     MParticleUser user = MParticle.getInstance().Identity().getCurrentUser();
-
-                    JSONArray jsonArray = provider.getConfiguration().getPlacementAttributes();
-
+                    JSONArray jsonArray = new JSONArray();
+                    KitConfiguration kitConfig = provider.getConfiguration();
+                    if (kitConfig != null) {
+                        try {
+                            jsonArray = kitConfig.getPlacementAttributes();
+                        } catch (JSONException e) {
+                            Logger.warning("Invalid placementAttributes for kit: " + provider.getName() + " JSON: " + e.getMessage());
+                        }
+                    }
                     for (int i = 0; i < jsonArray.length(); i++) {
                         JSONObject obj = jsonArray.optJSONObject(i);
                         if (obj == null) continue;
-
-                        String mapKey = obj.optString("map");
-                        String valueValue = obj.optString("value");
-                        if (attributes.containsKey(mapKey)) {
-                            String value = attributes.remove(mapKey);
-                            attributes.put(valueValue, value);
+                        String mapFrom = obj.optString("map");
+                        String mapTo = obj.optString("value");
+                        if (attributes.containsKey(mapFrom)) {
+                            String value = attributes.remove(mapFrom);
+                            attributes.put(mapTo, value);
                         }
                     }
 

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -1338,7 +1338,7 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
                     KitConfiguration kitConfig = provider.getConfiguration();
                     if (kitConfig != null) {
                         try {
-                            jsonArray = kitConfig.getPlacementAttributes();
+                            jsonArray = kitConfig.getPlacementAttributesMapping();
                         } catch (JSONException e) {
                             Logger.warning("Invalid placementAttributes for kit: " + provider.getName() + " JSON: " + e.getMessage());
                         }
@@ -1353,7 +1353,6 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
                             attributes.put(mapTo, value);
                         }
                     }
-
                     Map<String, Object> objectAttributes = new HashMap<>();
                     for (Map.Entry<String, String> entry : attributes.entrySet()) {
                         objectAttributes.put(entry.getKey(), entry.getValue());

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -1334,12 +1334,25 @@ public class KitManagerImpl implements KitManager, AttributionListener, UserAttr
             try {
                 if (provider instanceof KitIntegration.RoktListener && !provider.isDisabled()) {
                     MParticleUser user = MParticle.getInstance().Identity().getCurrentUser();
-                    Map<String, Object> objectAttributes = new HashMap<>();
 
+                    JSONArray jsonArray = provider.getConfiguration().getPlacementAttributes();
+
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        JSONObject obj = jsonArray.optJSONObject(i);
+                        if (obj == null) continue;
+
+                        String mapKey = obj.optString("map");
+                        String valueValue = obj.optString("value");
+                        if (attributes.containsKey(mapKey)) {
+                            String value = attributes.remove(mapKey);
+                            attributes.put(valueValue, value);
+                        }
+                    }
+
+                    Map<String, Object> objectAttributes = new HashMap<>();
                     for (Map.Entry<String, String> entry : attributes.entrySet()) {
                         objectAttributes.put(entry.getKey(), entry.getValue());
                     }
-
                     user.setUserAttributes(objectAttributes);
                     ((KitIntegration.RoktListener) provider).execute(viewName,
                             attributes,

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -29,9 +29,9 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import java.lang.ref.WeakReference
 import java.util.Arrays
 import java.util.LinkedList
-import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
 
 class KitManagerImplTest {
@@ -779,17 +779,17 @@ class KitManagerImplTest {
 
         val configJSONObj = JSONObject().apply {
             put("id", kitId)
-      }
+        }
         val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
-        val settingsMap =  hashMapOf(
-        "placementAttributes" to """
+        val settingsMap = hashMapOf(
+            "placementAttributes" to """
         [
             {"map": "number", "value": "no"},
             {"map": "customerId", "value": "minorcatid"}
         ]
-    """.trimIndent()
+            """.trimIndent()
         )
         val field = KitConfiguration::class.java.getDeclaredField("settings")
         field.isAccessible = true
@@ -824,8 +824,9 @@ class KitManagerImplTest {
             Pair("lastname", "Test1"),
             Pair("number", "(123) 456-9898"),
             Pair("customerId", "55555"),
-            Pair("country", "US"))
-        manager.execute("Test",attributes,null,null,null,null,null,null)
+            Pair("country", "US")
+        )
+        manager.execute("Test", attributes, null, null, null, null, null, null)
         Assert.assertEquals(5, attributes.size)
         Assert.assertEquals("(123) 456-9898", attributes["no"])
         Assert.assertEquals("55555", attributes["minorcatid"])
@@ -845,13 +846,13 @@ class KitManagerImplTest {
         val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
-        val settingsMap =  hashMapOf(
+        val settingsMap = hashMapOf(
             "placementAttributes" to """
         [
               {"map": "number", "value": "no"},
             {"map": "customerId", "value": "minorcatid"}
         ]
-    """.trimIndent()
+            """.trimIndent()
         )
         val field = KitConfiguration::class.java.getDeclaredField("settings")
         field.isAccessible = true
@@ -886,8 +887,9 @@ class KitManagerImplTest {
             Pair("lastname", "Test1"),
             Pair("call", "(123) 456-9898"),
             Pair("postal", "5-45555"),
-            Pair("country", "US"))
-        manager.execute("Test",attributes,null,null,null,null,null,null)
+            Pair("country", "US")
+        )
+        manager.execute("Test", attributes, null, null, null, null, null, null)
         Assert.assertEquals(5, attributes.size)
         Assert.assertEquals("(123) 456-9898", attributes["call"])
         Assert.assertEquals("5-45555", attributes["postal"])
@@ -907,13 +909,13 @@ class KitManagerImplTest {
         val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
-        val settingsMap =  hashMapOf(
+        val settingsMap = hashMapOf(
             "placementAttributes" to """
         [
               {"map": "number", "value": "no"},
             {"map": "customerId", "value": "minorcatid"}
         ]
-    """.trimIndent()
+            """.trimIndent()
         )
         val field = KitConfiguration::class.java.getDeclaredField("settings")
         field.isAccessible = true
@@ -948,8 +950,9 @@ class KitManagerImplTest {
             Pair("lastname", "Test1"),
             Pair("no", "(123) 456-9898"),
             Pair("minorcatid", "5-45555"),
-            Pair("country", "US"))
-        manager.execute("Test",attributes,null,null,null,null,null,null)
+            Pair("country", "US")
+        )
+        manager.execute("Test", attributes, null, null, null, null, null, null)
         Assert.assertEquals(5, attributes.size)
         Assert.assertEquals("(123) 456-9898", attributes["no"])
         Assert.assertEquals("5-45555", attributes["minorcatid"])
@@ -969,12 +972,12 @@ class KitManagerImplTest {
         val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
-        val settingsMap =  hashMapOf(
+        val settingsMap = hashMapOf(
             "placementAttributes" to """
         [
            
         ]
-    """.trimIndent()
+            """.trimIndent()
         )
         val field = KitConfiguration::class.java.getDeclaredField("settings")
         field.isAccessible = true
@@ -1009,8 +1012,9 @@ class KitManagerImplTest {
             Pair("lastname", "Test1"),
             Pair("number", "(123) 456-9898"),
             Pair("customerId", "55555"),
-            Pair("country", "US"))
-        manager.execute("Test",attributes,null,null,null,null,null,null)
+            Pair("country", "US")
+        )
+        manager.execute("Test", attributes, null, null, null, null, null, null)
         Assert.assertEquals(5, attributes.size)
         Assert.assertEquals("(123) 456-9898", attributes["number"])
         Assert.assertEquals("55555", attributes["customerId"])
@@ -1020,7 +1024,7 @@ class KitManagerImplTest {
     }
 
     internal inner class mockProvider(val config: KitConfiguration) : KitIntegration(), KitIntegration.RoktListener {
-       override fun isDisabled(): Boolean = false
+        override fun isDisabled(): Boolean = false
         override fun getName(): String = "FakeProvider"
         override fun onKitCreate(settings: MutableMap<String, String>?, context: Context?): MutableList<ReportingMessage> {
             TODO("Not yet implemented")
@@ -1029,7 +1033,6 @@ class KitManagerImplTest {
         override fun setOptOut(optedOut: Boolean): MutableList<ReportingMessage> {
             TODO("Not yet implemented")
         }
-
 
         override fun getConfiguration(): KitConfiguration {
             return config

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -1,5 +1,7 @@
 package com.mparticle.kits
 
+import android.content.Context
+import android.graphics.Typeface
 import com.mparticle.BaseEvent
 import com.mparticle.MPEvent
 import com.mparticle.MParticle
@@ -17,6 +19,7 @@ import com.mparticle.mock.MockContext
 import com.mparticle.mock.MockKitConfiguration
 import com.mparticle.mock.MockKitManagerImpl
 import com.mparticle.mock.MockMParticle
+import com.mparticle.rokt.RoktEmbeddedView
 import com.mparticle.testutils.TestingUtils
 import junit.framework.TestCase
 import org.json.JSONArray
@@ -28,6 +31,8 @@ import org.junit.Test
 import org.mockito.Mockito
 import java.util.Arrays
 import java.util.LinkedList
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
 
 class KitManagerImplTest {
     var mparticle: MParticle? = null
@@ -767,6 +772,283 @@ class KitManagerImplTest {
         Assert.assertEquals(2, manager.providers.size)
     }
 
+    @Test
+    fun testRokt_non_standard_partner_user_attrs() {
+        val sideloadedKit = Mockito.mock(MPSideloadedKit::class.java)
+        val kitId = 6000000
+
+        val configJSONObj = JSONObject().apply {
+            put("id", kitId)
+      }
+        val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
+        Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
+
+        val settingsMap =  hashMapOf(
+        "placementAttributes" to """
+        [
+            {"map": "number", "value": "no"},
+            {"map": "customerId", "value": "minorcatid"}
+        ]
+    """.trimIndent()
+        )
+        val field = KitConfiguration::class.java.getDeclaredField("settings")
+        field.isAccessible = true
+        field.set(mockedKitConfig, settingsMap)
+
+        val mockedProvider = mockProvider(mockedKitConfig)
+
+        val options = MParticleOptions.builder(MockContext())
+            .sideloadedKits(mutableListOf(sideloadedKit) as List<SideloadedKit>).build()
+        val manager: KitManagerImpl = MockKitManagerImpl(options)
+        val factory = Mockito.mock(KitIntegrationFactory::class.java)
+        manager.setKitFactory(factory)
+
+        Mockito.`when`(factory.isSupported(Mockito.anyInt())).thenReturn(true)
+        val supportedKit = mutableSetOf(kitId)
+        Mockito.`when`(manager.supportedKits).thenReturn(supportedKit)
+        Mockito.`when`(sideloadedKit.isDisabled).thenReturn(false)
+        Mockito.`when`(
+            factory.createInstance(
+                Mockito.any(
+                    KitManagerImpl::class.java
+                ),
+                Mockito.any(KitConfiguration::class.java)
+            )
+        ).thenReturn(sideloadedKit)
+        manager.providers = ConcurrentHashMap<Int, KitIntegration>().apply {
+            put(42, mockedProvider)
+        }
+
+        val attributes = hashMapOf(
+            Pair("test", "Test"),
+            Pair("lastname", "Test1"),
+            Pair("number", "(123) 456-9898"),
+            Pair("customerId", "55555"),
+            Pair("country", "US"))
+        manager.execute("Test",attributes,null,null,null,null,null,null)
+        Assert.assertEquals(5, attributes.size)
+        Assert.assertEquals("(123) 456-9898", attributes["no"])
+        Assert.assertEquals("55555", attributes["minorcatid"])
+        Assert.assertEquals("Test1", attributes["lastname"])
+        Assert.assertEquals("Test", attributes["test"])
+        Assert.assertEquals("US", attributes["country"])
+    }
+
+    @Test
+    fun testExecute_shouldNotModifyAttributes_ifMappedKeysDoNotExist() {
+        val sideloadedKit = Mockito.mock(MPSideloadedKit::class.java)
+        val kitId = 6000000
+
+        val configJSONObj = JSONObject().apply {
+            put("id", kitId)
+        }
+        val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
+        Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
+
+        val settingsMap =  hashMapOf(
+            "placementAttributes" to """
+        [
+              {"map": "number", "value": "no"},
+            {"map": "customerId", "value": "minorcatid"}
+        ]
+    """.trimIndent()
+        )
+        val field = KitConfiguration::class.java.getDeclaredField("settings")
+        field.isAccessible = true
+        field.set(mockedKitConfig, settingsMap)
+
+        val mockedProvider = mockProvider(mockedKitConfig)
+
+        val options = MParticleOptions.builder(MockContext())
+            .sideloadedKits(mutableListOf(sideloadedKit) as List<SideloadedKit>).build()
+        val manager: KitManagerImpl = MockKitManagerImpl(options)
+        val factory = Mockito.mock(KitIntegrationFactory::class.java)
+        manager.setKitFactory(factory)
+
+        Mockito.`when`(factory.isSupported(Mockito.anyInt())).thenReturn(true)
+        val supportedKit = mutableSetOf(kitId)
+        Mockito.`when`(manager.supportedKits).thenReturn(supportedKit)
+        Mockito.`when`(sideloadedKit.isDisabled).thenReturn(false)
+        Mockito.`when`(
+            factory.createInstance(
+                Mockito.any(
+                    KitManagerImpl::class.java
+                ),
+                Mockito.any(KitConfiguration::class.java)
+            )
+        ).thenReturn(sideloadedKit)
+        manager.providers = ConcurrentHashMap<Int, KitIntegration>().apply {
+            put(42, mockedProvider)
+        }
+
+        val attributes = hashMapOf(
+            Pair("test", "Test"),
+            Pair("lastname", "Test1"),
+            Pair("call", "(123) 456-9898"),
+            Pair("postal", "5-45555"),
+            Pair("country", "US"))
+        manager.execute("Test",attributes,null,null,null,null,null,null)
+        Assert.assertEquals(5, attributes.size)
+        Assert.assertEquals("(123) 456-9898", attributes["call"])
+        Assert.assertEquals("5-45555", attributes["postal"])
+        Assert.assertEquals("Test1", attributes["lastname"])
+        Assert.assertEquals("Test", attributes["test"])
+        Assert.assertEquals("US", attributes["country"])
+    }
+
+    @Test
+    fun testExecute_shouldNotModifyAttributes_ifMapAndValueKeysAreSame() {
+        val sideloadedKit = Mockito.mock(MPSideloadedKit::class.java)
+        val kitId = 6000000
+
+        val configJSONObj = JSONObject().apply {
+            put("id", kitId)
+        }
+        val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
+        Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
+
+        val settingsMap =  hashMapOf(
+            "placementAttributes" to """
+        [
+              {"map": "number", "value": "no"},
+            {"map": "customerId", "value": "minorcatid"}
+        ]
+    """.trimIndent()
+        )
+        val field = KitConfiguration::class.java.getDeclaredField("settings")
+        field.isAccessible = true
+        field.set(mockedKitConfig, settingsMap)
+
+        val mockedProvider = mockProvider(mockedKitConfig)
+
+        val options = MParticleOptions.builder(MockContext())
+            .sideloadedKits(mutableListOf(sideloadedKit) as List<SideloadedKit>).build()
+        val manager: KitManagerImpl = MockKitManagerImpl(options)
+        val factory = Mockito.mock(KitIntegrationFactory::class.java)
+        manager.setKitFactory(factory)
+
+        Mockito.`when`(factory.isSupported(Mockito.anyInt())).thenReturn(true)
+        val supportedKit = mutableSetOf(kitId)
+        Mockito.`when`(manager.supportedKits).thenReturn(supportedKit)
+        Mockito.`when`(sideloadedKit.isDisabled).thenReturn(false)
+        Mockito.`when`(
+            factory.createInstance(
+                Mockito.any(
+                    KitManagerImpl::class.java
+                ),
+                Mockito.any(KitConfiguration::class.java)
+            )
+        ).thenReturn(sideloadedKit)
+        manager.providers = ConcurrentHashMap<Int, KitIntegration>().apply {
+            put(42, mockedProvider)
+        }
+
+        val attributes = hashMapOf(
+            Pair("test", "Test"),
+            Pair("lastname", "Test1"),
+            Pair("no", "(123) 456-9898"),
+            Pair("minorcatid", "5-45555"),
+            Pair("country", "US"))
+        manager.execute("Test",attributes,null,null,null,null,null,null)
+        Assert.assertEquals(5, attributes.size)
+        Assert.assertEquals("(123) 456-9898", attributes["no"])
+        Assert.assertEquals("5-45555", attributes["minorcatid"])
+        Assert.assertEquals("Test1", attributes["lastname"])
+        Assert.assertEquals("Test", attributes["test"])
+        Assert.assertEquals("US", attributes["country"])
+    }
+
+    @Test
+    fun testRokt_non_standard_partner_user_attrs_When_placementAttributes_is_empty() {
+        val sideloadedKit = Mockito.mock(MPSideloadedKit::class.java)
+        val kitId = 6000000
+
+        val configJSONObj = JSONObject().apply {
+            put("id", kitId)
+        }
+        val mockedKitConfig = KitConfiguration.createKitConfiguration(configJSONObj)
+        Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
+
+        val settingsMap =  hashMapOf(
+            "placementAttributes" to """
+        [
+           
+        ]
+    """.trimIndent()
+        )
+        val field = KitConfiguration::class.java.getDeclaredField("settings")
+        field.isAccessible = true
+        field.set(mockedKitConfig, settingsMap)
+
+        val mockedProvider = mockProvider(mockedKitConfig)
+
+        val options = MParticleOptions.builder(MockContext())
+            .sideloadedKits(mutableListOf(sideloadedKit) as List<SideloadedKit>).build()
+        val manager: KitManagerImpl = MockKitManagerImpl(options)
+        val factory = Mockito.mock(KitIntegrationFactory::class.java)
+        manager.setKitFactory(factory)
+
+        Mockito.`when`(factory.isSupported(Mockito.anyInt())).thenReturn(true)
+        val supportedKit = mutableSetOf(kitId)
+        Mockito.`when`(manager.supportedKits).thenReturn(supportedKit)
+        Mockito.`when`(sideloadedKit.isDisabled).thenReturn(false)
+        Mockito.`when`(
+            factory.createInstance(
+                Mockito.any(
+                    KitManagerImpl::class.java
+                ),
+                Mockito.any(KitConfiguration::class.java)
+            )
+        ).thenReturn(sideloadedKit)
+        manager.providers = ConcurrentHashMap<Int, KitIntegration>().apply {
+            put(42, mockedProvider)
+        }
+
+        val attributes = hashMapOf(
+            Pair("test", "Test"),
+            Pair("lastname", "Test1"),
+            Pair("number", "(123) 456-9898"),
+            Pair("customerId", "55555"),
+            Pair("country", "US"))
+        manager.execute("Test",attributes,null,null,null,null,null,null)
+        Assert.assertEquals(5, attributes.size)
+        Assert.assertEquals("(123) 456-9898", attributes["number"])
+        Assert.assertEquals("55555", attributes["customerId"])
+        Assert.assertEquals("Test1", attributes["lastname"])
+        Assert.assertEquals("Test", attributes["test"])
+        Assert.assertEquals("US", attributes["country"])
+    }
+
+    internal inner class mockProvider(val config: KitConfiguration) : KitIntegration(), KitIntegration.RoktListener {
+       override fun isDisabled(): Boolean = false
+        override fun getName(): String = "FakeProvider"
+        override fun onKitCreate(settings: MutableMap<String, String>?, context: Context?): MutableList<ReportingMessage> {
+            TODO("Not yet implemented")
+        }
+
+        override fun setOptOut(optedOut: Boolean): MutableList<ReportingMessage> {
+            TODO("Not yet implemented")
+        }
+
+
+        override fun getConfiguration(): KitConfiguration {
+            return config
+        }
+
+        override fun execute(
+            viewName: String?,
+            attributes: MutableMap<String, String>?,
+            onUnload: Runnable?,
+            onLoad: Runnable?,
+            onShouldHideLoadingIndicator: Runnable?,
+            onShouldShowLoadingIndicator: Runnable?,
+            placeHolders: MutableMap<String, WeakReference<RoktEmbeddedView>>?,
+            fontTypefaces: MutableMap<String, WeakReference<Typeface>>?,
+            user: FilteredMParticleUser?
+        ) {
+            println("Executed with $attributes")
+        }
+    }
     internal inner class KitManagerEventCounter : MockKitManagerImpl() {
         var logBaseEventCalled = 0
         var logCommerceEventCalled = 0

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -784,7 +784,7 @@ class KitManagerImplTest {
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
         val settingsMap = hashMapOf(
-            "placementAttributes" to """
+            "placementAttributesMapping" to """
         [
             {"map": "number", "value": "no"},
             {"map": "customerId", "value": "minorcatid"}
@@ -847,7 +847,7 @@ class KitManagerImplTest {
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
         val settingsMap = hashMapOf(
-            "placementAttributes" to """
+            "placementAttributesMapping" to """
         [
               {"map": "number", "value": "no"},
             {"map": "customerId", "value": "minorcatid"}
@@ -910,7 +910,7 @@ class KitManagerImplTest {
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
         val settingsMap = hashMapOf(
-            "placementAttributes" to """
+            "placementAttributesMapping" to """
         [
               {"map": "number", "value": "no"},
             {"map": "customerId", "value": "minorcatid"}
@@ -973,7 +973,7 @@ class KitManagerImplTest {
         Mockito.`when`(sideloadedKit.configuration).thenReturn(mockedKitConfig)
 
         val settingsMap = hashMapOf(
-            "placementAttributes" to """
+            "placementAttributesMapping" to """
         [
            
         ]


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Implement user attribute transformation based on placement mapping in Rokt execute

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested With sample app and Executed unit test cases

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7185
