### PR TITLE
fix: Removes `messageQueue` since produces memory leaks

### DIFF
--- a/android-core/src/main/java/com/mparticle/internal/BaseHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/BaseHandler.java
@@ -13,11 +13,6 @@ import java.util.concurrent.CountDownLatch;
 public class BaseHandler extends Handler {
     private volatile boolean disabled;
     private volatile boolean handling;
-    private ConcurrentHashMap<Message, Boolean> messageQueue = new ConcurrentHashMap();
-
-    public Set<Message> getMessageQueue() {
-        return messageQueue.keySet();
-    }
 
     public BaseHandler() {
     }
@@ -50,9 +45,6 @@ public class BaseHandler extends Handler {
         }
         handling = true;
         try {
-            if (msg != null) {
-                messageQueue.remove(msg);
-            }
             if (msg != null && msg.what == -1 && msg.obj instanceof CountDownLatch) {
                 ((CountDownLatch) msg.obj).countDown();
             } else {
@@ -78,20 +70,7 @@ public class BaseHandler extends Handler {
         if (InternalListenerManager.isEnabled()) {
             InternalListenerManager.getListener().onThreadMessage(getClass().getName(), msg, false);
         }
-        if (msg != null) {
-            messageQueue.put(msg, true);
-        }
         return super.sendMessageAtTime(msg, uptimeMillis);
-    }
-
-    public void removeMessage(int what) {
-        Set<Message> messages = messageQueue.keySet();
-        for (Message message : messages) {
-            if (message.what == what) {
-                messageQueue.remove(message);
-            }
-        }
-        super.removeMessages(what);
     }
 
     //Override this in order to handle messages

--- a/testutils/src/main/java/com/mparticle/AccessUtils.java
+++ b/testutils/src/main/java/com/mparticle/AccessUtils.java
@@ -19,20 +19,6 @@ public class AccessUtils {
         MParticle.reset(context, deleteDatabase, switchingWorkspaces);
     }
 
-    /**
-     * This is a way less than ideal implementation, but I think the insight is very important.
-     *
-     * This method returns an ordered list of the pending Messages in the UploadHandler queue. This
-     * gives us the ability to test the UploadHandler's true "state" when looking closely at how
-     * our Upload loop is performing
-     *
-     * @return
-     */
-    @RequiresApi(api = Build.VERSION_CODES.M)
-    public static Set<Message> getUploadHandlerMessageQueue() {
-        return getMessageManager().mUploadHandler.getMessageQueue();
-    }
-
     public static MessageManager getMessageManager() {
         return MParticle.getInstance().mMessageManager;
     }


### PR DESCRIPTION
 ## Summary
 Removes the (unnecessary?) `private ConcurrentHashMap<Message, Boolean> messageQueue` field and all its associated logic in `BaseHandler`, since it was identified by us (with LeakCanary) as the root cause of memory leaks when using `DialogFragment`.
 
 After inspecting the whole code, that logic is a NO-OP since it's only used by `AccessUtils.getUploadHandlerMessageQueue()`, a method that is not getting called anywhere, probably a legacy code.
 
 The leak is produced when a `sendMessageAtTime` method is invoked by AndroidX `DialogFragment`'s internal logic. Since this specialized version of `Handler` stores `Message`s in a map, the whole tree is retained, producing the leak.
 
 Unless we have missed something, `messageQueue` is not adding any value, therefore, there is no point in keeping it.
 
 ### LeakCanary report
 ```
 ┬───
│ GC Root: Thread object
│
├─ Ik instance
│    Leaking: NO (PathClassLoader↓ is not leaking)
│    Thread name: 'CleanupReference'
│    ↓ Thread.contextClassLoader
├─ dalvik.system.PathClassLoader instance
│    Leaking: NO (MParticle↓ is not leaking and A ClassLoader is never leaking)
│    ↓ ClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    Leaking: NO (MParticle↓ is not leaking)
│    ↓ Object[733]
├─ com.mparticle.MParticle class
│    Leaking: NO (a class is never leaking)
│    ↓ static MParticle.instance
│                       ~~~~~~~~
├─ com.mparticle.MParticle instance
│    Leaking: UNKNOWN
│    Retaining 129 B in 5 objects
│    mAppContext instance of com.glovoapp.HiltUiTestApp_Application
│    ↓ MParticle.mIdentityApi
│                ~~~~~~~~~~~~
├─ com.mparticle.identity.IdentityApi instance
│    Leaking: UNKNOWN
│    Retaining 16.7 kB in 577 objects
│    mContext instance of com.glovoapp.HiltUiTestApp_Application
│    ↓ IdentityApi.mMainHandler
│                  ~~~~~~~~~~~~
├─ com.mparticle.b instance
│    Leaking: UNKNOWN
│    Retaining 2.7 kB in 91 objects
│    ↓ b.c
│        ~
├─ java.util.concurrent.ConcurrentHashMap instance
│    Leaking: UNKNOWN
│    Retaining 2.7 kB in 90 objects
│    ↓ ConcurrentHashMap[key()]
│                       ~~~~~~~
├─ android.os.Message instance
│    Leaking: UNKNOWN
│    Retaining 2.5 kB in 87 objects
│    Message.what = 68
│    Message.when = 0 (6963473 ms before heap dump)
│    Message.obj = instance @322539720 of androidx.fragment.app.DialogFragment$2
│    Message.callback = null
│    Message.target = instance @322539736 of android.app.Dialog$ListenersHandler
│    ↓ Message.obj
│              ~~~
├─ androidx.fragment.app.DialogFragment$2 instance
│    Leaking: UNKNOWN
│    Retaining 2.4 kB in 84 objects
│    Anonymous class implementing android.content.DialogInterface$OnCancelListener
│    ↓ DialogFragment$2.this$0
│                       ~~~~~~
╰→ com.glovoapp.dialogs.OverlayProgressDialog instance
​     Leaking: YES (ObjectWatcher was watching this because com.glovoapp.dialogs.OverlayProgressDialog received Fragment#onDestroy() callback. Conflicts with Fragment.mLifecycleRegistry.state is INITIALIZED)
​     Retaining 2.4 kB in 83 objects
​     key = b09aba74-9150-412d-ab65-e56f4cd0efee
​     watchDurationMillis = 121257
​     retainedDurationMillis = 116245

522156 bytes retained by leaking objects
Signature: 05465ea5398979c4969c38a4a281600e9ab2b643
```

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Ran `./gradlew build` locally and it has been successful. 

