### PR TITLE
fix: Include missing overridesSubdirectory flag in networkOptions for domain mapping

### DIFF
--- a/android-core/src/main/java/com/mparticle/networking/DomainMapping.java
+++ b/android-core/src/main/java/com/mparticle/networking/DomainMapping.java
@@ -226,6 +226,7 @@ public class DomainMapping {
             return new JSONObject()
                     .put("mType", mType.value)
                     .put("url", mUrl)
+                    .put("overridesSubdirectory",overridesSubdirectory)
                     .put("mCertificates", certificatesJson);
         } catch (JSONException jse) {
             Logger.error(jse);
@@ -325,7 +326,8 @@ public class DomainMapping {
                 JSONObject jsonObject = new JSONObject(jsonString);
                 int type = jsonObject.getInt("mType");
                 String newUrl = jsonObject.getString("url");
-                Builder builder = new Builder(Endpoint.parseInt(type), newUrl);
+                boolean overridesSubdirectory = jsonObject.getBoolean("overridesSubdirectory");
+                Builder builder = new Builder(Endpoint.parseInt(type), newUrl, overridesSubdirectory);
                 JSONArray certificatesJsonArray = jsonObject.getJSONArray("mCertificates");
                 for (int i = 0; i < certificatesJsonArray.length(); i++) {
                     builder.addCertificate(Certificate.withCertificate(certificatesJsonArray.getJSONObject(i)));


### PR DESCRIPTION

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR fixes an issue related to domain mapping.
When we implemented workspace switching, we added an "uploaded settings" option under networkOptions. However, the overridesSubdirectory field was missing from the networkOptions JSON, so it always defaulted to false.
As a result, when domain mapping required overridesSubdirectory to be true, it caused issues. This PR adds that missing field to prevent those problems.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7377
