### PR TITLE
fix: Restore ProGuard rules to preserve Rokt class members

### DIFF
--- a/android-core/proguard.pro
+++ b/android-core/proguard.pro
@@ -208,11 +208,21 @@
 -keep class com.mparticle.rokt.RoktLayoutDimensionCallBack { *; }
 -keep class com.mparticle.rokt.RoktOptions { *; }
 
+# Preserve annotation classes
+-keep class androidx.annotation.NonNull { *; }
+-keep class androidx.annotation.Nullable { *; }
+-keepclassmembers class com.mparticle.** {
+    @androidx.annotation.NonNull *;
+    @androidx.annotation.Nullable *;
+}
+
 # Preserve all method signatures in the Rokt class to prevent overload resolution issues
 -keepclassmembers class com.mparticle.Rokt {
-    public void selectPlacements(...);
-    public void purchaseFinalized(...);
+    *;
 }
+-keepclassmembers class com.mparticle.KitIntegration$RoktListener* {
+     *;
+ }
 -keep public class com.mparticle.audience.* {
     *;
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- `events` API from Rokt class was getting removed by proguard. Keep the class members and annotations for kotlin metadata

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verified the local release snapshot aar file 
<img width="853" alt="Screenshot 2025-06-24 at 10 35 49 am" src="https://github.com/user-attachments/assets/7a9558b4-6aa5-49b9-9af7-63633d4f0c4e" />

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
