### PR TITLE
chore: Update kit plugin publishing URL from OSSRH to CPP

### DIFF
--- a/kit-plugin/src/main/groovy/com/mparticle/kits/KitPlugin.groovy
+++ b/kit-plugin/src/main/groovy/com/mparticle/kits/KitPlugin.groovy
@@ -136,7 +136,7 @@ class KitPlugin implements Plugin<Project> {
                     username System.getenv('sonatypeUsername') ?: ""
                     password System.getenv('sonatypePassword') ?: ""
                 }
-                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                url = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
             }
 
             def signingKey = System.getenv("mavenSigningKeyId")


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR migrates our artifact publishing workflow from OSSRH (The Open Source Software Repository Hosting) to the new Central Publishing Portal (CPP) as per the updated guidelines from Sonatype.
Guideline : https://central.sonatype.org/news/20250326_ossrh_sunset/

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7479
