### PR TITLE
fix: Print domain mapping logs only once per session

### DIFF
--- a/android-core/src/main/java/com/mparticle/networking/NetworkOptions.java
+++ b/android-core/src/main/java/com/mparticle/networking/NetworkOptions.java
@@ -20,12 +20,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 public class NetworkOptions {
 
     Map<Endpoint, DomainMapping> domainMappings = new HashMap<Endpoint, DomainMapping>();
     boolean pinningDisabledInDevelopment = false;
     boolean pinningDisabled = false;
+    private static Set<Endpoint> loggedDomainTypes = new HashSet<>();
 
     private NetworkOptions() {
     }
@@ -144,10 +147,13 @@ public class NetworkOptions {
                 domainMappings = new HashMap<Endpoint, DomainMapping>();
             }
             if (domainMappings.containsKey(domain.getType())) {
-                try {
-                    Logger.warning("Duplicate DomainMapping submitted, DomainMapping:\n" + domain.toJson().toString(4) + "\n will overwrite DomainMapping:\n" + domain.toJson().toString(4));
-                } catch (JSONException e) {
-                    e.printStackTrace();
+                if (!loggedDomainTypes.contains(domain.getType())) {
+                    try {
+                        Logger.warning("Duplicate DomainMapping submitted, DomainMapping:\n" + domain.toJson().toString(4) + "\n will overwrite DomainMapping:\n" + domain.toJson().toString(4));
+                        loggedDomainTypes.add(domain.getType());
+                    } catch (JSONException e) {
+                        e.printStackTrace();
+                    }
                 }
             }
             if (domain.getType() == EVENTS && !domain.isEventsOnly() && !domainMappings.containsKey(ALIAS)) {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Before, NetworkConfigure was called only once in a session. But after adding workspace switching, it started calling NetworkConfigure for every upload. Because of that, the domain mapping logs were printed many times in the same session.
To fix this, I added a HashSet to make sure the domain mapping logs print only once per session.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7554
