### PR TITLE
fix: Support mutable and immutable attributes in selectPlacement

### DIFF
--- a/android-core/src/main/kotlin/com/mparticle/Rokt.kt
+++ b/android-core/src/main/kotlin/com/mparticle/Rokt.kt
@@ -26,7 +26,7 @@ class Rokt internal constructor(
         config: RoktConfig? = null
     ) {
         if (mConfigManager.isEnabled) {
-            mKitManager.execute(identifier, attributes, callbacks, embeddedViews, fontTypefaces, config)
+            mKitManager.execute(identifier, HashMap(attributes), callbacks, embeddedViews, fontTypefaces, config)
         }
     }
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Previously, selectPlacement assumed attributes were always mutable. When an immutable map was passed, it caused issues if modifications were required during processing.Created a shallow copy of attributes before passing it to execute.This ensures compatibility with both immutable and mutable inputs.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample app for both immutable and mutable inputs.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
