### PR TITLE
Update AGP 8.7,3, Gradle 8.9, and Braze 41.1.1

### DIFF
--- a/kits/braze/braze-41/build.gradle
+++ b/kits/braze/braze-41/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath 'com.mparticle:android-kit-plugin:' + project.version
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -67,6 +67,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.braze:android-sdk-ui:41.0.0'
+    api 'com.braze:android-sdk-ui:41.1.1'
     testImplementation  files('libs/java-json.jar')
 }

--- a/kits/braze/braze-41/gradle/wrapper/gradle-wrapper.properties
+++ b/kits/braze/braze-41/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
In my testing, Braze 41 was not sending events when using the example app. This requires upgrading AGP from 8.1.4 to 8.7.3 and Gradle from 8.0.2 to 8.9 because Braze 41 depends on androidx.datastore 1.1.x (a Kotlin Multiplatform library) which needs AGP 8.6+ for correct Android variant resolution.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- {Any additional information or context relevant to this PR}

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
