### PR TITLE
fix: increase MPLatch timeout from 5s to 30s

### DIFF
--- a/android-core/src/androidTest/java/com/mparticle/internal/MParticleJSInterfaceITest.java
+++ b/android-core/src/androidTest/java/com/mparticle/internal/MParticleJSInterfaceITest.java
@@ -33,6 +33,8 @@ import com.mparticle.testutils.AndroidUtils;
 import com.mparticle.testutils.BaseCleanStartedEachTest;
 import com.mparticle.testutils.BuildConfig;
 import com.mparticle.testutils.MPLatch;
+
+import java.util.concurrent.TimeUnit;
 import com.mparticle.testutils.RandomUtils;
 
 import org.json.JSONArray;
@@ -68,6 +70,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
     private static boolean sdkFetchedSuccessfully = false;
     private static String bridgeToken = new RandomUtils().getAlphaString(5);
     private static String bridgeVersion = "2";
+    private static final int WEBVIEW_TIMEOUT_SECONDS = 30;
 
     private static final String jsStartupMParticle = "window.mParticle = {\n" +
             "            config: {\n" +
@@ -238,7 +241,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
 
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -263,7 +266,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 }
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -304,7 +307,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 }
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -361,7 +364,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 }
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -443,7 +446,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
             }
         });
         assertNull(error.value);
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -470,7 +473,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 }
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -496,7 +499,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 latch.countDown();
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -522,7 +525,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 }
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -548,7 +551,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 latch.countDown();
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 
@@ -574,7 +577,7 @@ public class MParticleJSInterfaceITest extends BaseCleanStartedEachTest {
                 }
             }
         });
-        latch.await();
+        latch.await(WEBVIEW_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(called.value);
     }
 

--- a/testutils/src/main/java/com/mparticle/testutils/MPLatch.java
+++ b/testutils/src/main/java/com/mparticle/testutils/MPLatch.java
@@ -49,7 +49,7 @@ public class MPLatch extends CountDownLatch {
 
     @Override
     public void await() throws InterruptedException {
-        int timeoutTimeMs = 30 * 1000;
+        int timeoutTimeMs = 5 * 1000;
         synchronized (this) {
             if (count == countDowned) {
                 return;

--- a/testutils/src/main/java/com/mparticle/testutils/MPLatch.java
+++ b/testutils/src/main/java/com/mparticle/testutils/MPLatch.java
@@ -49,7 +49,7 @@ public class MPLatch extends CountDownLatch {
 
     @Override
     public void await() throws InterruptedException {
-        int timeoutTimeMs = 5 * 1000;
+        int timeoutTimeMs = 30 * 1000;
         synchronized (this) {
             if (count == countDowned) {
                 return;


### PR DESCRIPTION
## Summary
- Increases the `MPLatch` await timeout from 5 seconds to 30 seconds
- The 5-second timeout is too short for `MParticleJSInterfaceITest` WebView JS bridge tests running on newer GitHub Actions runner images (`ubuntu24/20260309.50`+)
- Tests started consistently failing on **March 12, 2026** when the runner image updated — no code changes in either the web SDK or Android SDK caused the regression
- The workflow-level `timeout-minutes: 15` still guards against genuine hangs

## Context
The `MParticleJSInterfaceITest` tests in `mparticle-web-sdk`'s [Android Bridge Tests workflow](https://github.com/mParticle/mparticle-web-sdk/actions/workflows/android-bridge-tests.yml) have been failing since the GitHub Actions runner image updated from `ubuntu24/20260302.42` to `ubuntu24/20260309.50`. We verified:
- Same web SDK code (byte-for-byte identical `mparticle.js`) passes on old runner, fails on new
- Same Android SDK commit (`892a7783`) in both passing and failing runs
- Downgrading platform-tools to 36.0.2 does **not** fix it
- Bumping emulator API level from 29 to 34 reduces failures (1/10 vs 2+/10) but doesn't eliminate them
- The root cause is environmental changes in the runner image that slow WebView/JS initialization beyond the 5-second latch timeout

## Test plan
- [ ] Verify `MParticleJSInterfaceITest` passes in Android SDK CI
- [ ] After merge, verify [Android Bridge Tests](https://github.com/mParticle/mparticle-web-sdk/actions/workflows/android-bridge-tests.yml) in `mparticle-web-sdk` pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)