### PR TITLE
ci: generate CHANGELOG on release draft

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -63,6 +63,16 @@ jobs:
       - name: Publish to Maven local (smoke test)
         run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ steps.bump-version.outputs.new_version }}
 
+      - name: Generate changelog entry
+        id: changelog
+        uses: ROKT/rokt-workflows/actions/generate-changelog@main
+        with:
+          version: ${{ steps.bump-version.outputs.new_version }}
+          repo-url: https://github.com/${{ github.repository }}
+          changelog-path: CHANGELOG.md
+          exclude-types: chore,ci,test,build
+          kits-path: kits
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -65,7 +65,8 @@ jobs:
 
       - name: Generate changelog entry
         id: changelog
-        uses: ROKT/rokt-workflows/actions/generate-changelog@main
+        # Pinned SHA for Semgrep (no mutable @main); bump when upgrading the action.
+        uses: ROKT/rokt-workflows/actions/generate-changelog@c5c93e92107c520fb8b8cf71070995abdf4c403f
         with:
           version: ${{ steps.bump-version.outputs.new_version }}
           repo-url: https://github.com/${{ github.repository }}


### PR DESCRIPTION
Adds the ROKT `generate-changelog` composite action to **Release – Draft** after the Maven Local smoke step.

- Runs with `kits-path: kits` for Core vs Kits grouping.
- Omits explicit `tag-prefix` so semver matches `VERSION` and GitHub release tags.