### PR TITLE
refactor: centralize active kit filtering in KitManagerImpl

### DIFF
--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -1334,9 +1334,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void setWrapperSdkVersion(@NonNull WrapperSdkVersion wrapperSdkVersion) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.RoktListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.RoktListener) {
                     ((KitIntegration.RoktListener) provider).setWrapperSdkVersion(wrapperSdkVersion);
                 }
             } catch (Exception e) {

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -394,12 +394,10 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void setLocation(Location location) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (!provider.isDisabled()) {
-                    provider.setLocation(location);
-                    mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), true, location);
-                }
+                provider.setLocation(location);
+                mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), true, location);
             } catch (Exception e) {
                 Logger.warning("Failed to call setLocation for kit: " + provider.getName() + ": " + e.getMessage());
             }
@@ -408,13 +406,11 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void logNetworkPerformance(String url, long startTime, String method, long length, long bytesSent, long bytesReceived, String requestString, int responseCode) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (!provider.isDisabled()) {
-                    List<ReportingMessage> report = provider.logNetworkPerformance(url, startTime, method, length, bytesSent, bytesReceived, requestString, responseCode);
-                    getReportingManager().logAll(report);
-                    mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), url, startTime, method, length, bytesSent, bytesReceived, requestString, responseCode);
-                }
+                List<ReportingMessage> report = provider.logNetworkPerformance(url, startTime, method, length, bytesSent, bytesReceived, requestString, responseCode);
+                getReportingManager().logAll(report);
+                mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), url, startTime, method, length, bytesSent, bytesReceived, requestString, responseCode);
             } catch (Exception e) {
                 Logger.warning("Failed to call logNetworkPerformance for kit: " + provider.getName() + ": " + e.getMessage());
             }
@@ -485,74 +481,74 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     //================================================================================
 
     protected void logCommerceEvent(CommerceEvent event) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (!provider.isDisabled()) {
-                    CommerceEvent filteredEvent = provider.getConfiguration().filterCommerceEvent(event);
-                    if (filteredEvent != null) {
-                        if (provider instanceof KitIntegration.CommerceListener) {
-                            List<CustomMapping.ProjectionResult> projectedEvents = CustomMapping.projectEvents(
-                                    filteredEvent,
-                                    provider.getConfiguration().getCustomMappingList(),
-                                    provider.getConfiguration().getDefaultCommerceCustomMapping()
-                            );
-                            if (projectedEvents != null && projectedEvents.size() > 0) {
-                                ReportingMessage masterMessage = ReportingMessage.fromEvent(provider, filteredEvent);
-                                boolean forwarded = false;
-                                for (int i = 0; i < projectedEvents.size(); i++) {
-                                    CustomMapping.ProjectionResult result = projectedEvents.get(i);
-                                    List<ReportingMessage> report = null;
-                                    String messageType = null;
-                                    if (result.getMPEvent() != null) {
-                                        MPEvent projectedEvent = projectedEvents.get(i).getMPEvent();
-                                        report = ((KitIntegration.EventListener) provider).logEvent(projectedEvent);
-                                        mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), projectedEvent);
-                                        messageType = ReportingMessage.MessageType.EVENT;
-                                    } else {
-                                        CommerceEvent projectedEvent = projectedEvents.get(i).getCommerceEvent();
-                                        report = ((KitIntegration.CommerceListener) provider).logEvent(projectedEvent);
-                                        mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), projectedEvent);
-                                        messageType = ReportingMessage.MessageType.COMMERCE_EVENT;
-                                    }
-                                    if (report != null && report.size() > 0) {
-                                        forwarded = true;
-                                        for (ReportingMessage message : report) {
-                                            masterMessage.addProjectionReport(
-                                                    new ReportingMessage.ProjectionReport(projectedEvents.get(i).getProjectionId(),
-                                                            messageType,
-                                                            message.getEventName(),
-                                                            message.getEventTypeString())
-                                            );
-                                        }
-                                    }
-                                }
-                                if (forwarded) {
-                                    getReportingManager().log(masterMessage);
-                                }
-                            } else {
-                                List<ReportingMessage> reporting = ((KitIntegration.CommerceListener) provider).logEvent(filteredEvent);
-                                mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(reporting), filteredEvent);
-                                if (reporting != null && reporting.size() > 0) {
-                                    getReportingManager().log(
-                                            ReportingMessage.fromEvent(provider, filteredEvent)
-                                    );
-                                }
-                            }
-                        } else if (provider instanceof KitIntegration.EventListener) {
-                            List<MPEvent> events = CommerceEventUtils.expand(filteredEvent);
+                CommerceEvent filteredEvent = provider.getConfiguration().filterCommerceEvent(event);
+                if (filteredEvent != null) {
+                    if (provider instanceof KitIntegration.CommerceListener) {
+                        List<CustomMapping.ProjectionResult> projectedEvents = CustomMapping.projectEvents(
+                                filteredEvent,
+                                provider.getConfiguration().getCustomMappingList(),
+                                provider.getConfiguration().getDefaultCommerceCustomMapping()
+                        );
+                        if (projectedEvents != null && projectedEvents.size() > 0) {
+                            ReportingMessage masterMessage = ReportingMessage.fromEvent(provider, filteredEvent);
                             boolean forwarded = false;
-                            if (events != null) {
-                                for (MPEvent expandedEvent : events) {
-                                    List<ReportingMessage> reporting = ((KitIntegration.EventListener) provider).logEvent(expandedEvent);
-                                    mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(reporting), expandedEvent);
-                                    forwarded = forwarded || (reporting != null && reporting.size() > 0);
+                            for (int i = 0; i < projectedEvents.size(); i++) {
+                                CustomMapping.ProjectionResult result = projectedEvents.get(i);
+                                List<ReportingMessage> report = null;
+                                String messageType = null;
+                                if (result.getMPEvent() != null) {
+                                    MPEvent projectedEvent = projectedEvents.get(i).getMPEvent();
+                                    report = ((KitIntegration.EventListener) provider).logEvent(projectedEvent);
+                                    mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), projectedEvent);
+                                    messageType = ReportingMessage.MessageType.EVENT;
+                                } else {
+                                    CommerceEvent projectedEvent = projectedEvents.get(i).getCommerceEvent();
+                                    report = ((KitIntegration.CommerceListener) provider).logEvent(projectedEvent);
+                                    mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), projectedEvent);
+                                    messageType = ReportingMessage.MessageType.COMMERCE_EVENT;
+                                }
+                                if (report != null && report.size() > 0) {
+                                    forwarded = true;
+                                    for (ReportingMessage message : report) {
+                                        masterMessage.addProjectionReport(
+                                                new ReportingMessage.ProjectionReport(projectedEvents.get(i).getProjectionId(),
+                                                        messageType,
+                                                        message.getEventName(),
+                                                        message.getEventTypeString())
+                                        );
+                                    }
                                 }
                             }
                             if (forwarded) {
                                 getReportingManager().log(
+                                        masterMessage
+                                );
+                            }
+                        } else {
+                            List<ReportingMessage> reporting = ((KitIntegration.CommerceListener) provider).logEvent(filteredEvent);
+                            mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(reporting), filteredEvent);
+                            if (reporting != null && reporting.size() > 0) {
+                                getReportingManager().log(
                                         ReportingMessage.fromEvent(provider, filteredEvent)
                                 );
                             }
+                        }
+                    } else if (provider instanceof KitIntegration.EventListener) {
+                        List<MPEvent> events = CommerceEventUtils.expand(filteredEvent);
+                        boolean forwarded = false;
+                        if (events != null) {
+                            for (MPEvent expandedEvent : events) {
+                                List<ReportingMessage> reporting = ((KitIntegration.EventListener) provider).logEvent(expandedEvent);
+                                mCoreCallbacks.getKitListener().onKitApiCalled("logMPEvent()", provider.getConfiguration().getKitId(), !MPUtility.isEmpty(reporting), expandedEvent);
+                                forwarded = forwarded || (reporting != null && reporting.size() > 0);
+                            }
+                        }
+                        if (forwarded) {
+                            getReportingManager().log(
+                                    ReportingMessage.fromEvent(provider, filteredEvent)
+                            );
                         }
                     }
                 }

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -887,8 +887,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void leaveBreadcrumb(String breadcrumb) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.EventListener) {
-                    List<ReportingMessage> report = ((KitIntegration.EventListener) provider).leaveBreadcrumb(breadcrumb);
+                if (provider instanceof KitIntegration.EventListener listener) {
+                    List<ReportingMessage> report = listener.leaveBreadcrumb(breadcrumb);
                     getReportingManager().logAll(report);
                     mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), breadcrumb);
                 }
@@ -902,8 +902,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void logError(String message, Map<String, String> eventData) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.EventListener) {
-                    List<ReportingMessage> report = ((KitIntegration.EventListener) provider).logError(message, eventData);
+                if (provider instanceof KitIntegration.EventListener listener) {
+                    List<ReportingMessage> report = listener.logError(message, eventData);
                     getReportingManager().logAll(report);
                     mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), message, eventData);
                 }
@@ -917,8 +917,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void logException(Exception exception, Map<String, String> eventData, String message) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.EventListener) {
-                    List<ReportingMessage> report = ((KitIntegration.EventListener) provider).logException(exception, eventData, message);
+                if (provider instanceof KitIntegration.EventListener listener) {
+                    List<ReportingMessage> report = listener.logException(exception, eventData, message);
                     getReportingManager().logAll(report);
                     mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), exception, message, eventData);
                 }
@@ -1004,8 +1004,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityCreated(activity, savedInstanceState);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivityCreated(activity, savedInstanceState);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1018,8 +1018,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivityStarted(Activity activity) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityStarted(activity);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivityStarted(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1032,8 +1032,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivityResumed(Activity activity) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityResumed(activity);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivityResumed(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1046,8 +1046,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivityPaused(Activity activity) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityPaused(activity);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivityPaused(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1060,8 +1060,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivityStopped(Activity activity) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityStopped(activity);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivityStopped(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1074,8 +1074,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivitySaveInstanceState(activity, outState);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivitySaveInstanceState(activity, outState);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1088,8 +1088,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onActivityDestroyed(Activity activity) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityDestroyed(activity);
+                if (provider instanceof KitIntegration.ActivityListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onActivityDestroyed(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1102,8 +1102,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onSessionEnd() {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.SessionListener) {
-                    List<ReportingMessage> reportingMessages = ((KitIntegration.SessionListener) provider).onSessionEnd();
+                if (provider instanceof KitIntegration.SessionListener listener) {
+                    List<ReportingMessage> reportingMessages = listener.onSessionEnd();
                     getReportingManager().logAll(reportingMessages);
                 }
             } catch (Exception e) {
@@ -1209,8 +1209,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
         reloadKits();
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener) {
-                    ((KitIntegration.IdentityListener) provider).onUserIdentified(FilteredMParticleUser.getInstance(mParticleUser, provider));
+                if (provider instanceof KitIntegration.IdentityListener listener) {
+                    listener.onUserIdentified(FilteredMParticleUser.getInstance(mParticleUser, provider));
                 }
             } catch (Exception e) {
                 Logger.warning("Failed to call onUserIdentified for kit: " + provider.getName() + ": " + e.getMessage());
@@ -1237,8 +1237,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onIdentifyCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener) {
-                    ((KitIntegration.IdentityListener) provider).onIdentifyCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
+                if (provider instanceof KitIntegration.IdentityListener listener) {
+                    listener.onIdentifyCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
                 Logger.warning("Failed to call onIdentifyCompleted for kit: " + provider.getName() + ": " + e.getMessage());
@@ -1250,8 +1250,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onLoginCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener) {
-                    ((KitIntegration.IdentityListener) provider).onLoginCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
+                if (provider instanceof KitIntegration.IdentityListener listener) {
+                    listener.onLoginCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
                 Logger.warning("Failed to call onLoginCompleted for kit: " + provider.getName() + ": " + e.getMessage());
@@ -1263,8 +1263,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onLogoutCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener) {
-                    ((KitIntegration.IdentityListener) provider).onLogoutCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
+                if (provider instanceof KitIntegration.IdentityListener listener) {
+                    listener.onLogoutCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
                 Logger.warning("Failed to call onLogoutCompleted for kit: " + provider.getName() + ": " + e.getMessage());
@@ -1276,8 +1276,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onModifyCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener) {
-                    ((KitIntegration.IdentityListener) provider).onModifyCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
+                if (provider instanceof KitIntegration.IdentityListener listener) {
+                    listener.onModifyCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
                 Logger.warning("Failed to call onModifyCompleted for kit: " + provider.getName() + ": " + e.getMessage());
@@ -1313,8 +1313,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     @Nullable
     public RoktKitApi getRoktKitApi() {
         for (KitIntegration provider : activeKits()) {
-            if (provider instanceof KitIntegration.RoktListener) {
-                return new RoktKitApiImpl((KitIntegration.RoktListener) provider, provider);
+            if (provider instanceof KitIntegration.RoktListener listener) {
+                return new RoktKitApiImpl(listener, provider);
             }
         }
         return null;
@@ -1324,8 +1324,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void setWrapperSdkVersion(@NonNull WrapperSdkVersion wrapperSdkVersion) {
         for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.RoktListener) {
-                    ((KitIntegration.RoktListener) provider).setWrapperSdkVersion(wrapperSdkVersion);
+                if (provider instanceof KitIntegration.RoktListener listener) {
+                    listener.setWrapperSdkVersion(wrapperSdkVersion);
                 }
             } catch (Exception e) {
                 Logger.warning("Failed to call setWrapperSdkVersion for kit: " + provider.getName() + ": " + e.getMessage());

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -1190,11 +1190,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
         MParticle instance = MParticle.getInstance();
         if (instance != null) {
             Intent mockIntent = getMockInstallReferrerIntent(instance.getInstallReferrer());
-            for (KitIntegration provider : providers.values()) {
+            for (KitIntegration provider : activeKits()) {
                 try {
-                    if (!provider.isDisabled()) {
-                        provider.setInstallReferrer(mockIntent);
-                    }
+                    provider.setInstallReferrer(mockIntent);
                 } catch (Exception e) {
                     Logger.warning("Failed to update Install Referrer for kit: " + provider.getName() + ": " + e.getMessage());
                 }
@@ -1209,9 +1207,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onUserIdentified(MParticleUser mParticleUser, MParticleUser previousUser) {
         //due to consent forwarding rules we need to re-verify kits whenever the user changes
         reloadKits();
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.IdentityListener) {
                     ((KitIntegration.IdentityListener) provider).onUserIdentified(FilteredMParticleUser.getInstance(mParticleUser, provider));
                 }
             } catch (Exception e) {
@@ -1237,9 +1235,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onIdentifyCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.IdentityListener) {
                     ((KitIntegration.IdentityListener) provider).onIdentifyCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
@@ -1250,9 +1248,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onLoginCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.IdentityListener) {
                     ((KitIntegration.IdentityListener) provider).onLoginCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
@@ -1263,9 +1261,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onLogoutCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.IdentityListener) {
                     ((KitIntegration.IdentityListener) provider).onLogoutCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
@@ -1276,9 +1274,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onModifyCompleted(MParticleUser mParticleUser, IdentityApiRequest identityApiRequest) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.IdentityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.IdentityListener) {
                     ((KitIntegration.IdentityListener) provider).onModifyCompleted(FilteredMParticleUser.getInstance(mParticleUser, provider), new FilteredIdentityApiRequest(identityApiRequest, provider));
                 }
             } catch (Exception e) {
@@ -1291,13 +1289,11 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     public void onConsentStateUpdated(final ConsentState oldState, final ConsentState newState, final long mpid) {
         //Due to consent forwarding rules we need to re-initialize kits whenever the user changes.
         reloadKits();
-        for (KitIntegration provider : providers.values()) {
-            if (provider instanceof KitIntegration.UserAttributeListener && !provider.isDisabled()) {
-                try {
-                    ((KitIntegration.UserAttributeListener) provider).onConsentStateUpdated(oldState, newState);
-                } catch (Exception e) {
-                    Logger.warning("Failed to call onConsentStateUpdated for kit: " + provider.getName() + ": " + e.getMessage());
-                }
+        for (KitIntegration.UserAttributeListener listener : userAttributeListeners()) {
+            try {
+                listener.onConsentStateUpdated(oldState, newState);
+            } catch (Exception e) {
+                Logger.warning("Failed to call onConsentStateUpdated for kit: " + listener.getName() + ": " + e.getMessage());
             }
         }
     }

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -564,19 +564,17 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public boolean onMessageReceived(Context context, Intent intent) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             if (provider instanceof KitIntegration.PushListener) {
                 try {
-                    if (!provider.isDisabled()) {
-                        boolean willHandlePush = ((KitIntegration.PushListener) provider).willHandlePushMessage(intent);
-                        mCoreCallbacks.getKitListener().onKitApiCalled("willHandlePushMessage()", provider.getConfiguration().getKitId(), willHandlePush, intent);
-                        if (willHandlePush) {
-                            ((KitIntegration.PushListener) provider).onPushMessageReceived(context, intent);
-                            mCoreCallbacks.getKitListener().onKitApiCalled("onPushMessageReceived()", provider.getConfiguration().getKitId(), null, context, intent);
-                            ReportingMessage message = ReportingMessage.fromPushMessage(provider, intent);
-                            getReportingManager().log(message);
-                            return true;
-                        }
+                    boolean willHandlePush = ((KitIntegration.PushListener) provider).willHandlePushMessage(intent);
+                    mCoreCallbacks.getKitListener().onKitApiCalled("willHandlePushMessage()", provider.getConfiguration().getKitId(), willHandlePush, intent);
+                    if (willHandlePush) {
+                        ((KitIntegration.PushListener) provider).onPushMessageReceived(context, intent);
+                        mCoreCallbacks.getKitListener().onKitApiCalled("onPushMessageReceived()", provider.getConfiguration().getKitId(), null, context, intent);
+                        ReportingMessage message = ReportingMessage.fromPushMessage(provider, intent);
+                        getReportingManager().log(message);
+                        return true;
                     }
                 } catch (Exception e) {
                     Logger.warning("Failed to call onPushMessageReceived for kit: " + provider.getName() + ": " + e.getMessage());
@@ -588,18 +586,16 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public boolean onPushRegistration(String token, String senderId) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             if (provider instanceof KitIntegration.PushListener) {
                 try {
-                    if (!provider.isDisabled()) {
-                        boolean onPushRegistration = ((KitIntegration.PushListener) provider).onPushRegistration(token, senderId);
-                        mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), onPushRegistration, token, senderId);
-                        if (onPushRegistration) {
-                            ReportingMessage message = ReportingMessage.fromPushRegistrationMessage(provider);
-                            getReportingManager().log(message);
-                        }
-                        return true;
+                    boolean onPushRegistration = ((KitIntegration.PushListener) provider).onPushRegistration(token, senderId);
+                    mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), onPushRegistration, token, senderId);
+                    if (onPushRegistration) {
+                        ReportingMessage message = ReportingMessage.fromPushRegistrationMessage(provider);
+                        getReportingManager().log(message);
                     }
+                    return true;
                 } catch (Exception e) {
                     Logger.warning("Failed to call onPushRegistration for kit: " + provider.getName() + ": " + e.getMessage());
                 }
@@ -889,9 +885,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void leaveBreadcrumb(String breadcrumb) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.EventListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.EventListener) {
                     List<ReportingMessage> report = ((KitIntegration.EventListener) provider).leaveBreadcrumb(breadcrumb);
                     getReportingManager().logAll(report);
                     mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), breadcrumb);
@@ -904,9 +900,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void logError(String message, Map<String, String> eventData) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.EventListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.EventListener) {
                     List<ReportingMessage> report = ((KitIntegration.EventListener) provider).logError(message, eventData);
                     getReportingManager().logAll(report);
                     mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), message, eventData);
@@ -919,9 +915,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void logException(Exception exception, Map<String, String> eventData, String message) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.EventListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.EventListener) {
                     List<ReportingMessage> report = ((KitIntegration.EventListener) provider).logException(exception, eventData, message);
                     getReportingManager().logAll(report);
                     mCoreCallbacks.getKitListener().onKitApiCalled(provider.getConfiguration().getKitId(), !MPUtility.isEmpty(report), exception, message, eventData);
@@ -1006,9 +1002,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityCreated(activity, savedInstanceState);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1020,9 +1016,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivityStarted(Activity activity) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityStarted(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1034,9 +1030,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivityResumed(Activity activity) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityResumed(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1048,9 +1044,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivityPaused(Activity activity) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityPaused(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1062,9 +1058,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivityStopped(Activity activity) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityStopped(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1076,9 +1072,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivitySaveInstanceState(activity, outState);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1090,9 +1086,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onActivityDestroyed(Activity activity) {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.ActivityListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.ActivityListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.ActivityListener) provider).onActivityDestroyed(activity);
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1104,9 +1100,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onSessionEnd() {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.SessionListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.SessionListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.SessionListener) provider).onSessionEnd();
                     getReportingManager().logAll(reportingMessages);
                 }
@@ -1118,9 +1114,9 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
 
     @Override
     public void onSessionStart() {
-        for (KitIntegration provider : providers.values()) {
+        for (KitIntegration provider : activeKits()) {
             try {
-                if (provider instanceof KitIntegration.SessionListener && !provider.isDisabled()) {
+                if (provider instanceof KitIntegration.SessionListener) {
                     List<ReportingMessage> reportingMessages = ((KitIntegration.SessionListener) provider).onSessionStart();
                     getReportingManager().logAll(reportingMessages);
                 }

--- a/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
+++ b/android-kit-base/src/main/java/com/mparticle/kits/KitManagerImpl.java
@@ -1324,8 +1324,8 @@ public class KitManagerImpl implements KitManager, AttributionListener, Identity
     @Override
     @Nullable
     public RoktKitApi getRoktKitApi() {
-        for (KitIntegration provider : providers.values()) {
-            if (provider instanceof KitIntegration.RoktListener && !provider.isDisabled()) {
+        for (KitIntegration provider : activeKits()) {
+            if (provider instanceof KitIntegration.RoktListener) {
                 return new RoktKitApiImpl((KitIntegration.RoktListener) provider, provider);
             }
         }


### PR DESCRIPTION
## Background
This refactor centralizes active-kit filtering in `KitManagerImpl` to reduce repeated listener checks and keep forwarding behavior consistent.

## What Has Changed
- Replaced repeated `providers.values()` + disabled checks with `activeKits()` in push, lifecycle, identity, consent, and referrer callback paths.
- Standardized forwarding loops to remove duplicated listener filtering logic and repeated casts.
- Added a reusable typed helper (`activeKitsOfType`) and applied it to listener selection paths.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.