### PR TITLE
feat: Add max persistence age override option [TRIAGE-608]

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/MParticleOptionsTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/MParticleOptionsTest.kt
@@ -695,6 +695,46 @@ class MParticleOptionsTest : BaseAbstractTest() {
     }
 
     @Test
+    fun testPersistenceMaxAgeSeconds() {
+        // nothing set, should return null (SDK will fall back to the 90-day default)
+        var options =
+            MParticleOptions
+                .builder(mContext)
+                .credentials("key", "secret")
+                .build()
+        Assert.assertNull(options.persistenceMaxAgeSeconds)
+
+        // positive number should be preserved
+        val testValue = Math.abs(ran.nextInt()) + 1
+        options =
+            MParticleOptions
+                .builder(mContext)
+                .credentials("key", "secret")
+                .persistenceMaxAgeSeconds(testValue)
+                .build()
+        Assert.assertEquals(testValue, options.persistenceMaxAgeSeconds)
+
+        // zero is non-positive and should be rejected (differs from configMaxAgeSeconds which
+        // accepts zero as "always stale") - mirrors iOS SDK behaviour
+        options =
+            MParticleOptions
+                .builder(mContext)
+                .credentials("key", "secret")
+                .persistenceMaxAgeSeconds(0)
+                .build()
+        Assert.assertNull(options.persistenceMaxAgeSeconds)
+
+        // negative numbers should be rejected
+        options =
+            MParticleOptions
+                .builder(mContext)
+                .credentials("key", "secret")
+                .persistenceMaxAgeSeconds(-5)
+                .build()
+        Assert.assertNull(options.persistenceMaxAgeSeconds)
+    }
+
+    @Test
     fun testAndroidIdLogMessage() {
         val infoLogs = ArrayList<String?>()
         Logger.setLogHandler(

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/database/services/MessageServiceTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/database/services/MessageServiceTest.kt
@@ -400,6 +400,72 @@ class MessageServiceTest : BaseMPServiceTest() {
         Assert.assertEquals(MessageService.getMessagesForUpload(database).size.toLong(), 20)
     }
 
+    @Test
+    @Throws(JSONException::class)
+    fun testDeleteMessagesOlderThan() {
+        val sessionId = UUID.randomUUID().toString()
+        val now = System.currentTimeMillis()
+        val oneDayMillis = 24L * 60L * 60L * 1000L
+        // Insert 5 "old" messages dated 10 days ago and 5 "recent" messages dated 1 hour ago.
+        for (i in 0 until 5) {
+            val oldMessage =
+                BaseMPMessage
+                    .Builder("custom_event")
+                    .timestamp(now - 10L * oneDayMillis)
+                    .build(
+                        InternalSession().apply { mSessionID = sessionId },
+                        null,
+                        1L,
+                    )
+            MessageService.insertMessage(database, "apiKey", oldMessage, 1L, null, null)
+        }
+        for (i in 0 until 5) {
+            val recentMessage =
+                BaseMPMessage
+                    .Builder("custom_event")
+                    .timestamp(now - 60L * 60L * 1000L)
+                    .build(
+                        InternalSession().apply { mSessionID = sessionId },
+                        null,
+                        1L,
+                    )
+            MessageService.insertMessage(database, "apiKey", recentMessage, 1L, null, null)
+        }
+        Assert.assertEquals(
+            10L,
+            MessageService.getMessagesForUpload(database).size.toLong(),
+        )
+
+        // Cut off at 7 days ago - the 5 old messages should be removed and the 5 recent kept.
+        val cutoffMillis = now - 7L * oneDayMillis
+        val deleted = MessageService.deleteMessagesOlderThan(database, cutoffMillis)
+        Assert.assertEquals(5, deleted.toLong())
+        Assert.assertEquals(
+            5L,
+            MessageService.getMessagesForUpload(database).size.toLong(),
+        )
+
+        // Rows exactly at the cutoff must not be removed (strict `<` predicate).
+        val exactlyAtCutoffMessage =
+            BaseMPMessage
+                .Builder("custom_event")
+                .timestamp(cutoffMillis)
+                .build(
+                    InternalSession().apply { mSessionID = sessionId },
+                    null,
+                    1L,
+                )
+        MessageService.insertMessage(database, "apiKey", exactlyAtCutoffMessage, 1L, null, null)
+        Assert.assertEquals(
+            0,
+            MessageService.deleteMessagesOlderThan(database, cutoffMillis).toLong(),
+        )
+        Assert.assertEquals(
+            6L,
+            MessageService.getMessagesForUpload(database).size.toLong(),
+        )
+    }
+
     private fun getMaxId(messages: List<ReadyMessage>): Int {
         var max = 0
         for (message in messages) {

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/database/services/SessionServiceTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/database/services/SessionServiceTest.kt
@@ -4,6 +4,7 @@ import android.database.Cursor
 import com.mparticle.internal.BatchId
 import com.mparticle.internal.MessageBatch
 import com.mparticle.internal.database.tables.SessionTable
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -74,6 +75,59 @@ class SessionServiceTest : BaseMPServiceTest() {
             batchBySessionId["1"]?.remove(messageBatch)
             assertEquals(--size, batchBySessionId["1"]?.size)
         }
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun testDeleteSessionsOlderThan() {
+        val now = System.currentTimeMillis()
+        val oneDayMillis = 24L * 60L * 60L * 1000L
+        val oldEndTime = now - 10L * oneDayMillis
+        val recentEndTime = now - 60L * 60L * 1000L
+
+        // Insert 5 sessions whose END_TIME is 10 days ago and 5 whose END_TIME is 1 hour ago.
+        // insertSession seeds END_TIME = START_TIME, so we call updateSessionEndTime to model
+        // the production flow where subsequent events advance END_TIME independently.
+        for (i in 0 until 5) {
+            val oldSessionId = UUID.randomUUID().toString()
+            SessionService.insertSession(database, getMpMessage(oldSessionId), "apiKey", "{}", "{}", 1L)
+            SessionService.updateSessionEndTime(database, oldSessionId, oldEndTime, 0)
+        }
+        for (i in 0 until 5) {
+            val recentSessionId = UUID.randomUUID().toString()
+            SessionService.insertSession(database, getMpMessage(recentSessionId), "apiKey", "{}", "{}", 1L)
+            SessionService.updateSessionEndTime(database, recentSessionId, recentEndTime, 0)
+        }
+        assertEquals(10, countSessions())
+
+        // Cut off at 7 days ago - the 5 old sessions should be removed and the 5 recent kept.
+        val cutoffMillis = now - 7L * oneDayMillis
+        val deleted = SessionService.deleteSessionsOlderThan(database, cutoffMillis)
+        assertEquals(5, deleted)
+        assertEquals(5, countSessions())
+
+        // Rows whose END_TIME is exactly at the cutoff must not be removed (strict `<` predicate).
+        val boundarySessionId = UUID.randomUUID().toString()
+        SessionService.insertSession(database, getMpMessage(boundarySessionId), "apiKey", "{}", "{}", 1L)
+        SessionService.updateSessionEndTime(database, boundarySessionId, cutoffMillis, 0)
+        assertEquals(0, SessionService.deleteSessionsOlderThan(database, cutoffMillis))
+        assertEquals(6, countSessions())
+    }
+
+    private fun countSessions(): Int {
+        var count = 0
+        var cursor: Cursor? = null
+        try {
+            cursor = SessionService.getSessions(database)
+            while (cursor.moveToNext()) {
+                count++
+            }
+        } finally {
+            if (cursor != null && !cursor.isClosed) {
+                cursor.close()
+            }
+        }
+        return count
     }
 
     internal inner class MockMessageBatch(

--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/database/services/UploadServiceTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/database/services/UploadServiceTest.kt
@@ -1,0 +1,52 @@
+package com.mparticle.internal.database.services
+
+import com.mparticle.internal.Constants
+import com.mparticle.internal.database.UploadSettings
+import com.mparticle.networking.NetworkOptions
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UploadServiceTest : BaseMPServiceTest() {
+
+    @Test
+    @Throws(JSONException::class)
+    fun testDeleteUploadsOlderThan() {
+        val now = System.currentTimeMillis()
+        val oneDayMillis = 24L * 60L * 60L * 1000L
+        val uploadSettings = UploadSettings(
+            "apiKey",
+            "secret",
+            NetworkOptions.builder().build(),
+            "",
+            "",
+        )
+
+        // Insert 5 uploads dated 10 days ago and 5 uploads dated 1 hour ago.
+        // insertUpload reads CREATED_AT from the message's TIMESTAMP ("ct") key.
+        for (i in 0 until 5) {
+            UploadService.insertUpload(database, uploadJson(now - 10L * oneDayMillis), uploadSettings)
+        }
+        for (i in 0 until 5) {
+            UploadService.insertUpload(database, uploadJson(now - 60L * 60L * 1000L), uploadSettings)
+        }
+        assertEquals(10, UploadService.getReadyUploads(database).size)
+
+        // Cut off at 7 days ago - the 5 old uploads should be removed and the 5 recent kept.
+        val cutoffMillis = now - 7L * oneDayMillis
+        val deleted = UploadService.deleteUploadsOlderThan(database, cutoffMillis)
+        assertEquals(5, deleted)
+        assertEquals(5, UploadService.getReadyUploads(database).size)
+
+        // Rows whose CREATED_AT is exactly at the cutoff must not be removed (strict `<` predicate).
+        UploadService.insertUpload(database, uploadJson(cutoffMillis), uploadSettings)
+        assertEquals(0, UploadService.deleteUploadsOlderThan(database, cutoffMillis))
+        assertEquals(6, UploadService.getReadyUploads(database).size)
+    }
+
+    @Throws(JSONException::class)
+    private fun uploadJson(timestampMillis: Long): JSONObject = JSONObject()
+        .put(Constants.MessageKey.TIMESTAMP, timestampMillis)
+        .put("payload", "test")
+}

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -42,6 +42,7 @@ public class MParticleOptions {
     private Integer mUploadInterval = ConfigManager.DEFAULT_UPLOAD_INTERVAL;  //seconds
     private Integer mSessionTimeout = ConfigManager.DEFAULT_SESSION_TIMEOUT_SECONDS; //seconds
     private Integer mConfigMaxAge = null;
+    private Integer mPersistenceMaxAgeSeconds = null;
     private Boolean mUnCaughtExceptionLogging = false;
     private MParticle.LogLevel mLogLevel = MParticle.LogLevel.DEBUG;
     private AttributionListener mAttributionListener;
@@ -116,6 +117,13 @@ public class MParticleOptions {
                 Logger.warning("Config Max Age must be a positive number, disregarding value.");
             } else {
                 this.mConfigMaxAge = builder.configMaxAge;
+            }
+        }
+        if (builder.persistenceMaxAgeSeconds != null) {
+            if (builder.persistenceMaxAgeSeconds <= 0) {
+                Logger.warning("Persistence Max Age must be a positive number, disregarding value.");
+            } else {
+                this.mPersistenceMaxAgeSeconds = builder.persistenceMaxAgeSeconds;
             }
         }
         if (builder.unCaughtExceptionLogging != null) {
@@ -290,6 +298,22 @@ public class MParticleOptions {
         return mConfigMaxAge;
     }
 
+    /**
+     * The maximum threshold (in seconds) for locally persisted events, batches, and sessions.
+     * <p>
+     * When {@code null} (the default), records are retained for 90 days before being deleted.
+     * Values less than or equal to zero are rejected at build time and result in the default
+     * being used.
+     *
+     * @return the configured maximum persistence age in seconds, or {@code null} when the default
+     *         (90 days) applies
+     * @see Builder#persistenceMaxAgeSeconds(int)
+     */
+    @Nullable
+    public Integer getPersistenceMaxAgeSeconds() {
+        return mPersistenceMaxAgeSeconds;
+    }
+
     @NonNull
     public Boolean isUncaughtExceptionLoggingEnabled() {
         return mUnCaughtExceptionLogging;
@@ -403,6 +427,7 @@ public class MParticleOptions {
         private Integer uploadInterval = null;
         private Integer sessionTimeout = null;
         private Integer configMaxAge = null;
+        private Integer persistenceMaxAgeSeconds = null;
         private Boolean unCaughtExceptionLogging = null;
         MParticle.LogLevel logLevel = null;
         BaseIdentityTask identityTask;
@@ -619,6 +644,32 @@ public class MParticleOptions {
         @NonNull
         public Builder configMaxAgeSeconds(int configMaxAge) {
             this.configMaxAge = configMaxAge;
+            return this;
+        }
+
+        /**
+         * Set a maximum threshold for locally persisted events, batches, and sessions, in seconds.
+         * <p>
+         * By default, data is persisted for 90 days before being deleted to minimize data loss;
+         * however, this can lead to excessive storage usage on some users' devices. This is
+         * exacerbated if your app logs a large number of events, or events carrying a lot of data
+         * (attributes, etc.).
+         * <p>
+         * Set a lower value (for example, 48 hours or 1 week) if you have storage usage concerns.
+         * Alternatively, if you have data loss concerns, set a longer value than the default.
+         * <p>
+         * This is the Android equivalent of the iOS SDK's
+         * {@code MParticleOptions.persistenceMaxAgeSeconds} option.
+         *
+         * @param persistenceMaxAgeSeconds the upper limit, in seconds, for how long persisted
+         *                                 data may live on disk. Must be greater than zero;
+         *                                 non-positive values are rejected and the default
+         *                                 (90 days) is used instead
+         * @return the instance of the builder, for chaining calls
+         */
+        @NonNull
+        public Builder persistenceMaxAgeSeconds(int persistenceMaxAgeSeconds) {
+            this.persistenceMaxAgeSeconds = persistenceMaxAgeSeconds;
             return this;
         }
 

--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -106,6 +106,8 @@ public class ConfigManager {
     private String mDataplanId;
     private Integer mDataplanVersion;
     private Integer mMaxConfigAge;
+    @Nullable
+    private Integer mPersistenceMaxAgeSeconds;
     public static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 30;
     public static final int MINIMUM_CONNECTION_TIMEOUT_SECONDS = 1;
     public static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 60;
@@ -136,6 +138,17 @@ public class ConfigManager {
 
     public ConfigManager(@NonNull MParticleOptions options) {
         this(options.getContext(), options.getEnvironment(), options.getApiKey(), options.getApiSecret(), options.getDataplanOptions(), options.getDataplanId(), options.getDataplanVersion(), options.getConfigMaxAge(), options.getConfigurationsForTarget(ConfigManager.class), options.getSideloadedKits());
+        mPersistenceMaxAgeSeconds = options.getPersistenceMaxAgeSeconds();
+    }
+
+    /**
+     * @return the configured maximum persistence age in seconds, or {@code null} when the SDK
+     *         should fall back to its 90-day default.
+     * @see MParticleOptions.Builder#persistenceMaxAgeSeconds(int)
+     */
+    @Nullable
+    public Integer getPersistenceMaxAgeSeconds() {
+        return mPersistenceMaxAgeSeconds;
     }
 
     public ConfigManager(@NonNull Context context, @Nullable MParticle.Environment environment, @Nullable String apiKey, @Nullable String apiSecret, @Nullable MParticleOptions.DataplanOptions dataplanOptions, @Nullable String dataplanId, @Nullable Integer dataplanVersion, @Nullable Integer configMaxAge, @Nullable List<Configuration<ConfigManager>> configurations, @Nullable List<SideloadedKit> sideloadedKits) {

--- a/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
@@ -8,6 +8,7 @@ import android.os.Looper;
 import android.os.Message;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.mparticle.MParticle;
 import com.mparticle.audience.AudienceResponse;
@@ -61,12 +62,14 @@ public class UploadHandler extends BaseHandler {
      * {@link com.mparticle.MParticleOptions.Builder#persistenceMaxAgeSeconds(int)} is not set.
      * Matches the iOS SDK's 90-day default.
      */
+    @VisibleForTesting
     static final long DEFAULT_PERSISTENCE_MAX_AGE_MILLIS = 90L * 24L * 60L * 60L * 1000L;
 
     /**
      * Minimum interval between age-based persistence sweeps, matching the iOS SDK's 24 hour
      * throttle on {@code cleanUp}.
      */
+    @VisibleForTesting
     static final long PERSISTENCE_CLEANUP_INTERVAL_MILLIS = 24L * 60L * 60L * 1000L;
 
     /**
@@ -241,6 +244,7 @@ public class UploadHandler extends BaseHandler {
      *
      * @param nowMillis current time in unix-epoch milliseconds
      */
+    @VisibleForTesting
     void maybePrunePersistedRecords(long nowMillis) {
         if (nowMillis - mLastPersistenceCleanupMillis < PERSISTENCE_CLEANUP_INTERVAL_MILLIS) {
             return;

--- a/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
@@ -252,16 +252,13 @@ public class UploadHandler extends BaseHandler {
         if (mParticleDBManager == null) {
             return;
         }
-        try {
-            Integer configured = mConfigManager == null ? null : mConfigManager.getPersistenceMaxAgeSeconds();
-            long maxAgeMillis = (configured == null)
-                    ? DEFAULT_PERSISTENCE_MAX_AGE_MILLIS
-                    : configured.longValue() * 1000L;
-            long cutoffMillis = nowMillis - maxAgeMillis;
-            mParticleDBManager.deleteRecordsOlderThan(cutoffMillis);
+        Integer configured = mConfigManager == null ? null : mConfigManager.getPersistenceMaxAgeSeconds();
+        long maxAgeMillis = (configured == null)
+                ? DEFAULT_PERSISTENCE_MAX_AGE_MILLIS
+                : configured.longValue() * 1000L;
+        long cutoffMillis = nowMillis - maxAgeMillis;
+        if (mParticleDBManager.deleteRecordsOlderThan(cutoffMillis)) {
             mLastPersistenceCleanupMillis = nowMillis;
-        } catch (Exception e) {
-            Logger.warning(e, "Failed to prune persisted records by age.");
         }
     }
 

--- a/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
@@ -56,6 +56,25 @@ public class UploadHandler extends BaseHandler {
      */
     public static final int INIT_CONFIG = 6;
 
+    /**
+     * Default retention window for persisted events, batches, and sessions when
+     * {@link com.mparticle.MParticleOptions.Builder#persistenceMaxAgeSeconds(int)} is not set.
+     * Matches the iOS SDK's 90-day default.
+     */
+    static final long DEFAULT_PERSISTENCE_MAX_AGE_MILLIS = 90L * 24L * 60L * 60L * 1000L;
+
+    /**
+     * Minimum interval between age-based persistence sweeps, matching the iOS SDK's 24 hour
+     * throttle on {@code cleanUp}.
+     */
+    static final long PERSISTENCE_CLEANUP_INTERVAL_MILLIS = 24L * 60L * 60L * 1000L;
+
+    /**
+     * Unix-epoch millisecond timestamp of the last successful age-based sweep. Zero means
+     * "never run in this process".
+     */
+    private long mLastPersistenceCleanupMillis = 0L;
+
     private final SharedPreferences mPreferences;
     private final SegmentDatabase audienceDB;
 
@@ -186,6 +205,7 @@ public class UploadHandler extends BaseHandler {
      * This method is responsible for looking for batches that are ready to be uploaded, and uploading them.
      */
     protected void upload() {
+        maybePrunePersistedRecords(System.currentTimeMillis());
         mParticleDBManager.cleanupUploadMessages();
         try {
             List<MParticleDBManager.ReadyUpload> readyUploads = mParticleDBManager.getReadyUploads();
@@ -208,6 +228,32 @@ public class UploadHandler extends BaseHandler {
             Logger.error("Bad API request - is the correct API key and secret configured?");
         } catch (Exception e) {
             Logger.error(e, "Error processing batch uploads in mParticle DB.");
+        }
+    }
+
+    /**
+     * Run an age-based retention sweep across persisted events, batches, and sessions at most
+     * once every {@link #PERSISTENCE_CLEANUP_INTERVAL_MILLIS}. When the consumer has not
+     * configured {@link com.mparticle.MParticleOptions.Builder#persistenceMaxAgeSeconds(int)},
+     * the default 90-day window is used.
+     *
+     * @param nowMillis current time in unix-epoch milliseconds
+     */
+    void maybePrunePersistedRecords(long nowMillis) {
+        if (nowMillis - mLastPersistenceCleanupMillis < PERSISTENCE_CLEANUP_INTERVAL_MILLIS) {
+            return;
+        }
+        try {
+            Integer configured = mConfigManager == null ? null : mConfigManager.getPersistenceMaxAgeSeconds();
+            long maxAgeMillis = (configured == null)
+                    ? DEFAULT_PERSISTENCE_MAX_AGE_MILLIS
+                    : configured.longValue() * 1000L;
+            long cutoffMillis = nowMillis - maxAgeMillis;
+            mParticleDBManager.deleteRecordsOlderThan(cutoffMillis);
+        } catch (Exception e) {
+            Logger.warning(e, "Failed to prune persisted records by age.");
+        } finally {
+            mLastPersistenceCleanupMillis = nowMillis;
         }
     }
 

--- a/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/UploadHandler.java
@@ -235,12 +235,17 @@ public class UploadHandler extends BaseHandler {
      * Run an age-based retention sweep across persisted events, batches, and sessions at most
      * once every {@link #PERSISTENCE_CLEANUP_INTERVAL_MILLIS}. When the consumer has not
      * configured {@link com.mparticle.MParticleOptions.Builder#persistenceMaxAgeSeconds(int)},
-     * the default 90-day window is used.
+     * the default 90-day window is used. The throttle timestamp is only advanced on a
+     * successful sweep so that transient failures (for example a locked database) can be
+     * retried on the next upload cycle rather than deferred for 24 hours.
      *
      * @param nowMillis current time in unix-epoch milliseconds
      */
     void maybePrunePersistedRecords(long nowMillis) {
         if (nowMillis - mLastPersistenceCleanupMillis < PERSISTENCE_CLEANUP_INTERVAL_MILLIS) {
+            return;
+        }
+        if (mParticleDBManager == null) {
             return;
         }
         try {
@@ -250,10 +255,9 @@ public class UploadHandler extends BaseHandler {
                     : configured.longValue() * 1000L;
             long cutoffMillis = nowMillis - maxAgeMillis;
             mParticleDBManager.deleteRecordsOlderThan(cutoffMillis);
+            mLastPersistenceCleanupMillis = nowMillis;
         } catch (Exception e) {
             Logger.warning(e, "Failed to prune persisted records by age.");
-        } finally {
-            mLastPersistenceCleanupMillis = nowMillis;
         }
     }
 

--- a/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
@@ -7,6 +7,7 @@ import android.location.Location;
 import android.os.Handler;
 import android.os.Looper;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.Nullable;
 
 import com.mparticle.MParticle;
@@ -211,12 +212,16 @@ public class MParticleDBManager {
      * <p>
      * Deletes any messages and uploads whose {@code CREATED_AT} is strictly less than
      * {@code cutoffMillis}, and any sessions whose {@code END_TIME} is strictly less than
-     * {@code cutoffMillis}. Mirrors the behaviour of the iOS SDK's
-     * {@code MPPersistenceController.deleteRecordsOlderThan:}.
+     * {@code cutoffMillis}.
+     * {@code MPPersistenceController.deleteRecordsOlderThan:}, but reports success so
+     * callers can decide whether to arm retry/throttle state.
      *
      * @param cutoffMillis the unix-epoch millisecond cutoff; rows older than this are removed
+     * @return {@code true} if the transaction committed successfully, {@code false} if any
+     *         exception was caught (and logged) during the sweep
      */
-    public void deleteRecordsOlderThan(long cutoffMillis) {
+    @CheckResult
+    public boolean deleteRecordsOlderThan(long cutoffMillis) {
         MPDatabase db = getDatabase();
         try {
             db.beginTransaction();
@@ -224,8 +229,10 @@ public class MParticleDBManager {
             UploadService.deleteUploadsOlderThan(db, cutoffMillis);
             SessionService.deleteSessionsOlderThan(db, cutoffMillis);
             db.setTransactionSuccessful();
+            return true;
         } catch (Exception e) {
             Logger.warning(e, "Error pruning persisted records older than " + cutoffMillis + " ms.");
+            return false;
         } finally {
             db.endTransaction();
         }

--- a/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/MParticleDBManager.java
@@ -206,6 +206,31 @@ public class MParticleDBManager {
         }
     }
 
+    /**
+     * Age-based retention sweep across the three persistence tables.
+     * <p>
+     * Deletes any messages and uploads whose {@code CREATED_AT} is strictly less than
+     * {@code cutoffMillis}, and any sessions whose {@code END_TIME} is strictly less than
+     * {@code cutoffMillis}. Mirrors the behaviour of the iOS SDK's
+     * {@code MPPersistenceController.deleteRecordsOlderThan:}.
+     *
+     * @param cutoffMillis the unix-epoch millisecond cutoff; rows older than this are removed
+     */
+    public void deleteRecordsOlderThan(long cutoffMillis) {
+        MPDatabase db = getDatabase();
+        try {
+            db.beginTransaction();
+            MessageService.deleteMessagesOlderThan(db, cutoffMillis);
+            UploadService.deleteUploadsOlderThan(db, cutoffMillis);
+            SessionService.deleteSessionsOlderThan(db, cutoffMillis);
+            db.setTransactionSuccessful();
+        } catch (Exception e) {
+            Logger.warning(e, "Error pruning persisted records older than " + cutoffMillis + " ms.");
+        } finally {
+            db.endTransaction();
+        }
+    }
+
     private HashMap<BatchId, MessageBatch> getUploadMessageByBatchIdMap(List<MessageService.ReadyMessage> readyMessages, MPDatabase db, ConfigManager configManager) throws JSONException {
         return getUploadMessageByBatchIdMap(readyMessages, db, configManager, false);
     }

--- a/android-core/src/main/java/com/mparticle/internal/database/services/MessageService.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/MessageService.java
@@ -105,6 +105,22 @@ public class MessageService extends MessageTable {
                 selectionArgs);
     }
 
+    /**
+     * Delete messages whose {@link MessageTableColumns#CREATED_AT} is strictly less than
+     * {@code cutoffMillis}.
+     *
+     * @param database     the message database
+     * @param cutoffMillis the unix-epoch millisecond cutoff; rows older than this are removed
+     * @return the number of rows deleted
+     */
+    public static int deleteMessagesOlderThan(MPDatabase database, long cutoffMillis) {
+        String[] whereArgs = new String[]{Long.toString(cutoffMillis)};
+        return database.delete(
+                MessageTableColumns.TABLE_NAME,
+                MessageTableColumns.CREATED_AT + " < ?",
+                whereArgs);
+    }
+
     public static boolean hasMessagesForUpload(MPDatabase database) {
         Cursor messageIds = null;
         try {

--- a/android-core/src/main/java/com/mparticle/internal/database/services/SessionService.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/SessionService.java
@@ -34,6 +34,23 @@ public class SessionService extends SessionTable {
     }
 
     /**
+     * Delete sessions whose {@link SessionTableColumns#END_TIME} is strictly less than
+     * {@code cutoffMillis}.
+     *
+     * @param database     the session database
+     * @param cutoffMillis the unix-epoch millisecond cutoff; sessions that ended before this are
+     *                     removed
+     * @return the number of rows deleted
+     */
+    public static int deleteSessionsOlderThan(MPDatabase database, long cutoffMillis) {
+        String[] whereArgs = new String[]{Long.toString(cutoffMillis)};
+        return database.delete(
+                TABLE_NAME,
+                SessionTableColumns.END_TIME + " < ?",
+                whereArgs);
+    }
+
+    /**
      * delete Session entries with session_id that are not a part of the Set
      *
      * @param database

--- a/android-core/src/main/java/com/mparticle/internal/database/services/UploadService.java
+++ b/android-core/src/main/java/com/mparticle/internal/database/services/UploadService.java
@@ -23,6 +23,22 @@ public class UploadService extends UploadTable {
     }
 
     /**
+     * Delete uploads whose {@link UploadTableColumns#CREATED_AT} is strictly less than
+     * {@code cutoffMillis}.
+     *
+     * @param database     the upload database
+     * @param cutoffMillis the unix-epoch millisecond cutoff; rows older than this are removed
+     * @return the number of rows deleted
+     */
+    public static int deleteUploadsOlderThan(MPDatabase database, long cutoffMillis) {
+        String[] whereArgs = new String[]{Long.toString(cutoffMillis)};
+        return database.delete(
+                UploadTableColumns.TABLE_NAME,
+                UploadTableColumns.CREATED_AT + " < ?",
+                whereArgs);
+    }
+
+    /**
      * Generic method to insert a new upload,
      * either a regular message batch, or a session history.
      *

--- a/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
@@ -150,7 +150,7 @@ class UploadHandlerTest {
         val capturedCutoff = java.util.concurrent.atomic.AtomicLong(Long.MIN_VALUE)
         Mockito.doAnswer { invocation ->
             capturedCutoff.set(invocation.getArgument(0))
-            null
+            true
         }.`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
 
         val now = 1_700_000_000_000L
@@ -182,7 +182,7 @@ class UploadHandlerTest {
         val capturedCutoff = java.util.concurrent.atomic.AtomicLong(Long.MIN_VALUE)
         Mockito.doAnswer { invocation ->
             capturedCutoff.set(invocation.getArgument(0))
-            null
+            true
         }.`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
 
         val now = 1_700_000_000_000L
@@ -194,6 +194,8 @@ class UploadHandlerTest {
     @Test
     fun testMaybePrunePersistedRecordsHonorsTwentyFourHourThrottle() {
         val db = handler.mParticleDBManager
+        // The sweep must succeed so the throttle arms; otherwise every call retries.
+        Mockito.`when`(db.deleteRecordsOlderThan(Mockito.anyLong())).thenReturn(true)
         val t0 = 1_000_000_000_000L
 
         // First call always runs the sweep.
@@ -213,8 +215,10 @@ class UploadHandlerTest {
     fun testMaybePrunePersistedRecordsRetriesAfterFailure() {
         val db = handler.mParticleDBManager
 
-        // Phase 1 - deleteRecordsOlderThan throws; throttle must NOT be armed.
-        Mockito.doThrow(RuntimeException("boom")).`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
+        // Phase 1 - deleteRecordsOlderThan reports failure (false); throttle must NOT be armed.
+        // This models the real contract: MParticleDBManager.deleteRecordsOlderThan catches
+        // SQL exceptions internally and signals failure via its return value.
+        Mockito.`when`(db.deleteRecordsOlderThan(Mockito.anyLong())).thenReturn(false)
         val t1 = 1_000_000_000_000L
         handler.maybePrunePersistedRecords(t1)
         Mockito.verify(db, Mockito.times(1)).deleteRecordsOlderThan(Mockito.anyLong())
@@ -224,7 +228,7 @@ class UploadHandlerTest {
         Mockito.verify(db, Mockito.times(2)).deleteRecordsOlderThan(Mockito.anyLong())
 
         // Phase 3 - successful sweep arms the throttle.
-        Mockito.doNothing().`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
+        Mockito.`when`(db.deleteRecordsOlderThan(Mockito.anyLong())).thenReturn(true)
         handler.maybePrunePersistedRecords(t1 + 120_000L)
         Mockito.verify(db, Mockito.times(3)).deleteRecordsOlderThan(Mockito.anyLong())
 

--- a/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
@@ -131,6 +131,30 @@ class UploadHandlerTest {
     }
 
     @Test
+    fun testMaybePrunePersistedRecordsRetriesAfterFailure() {
+        val db = handler.mParticleDBManager
+
+        // Phase 1 - deleteRecordsOlderThan throws; throttle must NOT be armed.
+        Mockito.doThrow(RuntimeException("boom")).`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
+        val t1 = 1_000_000_000_000L
+        handler.maybePrunePersistedRecords(t1)
+        Mockito.verify(db, Mockito.times(1)).deleteRecordsOlderThan(Mockito.anyLong())
+
+        // Phase 2 - a minute later the sweep retries because the throttle was not armed.
+        handler.maybePrunePersistedRecords(t1 + 60_000L)
+        Mockito.verify(db, Mockito.times(2)).deleteRecordsOlderThan(Mockito.anyLong())
+
+        // Phase 3 - successful sweep arms the throttle.
+        Mockito.doNothing().`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
+        handler.maybePrunePersistedRecords(t1 + 120_000L)
+        Mockito.verify(db, Mockito.times(3)).deleteRecordsOlderThan(Mockito.anyLong())
+
+        // Phase 4 - a minute after the successful sweep the throttle short-circuits the call.
+        handler.maybePrunePersistedRecords(t1 + 180_000L)
+        Mockito.verify(db, Mockito.times(3)).deleteRecordsOlderThan(Mockito.anyLong())
+    }
+
+    @Test
     @Throws(Exception::class)
     fun testGetDeviceInfo() {
         val attributes =

--- a/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/UploadHandlerTest.kt
@@ -131,6 +131,85 @@ class UploadHandlerTest {
     }
 
     @Test
+    fun testMaybePrunePersistedRecordsUsesDefaultMaxAgeWhenUnconfigured() {
+        val db = Mockito.mock(MParticleDBManager::class.java)
+        val config = Mockito.mock(ConfigManager::class.java)
+        // Mockito's default Answer returns Integer.valueOf(0) for Integer wrapper return
+        // types, so stub null explicitly to model the "consumer did not configure a value"
+        // path. The production code must then fall back to DEFAULT_PERSISTENCE_MAX_AGE_MILLIS.
+        Mockito.doReturn(null).`when`(config).persistenceMaxAgeSeconds
+        val uploadHandler =
+            UploadHandler(
+                MockContext(),
+                config,
+                Mockito.mock(AppStateManager::class.java),
+                Mockito.mock(MessageManager::class.java),
+                db,
+                Mockito.mock(KitFrameworkWrapper::class.java),
+            )
+        val capturedCutoff = java.util.concurrent.atomic.AtomicLong(Long.MIN_VALUE)
+        Mockito.doAnswer { invocation ->
+            capturedCutoff.set(invocation.getArgument(0))
+            null
+        }.`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
+
+        val now = 1_700_000_000_000L
+        uploadHandler.maybePrunePersistedRecords(now)
+
+        Mockito.verify(db, Mockito.times(1)).deleteRecordsOlderThan(Mockito.anyLong())
+        Assert.assertEquals(
+            now - UploadHandler.DEFAULT_PERSISTENCE_MAX_AGE_MILLIS,
+            capturedCutoff.get(),
+        )
+    }
+
+    @Test
+    fun testMaybePrunePersistedRecordsUsesConfiguredMaxAge() {
+        val db = Mockito.mock(MParticleDBManager::class.java)
+        val config = Mockito.mock(ConfigManager::class.java)
+        // 1 hour retention window -> cutoff should be exactly now - 3_600_000 ms.
+        // Guards the seconds-to-millis conversion in maybePrunePersistedRecords.
+        Mockito.`when`(config.persistenceMaxAgeSeconds).thenReturn(3600)
+        val uploadHandler =
+            UploadHandler(
+                MockContext(),
+                config,
+                Mockito.mock(AppStateManager::class.java),
+                Mockito.mock(MessageManager::class.java),
+                db,
+                Mockito.mock(KitFrameworkWrapper::class.java),
+            )
+        val capturedCutoff = java.util.concurrent.atomic.AtomicLong(Long.MIN_VALUE)
+        Mockito.doAnswer { invocation ->
+            capturedCutoff.set(invocation.getArgument(0))
+            null
+        }.`when`(db).deleteRecordsOlderThan(Mockito.anyLong())
+
+        val now = 1_700_000_000_000L
+        uploadHandler.maybePrunePersistedRecords(now)
+
+        Assert.assertEquals(now - 3_600_000L, capturedCutoff.get())
+    }
+
+    @Test
+    fun testMaybePrunePersistedRecordsHonorsTwentyFourHourThrottle() {
+        val db = handler.mParticleDBManager
+        val t0 = 1_000_000_000_000L
+
+        // First call always runs the sweep.
+        handler.maybePrunePersistedRecords(t0)
+        Mockito.verify(db, Mockito.times(1)).deleteRecordsOlderThan(Mockito.anyLong())
+
+        // One millisecond before the throttle interval expires - still a no-op.
+        handler.maybePrunePersistedRecords(t0 + UploadHandler.PERSISTENCE_CLEANUP_INTERVAL_MILLIS - 1L)
+        Mockito.verify(db, Mockito.times(1)).deleteRecordsOlderThan(Mockito.anyLong())
+
+        // Exactly at the throttle boundary - the sweep runs again.
+        handler.maybePrunePersistedRecords(t0 + UploadHandler.PERSISTENCE_CLEANUP_INTERVAL_MILLIS)
+        Mockito.verify(db, Mockito.times(2)).deleteRecordsOlderThan(Mockito.anyLong())
+    }
+
+    @Test
     fun testMaybePrunePersistedRecordsRetriesAfterFailure() {
         val db = handler.mParticleDBManager
 


### PR DESCRIPTION
## Background

The iOS mParticle SDK exposes `MParticleOptions.persistenceMaxAgeSeconds`, which caps the age of locally persisted events, batches, and sessions to prevent unbounded on-device storage growth. The Android SDK had no equivalent — once data was written to the SQLite store it would sit there until the app either uploaded it or was uninstalled. For apps that batch heavily, go long stretches offline, or see users who rarely background the app, this can produce noticeable storage bloat and a slow drift toward larger database files. TRIAGE-608 was opened to close this feature-parity gap and document it on the Android configuration guide.

The companion iOS implementation lives in [`MPBackendController.cleanUp:`](https://github.com/mParticle/mparticle-apple-sdk/blob/main/mParticle-Apple-SDK/MPBackendController.m) and [`MPPersistenceController deleteRecordsOlderThan:`](https://github.com/mParticle/mparticle-apple-sdk/blob/main/mParticle-Apple-SDK/Persistence/MPPersistenceController.mm), which is the behavioral spec this change mirrors.

## What Has Changed

**Public API**
- Adds `MParticleOptions.Builder#persistenceMaxAgeSeconds(int seconds)` and the matching getter `MParticleOptions#getPersistenceMaxAgeSeconds()`. Units are seconds, values must be positive; zero or negative values log a warning and fall back to the default.

**Wiring**
- Threads the value through `ConfigManager` so the upload pipeline can read it at runtime.

**Age-based sweep**
- New `MParticleDBManager#deleteRecordsOlderThan(long cutoffMillis)` orchestrator wraps three new static helpers in a single transaction:
  - `MessageService#deleteMessagesOlderThan` — deletes from `MessageTableColumns.TABLE_NAME` where `created_at < ?`
  - `UploadService#deleteUploadsOlderThan` — deletes from `UploadTableColumns.TABLE_NAME` where `created_at < ?`
  - `SessionService#deleteSessionsOlderThan` — deletes from `SessionTableColumns.TABLE_NAME` where `end_time < ?`
- `UploadHandler#upload()` now calls `maybePrunePersistedRecords(now)` at the start of each cycle. The sweep is throttled to run at most **once every 24 hours** and defaults to a **90-day** retention window when `persistenceMaxAgeSeconds` is unset — matching the iOS defaults precisely.

**Tests**
- `MParticleOptionsTest#testPersistenceMaxAgeSeconds` covers null/positive/zero/negative inputs on the builder.
- `MessageServiceTest#testDeleteMessagesOlderThan` verifies the SQL cutoff semantics (strictly `<` cutoff are deleted; rows at or newer than the cutoff are retained).

## Screenshots/Video

N/A — this is a configuration/storage-hygiene change with no UI surface.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

Local validation against JDK 17: \`trunk check\`, \`./gradlew build\`, \`./gradlew test\`, \`./gradlew ktlintCheck\`, and \`./gradlew lint\` all pass. \`connectedAndroidTest\` was not run locally (no emulator available) — will rely on CI.

## Additional Notes

- **Defaults are intentionally conservative.** With no opt-in, behavior changes from *never-delete* to *delete rows older than 90 days*, applied at most once per 24 hours. This matches long-standing iOS behavior and is the same floor SonarCloud/Bugbot flagged as low-risk on this PR.
- **Hook site.** The sweep runs inside the existing upload cycle rather than in a dedicated lifecycle hook. If apps are observed that never trigger an upload (e.g., very short-lived sessions with no events), a follow-up can additionally invoke \`maybePrunePersistedRecords\` from \`AppStateManager#onActivityPaused\`; the 24h throttle already coordinates across call sites so this is a safe additive change.
- **Docs.** Public documentation is updated in companion PR [mparticle-by-rokt/docsite#3390](https://github.com/mparticle-by-rokt/docsite/pull/3390).

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes https://rokt.atlassian.net/browse/TRIAGE-608