### PR TITLE
Handle legacy persisted domain mappings safely

### DIFF
--- a/android-core/src/main/java/com/mparticle/networking/DomainMapping.java
+++ b/android-core/src/main/java/com/mparticle/networking/DomainMapping.java
@@ -326,7 +326,7 @@ public class DomainMapping {
                 JSONObject jsonObject = new JSONObject(jsonString);
                 int type = jsonObject.getInt("mType");
                 String newUrl = jsonObject.getString("url");
-                boolean overridesSubdirectory = jsonObject.getBoolean("overridesSubdirectory");
+                boolean overridesSubdirectory = jsonObject.optBoolean("overridesSubdirectory", false);
                 Builder builder = new Builder(Endpoint.parseInt(type), newUrl, overridesSubdirectory);
                 JSONArray certificatesJsonArray = jsonObject.getJSONArray("mCertificates");
                 for (int i = 0; i < certificatesJsonArray.length(); i++) {

--- a/android-core/src/main/java/com/mparticle/networking/NetworkOptions.java
+++ b/android-core/src/main/java/com/mparticle/networking/NetworkOptions.java
@@ -77,9 +77,12 @@ public class NetworkOptions {
             }
             JSONArray domainMappingsJson = jsonObject.getJSONArray("domainMappings");
             for (int i = 0; i < domainMappingsJson.length(); i++) {
-                builder.addDomainMapping(DomainMapping
-                        .withDomainMapping(domainMappingsJson.getString(i))
-                        .build());
+                DomainMapping.Builder domainMappingBuilder = DomainMapping.withDomainMapping(domainMappingsJson.getString(i));
+                if (domainMappingBuilder == null) {
+                    Logger.warning("NetworkOptions: skipping invalid persisted domain mapping at index " + i + ".");
+                    continue;
+                }
+                builder.addDomainMapping(domainMappingBuilder.build());
             }
         } catch (Exception e) {
             Logger.error(e);

--- a/android-core/src/test/kotlin/com/mparticle/networking/NetworkOptionsTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/networking/NetworkOptionsTest.kt
@@ -47,6 +47,50 @@ class NetworkOptionsTest {
         Assert.assertTrue(equals(options, optionsDeserialized))
     }
 
+    @Test
+    fun testLegacyDomainMappingWithoutOverridesSubdirectoryParses() {
+        val options =
+            NetworkOptions.withNetworkOptions(
+                """
+                {
+                  "disableDevPinning": false,
+                  "disablePinning": false,
+                  "domainMappings": [
+                    "{\"mType\":1,\"url\":\"www.configUrl.com\",\"mCertificates\":[]}"
+                  ]
+                }
+                """.trimIndent(),
+            )
+
+        Assert.assertNotNull(options)
+        Assert.assertNotNull(options!!.configDomain)
+        Assert.assertFalse(options.configDomain!!.isOverridesSubdirectory)
+        Assert.assertEquals("www.configUrl.com", options.configDomain!!.url)
+    }
+
+    @Test
+    fun testNetworkOptionsSkipsInvalidPersistedDomainMappings() {
+        val options =
+            NetworkOptions.withNetworkOptions(
+                """
+                {
+                  "disableDevPinning": false,
+                  "disablePinning": false,
+                  "domainMappings": [
+                    "{\"mType\":1,\"url\":\"www.configUrl.com\",\"overridesSubdirectory\":true,\"mCertificates\":[]}",
+                    "{\"mType\":1,\"url\":\"www.invalid.com\""
+                  ]
+                }
+                """.trimIndent(),
+            )
+
+        Assert.assertNotNull(options)
+        Assert.assertNotNull(options!!.configDomain)
+        Assert.assertEquals(1, options.domainMappings.size)
+        Assert.assertTrue(options.configDomain!!.isOverridesSubdirectory)
+        Assert.assertEquals("www.configUrl.com", options.configDomain!!.url)
+    }
+
     companion object {
         fun equals(
             networkOptions1: NetworkOptions,


### PR DESCRIPTION
## Background
- This issue appears to have been introduced after [#588](https://github.com/mParticle/mparticle-android-sdk/pull/588), where persisted `DomainMapping` parsing began expecting `overridesSubdirectory` to always be present.
- Users upgrading from older Android SDK versions can still have persisted `UploadSettings` / `NetworkOptions` JSON containing legacy `domainMappings` entries that do not include `overridesSubdirectory`.
- In mParticle logs, this surfaced as:
  - `No value for overridesSubdirectory`
  - `Attempt to invoke virtual method 'com.mparticle.networking.DomainMapping com.mparticle.networking.DomainMapping$Builder.build()' on a null object reference`
- The current parser expected `overridesSubdirectory` to always be present, which caused legacy entries to fail parsing.
- In the persisted `NetworkOptions` flow, that parse failure could produce a null `DomainMapping.Builder`, and the subsequent `.build()` call could trigger a null object reference crash.
- Because these values are read from persisted upload settings, affected users could continue seeing repeated failures until the stale rows were replaced.

## What Has Changed
- Updated `DomainMapping` JSON parsing to use a backward-compatible default of `false` when `overridesSubdirectory` is missing.
- Hardened `NetworkOptions` parsing so invalid persisted domain mapping entries are skipped instead of crashing the entire parse flow.
- Added regression tests covering:
  - legacy persisted `DomainMapping` JSON without `overridesSubdirectory`
  - `NetworkOptions` JSON with one valid persisted mapping and one invalid mapping

## Screenshots/Video
- Not applicable for this change.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
- Local validation run:
  - `./gradlew :android-core:testDebugUnitTest --tests com.mparticle.networking.NetworkOptionsTest`
- The fix is intentionally minimal and additive to preserve backward compatibility and avoid API changes.
