### PR TITLE
docs: add v6 Rokt migration guidance

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -331,3 +331,69 @@ val state = ConsentState.builder()
 
 ConsentState.builder().removeCCPAConsentState()
 ```
+
+---
+
+### Rokt API moved from `android-core` to `rokt-kit`
+
+Rokt APIs are now owned by the Rokt kit module. Usage remains the same (`MParticle.getInstance().Rokt()`); update imports to use the kit package types.
+
+Kotlin:
+
+```kotlin
+// Before
+import com.mparticle.Rokt
+
+val rokt = MParticle.getInstance()?.Rokt()
+
+// After
+import com.mparticle.kits.Rokt
+
+val rokt = MParticle.getInstance()?.Rokt()
+```
+
+Java:
+
+```java
+// Before
+com.mparticle.Rokt rokt = MParticle.getInstance().Rokt();
+
+// After
+com.mparticle.kits.Rokt rokt = MParticle.getInstance().Rokt();
+```
+
+---
+
+### Rokt wrapper types replaced with native Rokt SDK types
+
+The following mParticle wrapper types were removed:
+
+- `com.mparticle.RoktEvent`
+- `com.mparticle.MpRoktEventCallback`
+- `com.mparticle.rokt.RoktConfig`
+- `com.mparticle.rokt.PlacementOptions`
+
+Use native Rokt SDK types instead:
+
+- `com.rokt.roktsdk.RoktEvent`
+- `com.rokt.roktsdk.Rokt.RoktCallback`
+- `com.rokt.roktsdk.RoktConfig`
+- `com.rokt.roktsdk.PlacementOptions`
+
+Kotlin:
+
+```kotlin
+// Before
+val callback = object : MpRoktEventCallback { /* ... */ }
+val config = com.mparticle.rokt.RoktConfig.Builder().build()
+
+// After
+val callback = object : com.rokt.roktsdk.Rokt.RoktCallback { /* ... */ }
+val config = com.rokt.roktsdk.RoktConfig.Builder().build()
+```
+
+---
+
+### `Rokt.prepareAttributesAsync(...)` is no longer public API
+
+`prepareAttributesAsync` is now internal to the kit implementation and should not be called directly from app code.


### PR DESCRIPTION
## Background
Adds v6 migration guidance for Rokt API ownership and type updates so integrators can move to the new kit-owned API surface without changing call flow.

## What Has Changed
- Documented that Rokt APIs are now owned by `rokt-kit` while access remains `MParticle.getInstance().Rokt()`
- Added mapping from removed mParticle Rokt wrapper types to native `com.rokt.roktsdk` types
- Clarified that imports should use `com.mparticle.kits.Rokt` for app-facing code
- Documented that `Rokt.prepareAttributesAsync(...)` is internal and no longer public API

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes
Documentation-only change.