### PR TITLE
fix(ci): pin isolated-kit gradle version to prevent 6.0.0-rc.1 pull

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -245,9 +245,12 @@ jobs:
         run: ./gradlew publishReleaseLocal
       - name: "Run Android Kit Lint"
         run: ./gradlew publishReleaseLocal -c settings-kits.gradle lint
+      - name: "Get SDK version for isolated kits"
+        id: sdk-version
+        run: echo "version=$(./gradlew -q properties | grep '^version:' | awk '{print $2}')" >> $GITHUB_OUTPUT
       - name: "Run Isolated Kit Lint (urbanairship-kit)"
         working-directory: kits/urbanairship-kit
-        run: ./gradlew lint
+        run: ./gradlew -Pversion=${{ steps.sdk-version.outputs.version }} lint
       - name: "Archive Test Results"
         uses: actions/upload-artifact@v7
         if: always()
@@ -284,9 +287,12 @@ jobs:
         run: ./gradlew publishReleaseLocal
       - name: "Run Android Kit Kotlin Lint"
         run: ./gradlew publishReleaseLocal -c settings-kits.gradle ktlintCheck
+      - name: "Get SDK version for isolated kits"
+        id: sdk-version
+        run: echo "version=$(./gradlew -q properties | grep '^version:' | awk '{print $2}')" >> $GITHUB_OUTPUT
       - name: "Run Isolated Kit Kotlin Lint (urbanairship-kit)"
         working-directory: kits/urbanairship-kit
-        run: ./gradlew ktlintCheck
+        run: ./gradlew -Pversion=${{ steps.sdk-version.outputs.version }} ktlintCheck
       - name: "Archive Test Results"
         uses: actions/upload-artifact@v7
         if: always()
@@ -326,9 +332,12 @@ jobs:
         run: ./gradlew -PisRelease=true clean publishReleaseLocal
       - name: "Test Kits"
         run: ./gradlew -PisRelease=true clean testRelease publishReleaseLocal -c settings-kits.gradle
+      - name: "Get SDK version for isolated kits"
+        id: sdk-version
+        run: echo "version=$(./gradlew -PisRelease=true -q properties | grep '^version:' | awk '{print $2}')" >> $GITHUB_OUTPUT
       - name: "Test Isolated Kits (urbanairship-kit)"
         working-directory: kits/urbanairship-kit
-        run: ./gradlew -PisRelease=true clean testRelease publishReleaseLocal
+        run: ./gradlew -PisRelease=true -Pversion=${{ steps.sdk-version.outputs.version }} clean testRelease publishReleaseLocal
 
   semantic-release-dryrun:
     name: "Test Semantic Release - Dry Run"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -254,9 +254,12 @@ jobs:
         run: ./gradlew -PisRelease=true :android-kit-base:testRelease
       - name: "Run Kit Release Tests and Build"
         run: ./gradlew -PisRelease=true -p kits testRelease -c ../settings-kits.gradle
+      - name: "Get SDK version for isolated kits"
+        id: sdk-version
+        run: echo "version=$(./gradlew -PisRelease=true -q properties | grep '^version:' | awk '{print $2}')" >> $GITHUB_OUTPUT
       - name: "Run Isolated Kit Compatibility Tests (urbanairship-kit)"
         working-directory: kits/urbanairship-kit
-        run: ./gradlew -PisRelease=true testRelease
+        run: ./gradlew -PisRelease=true -Pversion=${{ steps.sdk-version.outputs.version }} testRelease
 
   automerge-dependabot:
     name: "Save PR Number for Dependabot Automerge"


### PR DESCRIPTION
## Summary

- Pin the standalone `urbanairship-kit` build invocations in `daily.yml` and `pull-request.yml` to the SDK version we're currently building, so they no longer resolve `+` to `com.mparticle:android-kit-plugin:6.0.0-rc.1` on Maven Central.
- Mirrors the pattern already used by `release.yml`'s Sonatype Release job.

## Why

The 2026-05-27 release run failed with two distinct errors, both in the urbanairship-kit isolated steps:

```
Run regression / Lint Checks → Run Isolated Kit Lint (urbanairship-kit)
  e: UrbanAirshipKit.kt:31:20 Unresolved reference 'AttributeListener'.
  e: 8× "overrides nothing"

Run regression / Update Kits → Test Isolated Kits (urbanairship-kit)
  Task 'publishReleaseLocal' not found in root project 'android-urbanairship-kit'.
```

Root cause: the kit's standalone `build.gradle` defaults `project.version = '+'`. With `6.0.0-rc.1` published to Maven Central on 2026-05-22, `+` resolves to the RC, which renamed `KitIntegration.AttributeListener` → `ModifyIdentityListener` and replaced the kit-plugin's task layout. The fix is to pass `-Pversion=<sdk-version>` so the kit resolves the freshly-published `mavenLocal` artifact instead.

Every PR's `Kit Compatibility Test` has been silently red since 2026-05-22 for the same reason.

## Companion changes

Defense-in-depth pin on the kit's standalone `project.version`:
- mparticle-integrations/mparticle-android-integration-urbanairship#193 + 32 other kit repos (fleet-wide).

External-consumer fixes for [#710](https://github.com/mParticle/mparticle-android-sdk/issues/710):
- mParticle/react-native-mparticle#329
- mParticle/cordova-plugin-mparticle#89
- mParticle/mparticle-android-media-sdk#77
- mParticle/mparticle-android-sample-apps#300

## Test plan

- [ ] Trigger the `Release SDK` workflow (dry run). `Lint Checks`, `Kotlin Lint Checks`, and `Update Kits` should all pass through the urbanairship-kit isolated step.
- [ ] Open a no-op PR to verify `Kit Compatibility Test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)