### PR TITLE
feat: add device-based consent to override MPID-scoped consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,200 +1,179 @@
-## [5.79.2](https://github.com/mParticle/mparticle-android-sdk/compare/v5.79.1...v5.79.2) (2026-06-22)
+## Unreleased
 
+### Added
+
+- Add device-based consent APIs (`MParticle.getDeviceConsentState()`, `MParticle.setDeviceConsentState()`) and `MParticleOptions.Builder.deviceBasedConsentEnabled()` so consent can be stored and applied at the device level, overriding MPID-based consent for kit forwarding rules and event uploads.
+
+## [5.79.2](https://github.com/mParticle/mparticle-android-sdk/compare/v5.79.1...v5.79.2) (2026-06-22)
 
 ### Updates & Maintenance
 
-* bump actions/checkout from 6.0.2 to 6.0.3 ([#720](https://github.com/mParticle/mparticle-android-sdk/issues/720)) ([d904edb](https://github.com/mParticle/mparticle-android-sdk/commit/d904edb0a944a2ce813e7dc31c026f0b2f7ccecb))
-* remove cross-platform-tests and semantic PR/branch checks ([#712](https://github.com/mParticle/mparticle-android-sdk/issues/712)) ([6cdacf2](https://github.com/mParticle/mparticle-android-sdk/commit/6cdacf2926e02e2359352dbcf12b4e4bb66236fa))
-* Update submodules ([976dd0d](https://github.com/mParticle/mparticle-android-sdk/commit/976dd0d13d6aa27f805a6b06a73d923f1a207e80))
+- bump actions/checkout from 6.0.2 to 6.0.3 ([#720](https://github.com/mParticle/mparticle-android-sdk/issues/720)) ([d904edb](https://github.com/mParticle/mparticle-android-sdk/commit/d904edb0a944a2ce813e7dc31c026f0b2f7ccecb))
+- remove cross-platform-tests and semantic PR/branch checks ([#712](https://github.com/mParticle/mparticle-android-sdk/issues/712)) ([6cdacf2](https://github.com/mParticle/mparticle-android-sdk/commit/6cdacf2926e02e2359352dbcf12b4e4bb66236fa))
+- Update submodules ([976dd0d](https://github.com/mParticle/mparticle-android-sdk/commit/976dd0d13d6aa27f805a6b06a73d923f1a207e80))
 
 ## [5.79.1](https://github.com/mParticle/mparticle-android-sdk/compare/v5.79.0...v5.79.1) (2026-05-27)
 
-
 ### Bug Fixes
 
-* **ci:** pin isolated-kit gradle version to prevent 6.0.0-rc.1 pull ([#714](https://github.com/mParticle/mparticle-android-sdk/issues/714)) ([eff10ea](https://github.com/mParticle/mparticle-android-sdk/commit/eff10ead69167f0ea3df248b2bbed089397600cd))
-
+- **ci:** pin isolated-kit gradle version to prevent 6.0.0-rc.1 pull ([#714](https://github.com/mParticle/mparticle-android-sdk/issues/714)) ([eff10ea](https://github.com/mParticle/mparticle-android-sdk/commit/eff10ead69167f0ea3df248b2bbed089397600cd))
 
 ### Updates & Maintenance
 
-* bump trunk-io/trunk-action from 1.2.4 to 1.3.1 ([#705](https://github.com/mParticle/mparticle-android-sdk/issues/705)) ([f4ceca7](https://github.com/mParticle/mparticle-android-sdk/commit/f4ceca7de2c2ba01ea87c98698ef7bb84991b4ab))
-* Update submodules ([e435979](https://github.com/mParticle/mparticle-android-sdk/commit/e435979e1e966ef2b318bb29135852f9d55df55a))
+- bump trunk-io/trunk-action from 1.2.4 to 1.3.1 ([#705](https://github.com/mParticle/mparticle-android-sdk/issues/705)) ([f4ceca7](https://github.com/mParticle/mparticle-android-sdk/commit/f4ceca7de2c2ba01ea87c98698ef7bb84991b4ab))
+- Update submodules ([e435979](https://github.com/mParticle/mparticle-android-sdk/commit/e435979e1e966ef2b318bb29135852f9d55df55a))
 
 ## [5.79.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.78.5...v5.79.0) (2026-05-14)
 
-
 ### Features
 
-* add customBaseURL CNAME support to NetworkOptions ([#701](https://github.com/mParticle/mparticle-android-sdk/issues/701)) ([5285149](https://github.com/mParticle/mparticle-android-sdk/commit/5285149118b58cbd5cf4fb90cb58627deb7538b9)), closes [mparticle-apple-sdk#760](https://github.com/mParticle/mparticle-apple-sdk/issues/760)
-* Add max persistence age override option [TRIAGE-608] ([#699](https://github.com/mParticle/mparticle-android-sdk/issues/699)) ([ca88322](https://github.com/mParticle/mparticle-android-sdk/commit/ca88322ac7ef8649ed111cf28afb81d99cdb271a))
-
+- add customBaseURL CNAME support to NetworkOptions ([#701](https://github.com/mParticle/mparticle-android-sdk/issues/701)) ([5285149](https://github.com/mParticle/mparticle-android-sdk/commit/5285149118b58cbd5cf4fb90cb58627deb7538b9)), closes [mparticle-apple-sdk#760](https://github.com/mParticle/mparticle-apple-sdk/issues/760)
+- Add max persistence age override option [TRIAGE-608] ([#699](https://github.com/mParticle/mparticle-android-sdk/issues/699)) ([ca88322](https://github.com/mParticle/mparticle-android-sdk/commit/ca88322ac7ef8649ed111cf28afb81d99cdb271a))
 
 ### Bug Fixes
 
-* increase MPLatch timeout from 5s to 30s ([#695](https://github.com/mParticle/mparticle-android-sdk/issues/695)) ([20f723f](https://github.com/mParticle/mparticle-android-sdk/commit/20f723f27cf296c879ceebc9d234edca039ab371))
-
+- increase MPLatch timeout from 5s to 30s ([#695](https://github.com/mParticle/mparticle-android-sdk/issues/695)) ([20f723f](https://github.com/mParticle/mparticle-android-sdk/commit/20f723f27cf296c879ceebc9d234edca039ab371))
 
 ### Updates & Maintenance
 
-* Update submodules ([59a4a9a](https://github.com/mParticle/mparticle-android-sdk/commit/59a4a9a68e3addfaf5c4eea1afd396889721819d))
+- Update submodules ([59a4a9a](https://github.com/mParticle/mparticle-android-sdk/commit/59a4a9a68e3addfaf5c4eea1afd396889721819d))
 
 ## [5.78.5](https://github.com/mParticle/mparticle-android-sdk/compare/v5.78.4...v5.78.5) (2026-03-25)
 
-
 ### Updates & Maintenance
 
-* Update submodules ([86d8d97](https://github.com/mParticle/mparticle-android-sdk/commit/86d8d9748a0c7a796dd0b0be6722f92acef301ea))
+- Update submodules ([86d8d97](https://github.com/mParticle/mparticle-android-sdk/commit/86d8d9748a0c7a796dd0b0be6722f92acef301ea))
 
 ## [5.78.4](https://github.com/mParticle/mparticle-android-sdk/compare/v5.78.3...v5.78.4) (2026-03-23)
 
-
 ### Updates & Maintenance
 
-* Update submodules ([08dab75](https://github.com/mParticle/mparticle-android-sdk/commit/08dab75e3715733f6f5655fbf39fbce16a2e01a2))
+- Update submodules ([08dab75](https://github.com/mParticle/mparticle-android-sdk/commit/08dab75e3715733f6f5655fbf39fbce16a2e01a2))
 
 ## [5.78.3](https://github.com/mParticle/mparticle-android-sdk/compare/v5.78.2...v5.78.3) (2026-03-11)
 
-
 ### Updates & Maintenance
 
-* bump actions/upload-artifact from 6 to 7 ([#649](https://github.com/mParticle/mparticle-android-sdk/issues/649)) ([0a188b1](https://github.com/mParticle/mparticle-android-sdk/commit/0a188b1f88efde471f8d6bff2aa8611b1b4bf956))
-* Update submodules ([cbb17d7](https://github.com/mParticle/mparticle-android-sdk/commit/cbb17d7e359d41d8d7577a9516cf7788c7288442))
+- bump actions/upload-artifact from 6 to 7 ([#649](https://github.com/mParticle/mparticle-android-sdk/issues/649)) ([0a188b1](https://github.com/mParticle/mparticle-android-sdk/commit/0a188b1f88efde471f8d6bff2aa8611b1b4bf956))
+- Update submodules ([cbb17d7](https://github.com/mParticle/mparticle-android-sdk/commit/cbb17d7e359d41d8d7577a9516cf7788c7288442))
 
 ## [5.78.2](https://github.com/mParticle/mparticle-android-sdk/compare/v5.78.1...v5.78.2) (2026-02-27)
 
-
 ### Bug Fixes
 
-* ci - use Gradle properties for SDK version extraction in release ([63b39e7](https://github.com/mParticle/mparticle-android-sdk/commit/63b39e71ec952735ac26bf10dbe4f3968120e371))
+- ci - use Gradle properties for SDK version extraction in release ([63b39e7](https://github.com/mParticle/mparticle-android-sdk/commit/63b39e71ec952735ac26bf10dbe4f3968120e371))
 
 ## [5.78.1](https://github.com/mParticle/mparticle-android-sdk/compare/v5.78.0...v5.78.1) (2026-02-27)
 
-
 ### Updates & Maintenance
 
-* Add AGENTS file ([#646](https://github.com/mParticle/mparticle-android-sdk/issues/646)) ([8e227fd](https://github.com/mParticle/mparticle-android-sdk/commit/8e227fd256d36bdcc92cfd58ecf81806e15d3c56))
-* add isolated kit support for urbanairship-kit ([#647](https://github.com/mParticle/mparticle-android-sdk/issues/647)) ([2b24344](https://github.com/mParticle/mparticle-android-sdk/commit/2b24344cb338e9704a4cce2bc204eb32c8213492))
-* Update submodules ([0200c4c](https://github.com/mParticle/mparticle-android-sdk/commit/0200c4c5b74f17ac55663651e80f6dfae84fe12d))
+- Add AGENTS file ([#646](https://github.com/mParticle/mparticle-android-sdk/issues/646)) ([8e227fd](https://github.com/mParticle/mparticle-android-sdk/commit/8e227fd256d36bdcc92cfd58ecf81806e15d3c56))
+- add isolated kit support for urbanairship-kit ([#647](https://github.com/mParticle/mparticle-android-sdk/issues/647)) ([2b24344](https://github.com/mParticle/mparticle-android-sdk/commit/2b24344cb338e9704a4cce2bc204eb32c8213492))
+- Update submodules ([0200c4c](https://github.com/mParticle/mparticle-android-sdk/commit/0200c4c5b74f17ac55663651e80f6dfae84fe12d))
 
 ## [5.78.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.77.0...v5.78.0) (2026-02-12)
 
-
 ### Features
 
-* Add PlacementOptions support to Rokt integration ([#639](https://github.com/mParticle/mparticle-android-sdk/issues/639)) ([61cc472](https://github.com/mParticle/mparticle-android-sdk/commit/61cc472fc42c0871380345cc74ba57a4d949310c))
-
+- Add PlacementOptions support to Rokt integration ([#639](https://github.com/mParticle/mparticle-android-sdk/issues/639)) ([61cc472](https://github.com/mParticle/mparticle-android-sdk/commit/61cc472fc42c0871380345cc74ba57a4d949310c))
 
 ### Updates & Maintenance
 
-* Update submodules ([91191f6](https://github.com/mParticle/mparticle-android-sdk/commit/91191f64db292fe6a58de2c8ba1cd786e0e0a509))
+- Update submodules ([91191f6](https://github.com/mParticle/mparticle-android-sdk/commit/91191f64db292fe6a58de2c8ba1cd786e0e0a509))
 
 ## [5.77.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.76.1...v5.77.0) (2026-02-03)
 
-
 ### Features
 
-* Add support for Get / Set SessionId on Rokt ([#645](https://github.com/mParticle/mparticle-android-sdk/issues/645)) ([2956a05](https://github.com/mParticle/mparticle-android-sdk/commit/2956a0547f93914e89e34c70f22820f0a3ea26ba))
-
+- Add support for Get / Set SessionId on Rokt ([#645](https://github.com/mParticle/mparticle-android-sdk/issues/645)) ([2956a05](https://github.com/mParticle/mparticle-android-sdk/commit/2956a0547f93914e89e34c70f22820f0a3ea26ba))
 
 ### Bug Fixes
 
-* Validate js-sdk-file input for Gradle 8 compatibility ([#644](https://github.com/mParticle/mparticle-android-sdk/issues/644)) ([2725387](https://github.com/mParticle/mparticle-android-sdk/commit/2725387df98c77dff9bf251fb528fc8241f4409c))
-
+- Validate js-sdk-file input for Gradle 8 compatibility ([#644](https://github.com/mParticle/mparticle-android-sdk/issues/644)) ([2725387](https://github.com/mParticle/mparticle-android-sdk/commit/2725387df98c77dff9bf251fb528fc8241f4409c))
 
 ### Updates & Maintenance
 
-* Update submodules ([d5d503f](https://github.com/mParticle/mparticle-android-sdk/commit/d5d503fe8443222777d08bbe667696402753a8b8))
+- Update submodules ([d5d503f](https://github.com/mParticle/mparticle-android-sdk/commit/d5d503fe8443222777d08bbe667696402753a8b8))
 
 ## [5.76.1](https://github.com/mParticle/mparticle-android-sdk/compare/v5.76.0...v5.76.1) (2026-01-29)
 
-
 ### Updates & Maintenance
 
-* bump actions/checkout from 6.0.1 to 6.0.2 ([#641](https://github.com/mParticle/mparticle-android-sdk/issues/641)) ([227b421](https://github.com/mParticle/mparticle-android-sdk/commit/227b4218fef761a82fe10ca0e0fdd5668b0f4979))
-* Update submodules ([e6dbcb8](https://github.com/mParticle/mparticle-android-sdk/commit/e6dbcb8f57d491d1e43457dca2f44b192ad5be29))
+- bump actions/checkout from 6.0.1 to 6.0.2 ([#641](https://github.com/mParticle/mparticle-android-sdk/issues/641)) ([227b421](https://github.com/mParticle/mparticle-android-sdk/commit/227b4218fef761a82fe10ca0e0fdd5668b0f4979))
+- Update submodules ([e6dbcb8](https://github.com/mParticle/mparticle-android-sdk/commit/e6dbcb8f57d491d1e43457dca2f44b192ad5be29))
 
 ## [5.76.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.75.1...v5.76.0) (2026-01-27)
 
-
 ### Features
 
-* Add trunk rule to detect mParticle API keys ([#633](https://github.com/mParticle/mparticle-android-sdk/issues/633)) ([3f3c79f](https://github.com/mParticle/mparticle-android-sdk/commit/3f3c79faf8b6ee8bff407428c8f11839e75faa2e))
-* Update Android Gradle plugin to 8.1.0 ([#575](https://github.com/mParticle/mparticle-android-sdk/issues/575)) ([fc6a25d](https://github.com/mParticle/mparticle-android-sdk/commit/fc6a25d354d180fc2e7a59e2a80b57880c608891))
-
+- Add trunk rule to detect mParticle API keys ([#633](https://github.com/mParticle/mparticle-android-sdk/issues/633)) ([3f3c79f](https://github.com/mParticle/mparticle-android-sdk/commit/3f3c79faf8b6ee8bff407428c8f11839e75faa2e))
+- Update Android Gradle plugin to 8.1.0 ([#575](https://github.com/mParticle/mparticle-android-sdk/issues/575)) ([fc6a25d](https://github.com/mParticle/mparticle-android-sdk/commit/fc6a25d354d180fc2e7a59e2a80b57880c608891))
 
 ### Bug Fixes
 
-* Align ktlint rules for kits with Android Studio defaults ([#640](https://github.com/mParticle/mparticle-android-sdk/issues/640)) ([e5484a0](https://github.com/mParticle/mparticle-android-sdk/commit/e5484a0fcafed11852c580c6f3cc5e27db0934fb))
-* migrate all generic logs to Logger class ([#630](https://github.com/mParticle/mparticle-android-sdk/issues/630)) ([9c9cb33](https://github.com/mParticle/mparticle-android-sdk/commit/9c9cb338424bf2f95038ed2456014f12bb7fe9b3))
-* Override ktlint rules for kits to avoid editorconfig conflicts ([#642](https://github.com/mParticle/mparticle-android-sdk/issues/642)) ([e31027a](https://github.com/mParticle/mparticle-android-sdk/commit/e31027a9fe70f483fd188a97641aa53fffeddbb3))
-
+- Align ktlint rules for kits with Android Studio defaults ([#640](https://github.com/mParticle/mparticle-android-sdk/issues/640)) ([e5484a0](https://github.com/mParticle/mparticle-android-sdk/commit/e5484a0fcafed11852c580c6f3cc5e27db0934fb))
+- migrate all generic logs to Logger class ([#630](https://github.com/mParticle/mparticle-android-sdk/issues/630)) ([9c9cb33](https://github.com/mParticle/mparticle-android-sdk/commit/9c9cb338424bf2f95038ed2456014f12bb7fe9b3))
+- Override ktlint rules for kits to avoid editorconfig conflicts ([#642](https://github.com/mParticle/mparticle-android-sdk/issues/642)) ([e31027a](https://github.com/mParticle/mparticle-android-sdk/commit/e31027a9fe70f483fd188a97641aa53fffeddbb3))
 
 ### Updates & Maintenance
 
-* bump actions/cache from 4 to 5 ([#635](https://github.com/mParticle/mparticle-android-sdk/issues/635)) ([fb471fa](https://github.com/mParticle/mparticle-android-sdk/commit/fb471fa5ffec283a03fd629ee2758262a726582e))
-* bump actions/checkout from 5 to 6 ([#631](https://github.com/mParticle/mparticle-android-sdk/issues/631)) ([a0b2442](https://github.com/mParticle/mparticle-android-sdk/commit/a0b24424aaa43808a4fdac028d82cc4db8d40262))
-* bump actions/checkout from 5.0.0 to 6.0.1 ([#637](https://github.com/mParticle/mparticle-android-sdk/issues/637)) ([449a0b5](https://github.com/mParticle/mparticle-android-sdk/commit/449a0b5c22293bfe21336002cf2835eb81c8a1af))
-* bump actions/setup-java from 4 to 5 ([#625](https://github.com/mParticle/mparticle-android-sdk/issues/625)) ([46823b8](https://github.com/mParticle/mparticle-android-sdk/commit/46823b8d1174bdb5345483ab43407bbe82e34f88))
-* bump actions/upload-artifact from 5 to 6 ([#636](https://github.com/mParticle/mparticle-android-sdk/issues/636)) ([05f6133](https://github.com/mParticle/mparticle-android-sdk/commit/05f6133f5e69f1bc1d331fd4772e8f4134fec539))
-* Remove empty workflow file ([#634](https://github.com/mParticle/mparticle-android-sdk/issues/634)) ([0780abd](https://github.com/mParticle/mparticle-android-sdk/commit/0780abd0387a4b8281e0c8432180813719f080ad))
-* Update submodules ([d6bf37f](https://github.com/mParticle/mparticle-android-sdk/commit/d6bf37f7ad63f467efeb7c706c40841be48fbc5b))
+- bump actions/cache from 4 to 5 ([#635](https://github.com/mParticle/mparticle-android-sdk/issues/635)) ([fb471fa](https://github.com/mParticle/mparticle-android-sdk/commit/fb471fa5ffec283a03fd629ee2758262a726582e))
+- bump actions/checkout from 5 to 6 ([#631](https://github.com/mParticle/mparticle-android-sdk/issues/631)) ([a0b2442](https://github.com/mParticle/mparticle-android-sdk/commit/a0b24424aaa43808a4fdac028d82cc4db8d40262))
+- bump actions/checkout from 5.0.0 to 6.0.1 ([#637](https://github.com/mParticle/mparticle-android-sdk/issues/637)) ([449a0b5](https://github.com/mParticle/mparticle-android-sdk/commit/449a0b5c22293bfe21336002cf2835eb81c8a1af))
+- bump actions/setup-java from 4 to 5 ([#625](https://github.com/mParticle/mparticle-android-sdk/issues/625)) ([46823b8](https://github.com/mParticle/mparticle-android-sdk/commit/46823b8d1174bdb5345483ab43407bbe82e34f88))
+- bump actions/upload-artifact from 5 to 6 ([#636](https://github.com/mParticle/mparticle-android-sdk/issues/636)) ([05f6133](https://github.com/mParticle/mparticle-android-sdk/commit/05f6133f5e69f1bc1d331fd4772e8f4134fec539))
+- Remove empty workflow file ([#634](https://github.com/mParticle/mparticle-android-sdk/issues/634)) ([0780abd](https://github.com/mParticle/mparticle-android-sdk/commit/0780abd0387a4b8281e0c8432180813719f080ad))
+- Update submodules ([d6bf37f](https://github.com/mParticle/mparticle-android-sdk/commit/d6bf37f7ad63f467efeb7c706c40841be48fbc5b))
 
 ## [5.75.1](https://github.com/mParticle/mparticle-android-sdk/compare/v5.75.0...v5.75.1) (2025-11-20)
 
-
 ### Updates & Maintenance
 
-* restore rokt-kit submodule ([#629](https://github.com/mParticle/mparticle-android-sdk/issues/629)) ([6bd0fba](https://github.com/mParticle/mparticle-android-sdk/commit/6bd0fbae72d1f587deb32fdda60612c0f90c6540))
+- restore rokt-kit submodule ([#629](https://github.com/mParticle/mparticle-android-sdk/issues/629)) ([6bd0fba](https://github.com/mParticle/mparticle-android-sdk/commit/6bd0fbae72d1f587deb32fdda60612c0f90c6540))
 
 ## [5.75.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.74.3...v5.75.0) (2025-11-20)
 
-
 ### Features
 
-* Implement Trunk tool ([#604](https://github.com/mParticle/mparticle-android-sdk/issues/604)) ([d02a125](https://github.com/mParticle/mparticle-android-sdk/commit/d02a1252ef7d08513cbdb8e53cd759755be2ef5d))
-
+- Implement Trunk tool ([#604](https://github.com/mParticle/mparticle-android-sdk/issues/604)) ([d02a125](https://github.com/mParticle/mparticle-android-sdk/commit/d02a1252ef7d08513cbdb8e53cd759755be2ef5d))
 
 ### Updates & Maintenance
 
-* add token to checkout step for regression branch pushes ([#627](https://github.com/mParticle/mparticle-android-sdk/issues/627)) ([afe965e](https://github.com/mParticle/mparticle-android-sdk/commit/afe965edd8ec1eda5ca1864e0df0dde535092567))
-* bump andymckay/cancel-action from 435124153eb37d6a62a29d053a7e449652f89d51 to a955d435292c0d409d104b57d8e78435a93a6ef1 ([#624](https://github.com/mParticle/mparticle-android-sdk/issues/624)) ([2f1644a](https://github.com/mParticle/mparticle-android-sdk/commit/2f1644a5a88053f60cb5696ff471fcfd9b1a4321))
-* bump reactivecircus/android-emulator-runner from 2.34.0 to 2.35.0 ([#626](https://github.com/mParticle/mparticle-android-sdk/issues/626)) ([8f4b392](https://github.com/mParticle/mparticle-android-sdk/commit/8f4b3927b63cd8dd80e6ae703f50ad49982de634))
-* update permissions to allow branch push and delete operations ([#628](https://github.com/mParticle/mparticle-android-sdk/issues/628)) ([d66079d](https://github.com/mParticle/mparticle-android-sdk/commit/d66079dc78ad8dbe8ab09415bf9a5af43528b4aa))
+- add token to checkout step for regression branch pushes ([#627](https://github.com/mParticle/mparticle-android-sdk/issues/627)) ([afe965e](https://github.com/mParticle/mparticle-android-sdk/commit/afe965edd8ec1eda5ca1864e0df0dde535092567))
+- bump andymckay/cancel-action from 435124153eb37d6a62a29d053a7e449652f89d51 to a955d435292c0d409d104b57d8e78435a93a6ef1 ([#624](https://github.com/mParticle/mparticle-android-sdk/issues/624)) ([2f1644a](https://github.com/mParticle/mparticle-android-sdk/commit/2f1644a5a88053f60cb5696ff471fcfd9b1a4321))
+- bump reactivecircus/android-emulator-runner from 2.34.0 to 2.35.0 ([#626](https://github.com/mParticle/mparticle-android-sdk/issues/626)) ([8f4b392](https://github.com/mParticle/mparticle-android-sdk/commit/8f4b3927b63cd8dd80e6ae703f50ad49982de634))
+- update permissions to allow branch push and delete operations ([#628](https://github.com/mParticle/mparticle-android-sdk/issues/628)) ([d66079d](https://github.com/mParticle/mparticle-android-sdk/commit/d66079dc78ad8dbe8ab09415bf9a5af43528b4aa))
 
 ## [5.74.3](https://github.com/mParticle/mparticle-android-sdk/compare/v5.74.2...v5.74.3) (2025-11-04)
 
-
 ### Updates & Maintenance
 
-* Add step to ensure deployment visibility ([#611](https://github.com/mParticle/mparticle-android-sdk/issues/611)) ([9b5af9e](https://github.com/mParticle/mparticle-android-sdk/commit/9b5af9e2ddc761dfe8552d5801fe1bac38df2a8e))
-* bump actions/cache from 3 to 4 ([#622](https://github.com/mParticle/mparticle-android-sdk/issues/622)) ([7c46e93](https://github.com/mParticle/mparticle-android-sdk/commit/7c46e9320bc94f1ce72c9786fdcca0ddd89dd661))
-* bump actions/checkout from 3 to 5 ([#617](https://github.com/mParticle/mparticle-android-sdk/issues/617)) ([59fd344](https://github.com/mParticle/mparticle-android-sdk/commit/59fd34423643f25aea5b0e5aac35256d789e7c86))
-* bump actions/upload-artifact from 4 to 5 ([#614](https://github.com/mParticle/mparticle-android-sdk/issues/614)) ([d4f7882](https://github.com/mParticle/mparticle-android-sdk/commit/d4f788229a363fd150a9f43895d8e32425db0f64))
-* bump crazy-max/ghaction-import-gpg from 6.0.0 to 6.3.0 ([#615](https://github.com/mParticle/mparticle-android-sdk/issues/615)) ([8881009](https://github.com/mParticle/mparticle-android-sdk/commit/88810095bd87f945d8476c66999b54aead05c758))
-* bump reactivecircus/android-emulator-runner from 2.33.0 to 2.34.0 ([#623](https://github.com/mParticle/mparticle-android-sdk/issues/623)) ([15a16a8](https://github.com/mParticle/mparticle-android-sdk/commit/15a16a8275f29bb0f4e7a6239bed5d88d7c969f5))
-* Enable Dependabot for Github Actions ([#608](https://github.com/mParticle/mparticle-android-sdk/issues/608)) ([0174ff2](https://github.com/mParticle/mparticle-android-sdk/commit/0174ff2483636bd519f2f597aefc2d19f4db9d5c))
-* Remove target branch check ([#610](https://github.com/mParticle/mparticle-android-sdk/issues/610)) ([ac69641](https://github.com/mParticle/mparticle-android-sdk/commit/ac696417774da8c1f30593bc8c1b5d0e01f0c18a))
-* Update submodules ([ec57498](https://github.com/mParticle/mparticle-android-sdk/commit/ec57498a5fc007a2f99f3183046093452d8d461e))
+- Add step to ensure deployment visibility ([#611](https://github.com/mParticle/mparticle-android-sdk/issues/611)) ([9b5af9e](https://github.com/mParticle/mparticle-android-sdk/commit/9b5af9e2ddc761dfe8552d5801fe1bac38df2a8e))
+- bump actions/cache from 3 to 4 ([#622](https://github.com/mParticle/mparticle-android-sdk/issues/622)) ([7c46e93](https://github.com/mParticle/mparticle-android-sdk/commit/7c46e9320bc94f1ce72c9786fdcca0ddd89dd661))
+- bump actions/checkout from 3 to 5 ([#617](https://github.com/mParticle/mparticle-android-sdk/issues/617)) ([59fd344](https://github.com/mParticle/mparticle-android-sdk/commit/59fd34423643f25aea5b0e5aac35256d789e7c86))
+- bump actions/upload-artifact from 4 to 5 ([#614](https://github.com/mParticle/mparticle-android-sdk/issues/614)) ([d4f7882](https://github.com/mParticle/mparticle-android-sdk/commit/d4f788229a363fd150a9f43895d8e32425db0f64))
+- bump crazy-max/ghaction-import-gpg from 6.0.0 to 6.3.0 ([#615](https://github.com/mParticle/mparticle-android-sdk/issues/615)) ([8881009](https://github.com/mParticle/mparticle-android-sdk/commit/88810095bd87f945d8476c66999b54aead05c758))
+- bump reactivecircus/android-emulator-runner from 2.33.0 to 2.34.0 ([#623](https://github.com/mParticle/mparticle-android-sdk/issues/623)) ([15a16a8](https://github.com/mParticle/mparticle-android-sdk/commit/15a16a8275f29bb0f4e7a6239bed5d88d7c969f5))
+- Enable Dependabot for Github Actions ([#608](https://github.com/mParticle/mparticle-android-sdk/issues/608)) ([0174ff2](https://github.com/mParticle/mparticle-android-sdk/commit/0174ff2483636bd519f2f597aefc2d19f4db9d5c))
+- Remove target branch check ([#610](https://github.com/mParticle/mparticle-android-sdk/issues/610)) ([ac69641](https://github.com/mParticle/mparticle-android-sdk/commit/ac696417774da8c1f30593bc8c1b5d0e01f0c18a))
+- Update submodules ([ec57498](https://github.com/mParticle/mparticle-android-sdk/commit/ec57498a5fc007a2f99f3183046093452d8d461e))
 
 ## [5.74.2](https://github.com/mParticle/mparticle-android-sdk/compare/v5.74.1...v5.74.2) (2025-10-28)
 
-
 ### Updates & Maintenance
 
-* Update submodules ([c0b4106](https://github.com/mParticle/mparticle-android-sdk/commit/c0b4106618780ee0e80bff12ce9a042c19da81dc))
+- Update submodules ([c0b4106](https://github.com/mParticle/mparticle-android-sdk/commit/c0b4106618780ee0e80bff12ce9a042c19da81dc))
 
 ## [5.74.1](https://github.com/mParticle/mparticle-android-sdk/compare/v5.74.0...v5.74.1) (2025-10-21)
 
-
 ### Bug Fixes
 
-* Add proguard rules to prevent stripping of Rokt class ([#607](https://github.com/mParticle/mparticle-android-sdk/issues/607)) ([18ef17b](https://github.com/mParticle/mparticle-android-sdk/commit/18ef17bdf23e388f736814b5d9f579af3258229c))
-
+- Add proguard rules to prevent stripping of Rokt class ([#607](https://github.com/mParticle/mparticle-android-sdk/issues/607)) ([18ef17b](https://github.com/mParticle/mparticle-android-sdk/commit/18ef17bdf23e388f736814b5d9f579af3258229c))
 
 ### Updates & Maintenance
 
-* Change release to use main branch ([#609](https://github.com/mParticle/mparticle-android-sdk/issues/609)) ([7d41cc3](https://github.com/mParticle/mparticle-android-sdk/commit/7d41cc3230ea4df8f6d4b639414e5afa66705828))
-* Update submodules ([e233046](https://github.com/mParticle/mparticle-android-sdk/commit/e233046a09d4de845d4cf4a7bf75d03dcb12aa3b))
+- Change release to use main branch ([#609](https://github.com/mParticle/mparticle-android-sdk/issues/609)) ([7d41cc3](https://github.com/mParticle/mparticle-android-sdk/commit/7d41cc3230ea4df8f6d4b639414e5afa66705828))
+- Update submodules ([e233046](https://github.com/mParticle/mparticle-android-sdk/commit/e233046a09d4de845d4cf4a7bf75d03dcb12aa3b))
 
 ## [5.74.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.73.2...v5.74.0) (2025-09-23)
 

--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 import com.mparticle.commerce.CommerceEvent;
+import com.mparticle.consent.ConsentState;
 import com.mparticle.identity.IdentityApi;
 import com.mparticle.identity.IdentityApiRequest;
 import com.mparticle.identity.IdentityApiResult;
@@ -909,6 +910,48 @@ public class MParticle {
             }
             mKitManager.setOptOut(optOutStatus);
         }
+    }
+
+    /**
+     * Query the device-level consent state.
+     * <p>
+     * Device-level consent, when set, overrides MPID-based consent when applying consent forwarding
+     * rules and uploading events.
+     *
+     * @return the device-level consent state, or an empty state if none has been set
+     */
+    @NonNull
+    public ConsentState getDeviceConsentState() {
+        return mConfigManager.getDeviceConsentState();
+    }
+
+    /**
+     * Set the device-level consent state.
+     * <p>
+     * Device-level consent overrides MPID-based consent when applying consent forwarding rules
+     * and uploading events. Pass {@code null} to clear the device-level override and fall back to
+     * MPID-based consent.
+     *
+     * @param state the device-level consent state, or {@code null} to clear the override
+     */
+    public void setDeviceConsentState(@Nullable ConsentState state) {
+        ConsentState oldState = mConfigManager.getEffectiveConsentState(mConfigManager.getMpid());
+        mConfigManager.setDeviceConsentState(state);
+        ConsentState newState = mConfigManager.getEffectiveConsentState(mConfigManager.getMpid());
+        mKitManager.onConsentStateUpdated(oldState, newState, mConfigManager.getMpid());
+    }
+
+    /**
+     * Query whether device-based consent is enabled.
+     * <p>
+     * When enabled, {@link com.mparticle.identity.MParticleUser#setConsentState(ConsentState)}
+     * also persists consent at the device level.
+     *
+     * @return true if device-based consent is enabled
+     */
+    @NonNull
+    public Boolean isDeviceBasedConsentEnabled() {
+        return mConfigManager.isDeviceBasedConsentEnabled();
     }
 
     /**

--- a/android-core/src/main/java/com/mparticle/MParticleOptions.java
+++ b/android-core/src/main/java/com/mparticle/MParticleOptions.java
@@ -38,6 +38,7 @@ public class MParticleOptions {
     private String mApiSecret;
     private IdentityApiRequest mIdentifyRequest;
     private Boolean mDevicePerformanceMetricsDisabled = false;
+    private Boolean mDeviceBasedConsentEnabled = false;
     private Boolean mAndroidIdEnabled = false;
     private Integer mUploadInterval = ConfigManager.DEFAULT_UPLOAD_INTERVAL;  //seconds
     private Integer mSessionTimeout = ConfigManager.DEFAULT_SESSION_TIMEOUT_SECONDS; //seconds
@@ -92,6 +93,9 @@ public class MParticleOptions {
         }
         if (builder.devicePerformanceMetricsDisabled != null) {
             this.mDevicePerformanceMetricsDisabled = builder.devicePerformanceMetricsDisabled;
+        }
+        if (builder.deviceBasedConsentEnabled != null) {
+            this.mDeviceBasedConsentEnabled = builder.deviceBasedConsentEnabled;
         }
         if (builder.androidIdEnabled != null) {
             this.mAndroidIdEnabled = builder.androidIdEnabled;
@@ -252,6 +256,20 @@ public class MParticleOptions {
     @NonNull
     public Boolean isDevicePerformanceMetricsDisabled() {
         return mDevicePerformanceMetricsDisabled;
+    }
+
+    /**
+     * Query whether device-based consent is enabled.
+     * <p>
+     * When enabled, {@link com.mparticle.identity.MParticleUser#setConsentState(ConsentState)}
+     * will persist consent at the device level in addition to the current MPID. Device-level
+     * consent overrides MPID-based consent when applying consent forwarding rules and uploading events.
+     *
+     * @return true if device-based consent is enabled
+     */
+    @NonNull
+    public Boolean isDeviceBasedConsentEnabled() {
+        return mDeviceBasedConsentEnabled;
     }
 
     /**
@@ -423,6 +441,7 @@ public class MParticleOptions {
         private MParticle.Environment environment;
         private IdentityApiRequest identifyRequest;
         private Boolean devicePerformanceMetricsDisabled = null;
+        private Boolean deviceBasedConsentEnabled = null;
         private Boolean androidIdEnabled = null;
         private Integer uploadInterval = null;
         private Integer sessionTimeout = null;
@@ -567,6 +586,23 @@ public class MParticleOptions {
         @NonNull
         public Builder devicePerformanceMetricsDisabled(boolean disabled) {
             this.devicePerformanceMetricsDisabled = disabled;
+            return this;
+        }
+
+        /**
+         * Enable device-based consent.
+         * <p>
+         * When enabled, consent set via {@link com.mparticle.identity.MParticleUser#setConsentState(ConsentState)}
+         * is stored at the device level and overrides MPID-based consent when applying consent forwarding
+         * rules and uploading events. This is useful when consent is collected before the user's MPID is known
+         * or when the MPID changes during a flow such as checkout.
+         *
+         * @param enabled true to enable device-based consent
+         * @return the instance of the builder, for chaining calls
+         */
+        @NonNull
+        public Builder deviceBasedConsentEnabled(boolean enabled) {
+            this.deviceBasedConsentEnabled = enabled;
             return this;
         }
 

--- a/android-core/src/main/java/com/mparticle/identity/MParticleUserDelegate.java
+++ b/android-core/src/main/java/com/mparticle/identity/MParticleUserDelegate.java
@@ -276,13 +276,17 @@ class MParticleUserDelegate {
     }
 
     public ConsentState getConsentState(long mpid) {
-        return mConfigManager.getConsentState(mpid);
+        return mConfigManager.getEffectiveConsentState(mpid);
     }
 
     public void setConsentState(ConsentState state, long mpid) {
         ConsentState oldState = getConsentState(mpid);
         mConfigManager.setConsentState(state, mpid);
-        mKitManager.onConsentStateUpdated(oldState, state, mpid);
+        if (mConfigManager.isDeviceBasedConsentEnabled()) {
+            mConfigManager.setDeviceConsentState(state);
+        }
+        ConsentState newState = getConsentState(mpid);
+        mKitManager.onConsentStateUpdated(oldState, newState, mpid);
     }
 
     public boolean isLoggedIn(Long mpid) {

--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -91,6 +91,7 @@ public class ConfigManager {
     private UserStorage mUserStorage;
     private String mLogUnhandledExceptions = VALUE_APP_DEFINED;
     private boolean audienceAPIFlag = false;
+    private boolean mDeviceBasedConsentEnabled = false;
 
     private boolean mSendOoEvents;
     private JSONObject mProviderPersistence;
@@ -134,11 +135,13 @@ public class ConfigManager {
     public ConfigManager(Context context) {
         mContext = context;
         sPreferences = getPreferences(mContext);
+        mDeviceBasedConsentEnabled = sPreferences.getBoolean(Constants.PrefKeys.DEVICE_BASED_CONSENT_ENABLED, false);
     }
 
     public ConfigManager(@NonNull MParticleOptions options) {
         this(options.getContext(), options.getEnvironment(), options.getApiKey(), options.getApiSecret(), options.getDataplanOptions(), options.getDataplanId(), options.getDataplanVersion(), options.getConfigMaxAge(), options.getConfigurationsForTarget(ConfigManager.class), options.getSideloadedKits());
         mPersistenceMaxAgeSeconds = options.getPersistenceMaxAgeSeconds();
+        setDeviceBasedConsentEnabled(options.isDeviceBasedConsentEnabled());
     }
 
     /**
@@ -177,6 +180,7 @@ public class ConfigManager {
                 configuration.apply(this);
             }
         }
+        mDeviceBasedConsentEnabled = sPreferences.getBoolean(Constants.PrefKeys.DEVICE_BASED_CONSENT_ENABLED, false);
     }
 
     public void onMParticleStarted() {
@@ -1333,6 +1337,50 @@ public class ConfigManager {
     public ConsentState getConsentState(long mpid) {
         String serializedConsent = getUserStorage(mpid).getSerializedConsentState();
         return ConsentState.withConsentState(serializedConsent).build();
+    }
+
+    public boolean isDeviceBasedConsentEnabled() {
+        return mDeviceBasedConsentEnabled;
+    }
+
+    public void setDeviceBasedConsentEnabled(boolean deviceBasedConsentEnabled) {
+        mDeviceBasedConsentEnabled = deviceBasedConsentEnabled;
+        sPreferences.edit()
+                .putBoolean(Constants.PrefKeys.DEVICE_BASED_CONSENT_ENABLED, deviceBasedConsentEnabled)
+                .apply();
+    }
+
+    public boolean hasDeviceConsentOverride() {
+        return sPreferences.contains(Constants.PrefKeys.DEVICE_CONSENT_STATE);
+    }
+
+    @NonNull
+    public ConsentState getDeviceConsentState() {
+        if (!hasDeviceConsentOverride()) {
+            return ConsentState.withConsentState((String) null).build();
+        }
+        String serializedConsent = sPreferences.getString(Constants.PrefKeys.DEVICE_CONSENT_STATE, null);
+        return ConsentState.withConsentState(serializedConsent).build();
+    }
+
+    public void setDeviceConsentState(@Nullable ConsentState state) {
+        if (state != null) {
+            sPreferences.edit()
+                    .putString(Constants.PrefKeys.DEVICE_CONSENT_STATE, state.toString())
+                    .apply();
+        } else {
+            sPreferences.edit()
+                    .remove(Constants.PrefKeys.DEVICE_CONSENT_STATE)
+                    .apply();
+        }
+    }
+
+    @NonNull
+    public ConsentState getEffectiveConsentState(long mpid) {
+        if (hasDeviceConsentOverride()) {
+            return getDeviceConsentState();
+        }
+        return getConsentState(mpid);
     }
 
     public boolean isDirectUrlRoutingEnabled() {

--- a/android-core/src/main/java/com/mparticle/internal/MessageBatch.java
+++ b/android-core/src/main/java/com/mparticle/internal/MessageBatch.java
@@ -54,7 +54,7 @@ public class MessageBatch extends JSONObject {
         uploadMessage.put(Constants.MessageKey.COOKIES, cookies);
         uploadMessage.put(Constants.MessageKey.PROVIDER_PERSISTENCE, configManager.getProviderPersistence());
         uploadMessage.put(Constants.MessageKey.INTEGRATION_ATTRIBUTES, configManager.getIntegrationAttributes());
-        uploadMessage.addConsentState(configManager.getConsentState(batchId.getMpid()));
+        uploadMessage.addConsentState(configManager.getEffectiveConsentState(batchId.getMpid()));
         uploadMessage.addDataplanContext(batchId.getDataplanId(), batchId.getDataplanVersion());
         return uploadMessage;
     }

--- a/android-core/src/main/kotlin/com/mparticle/internal/Constants.kt
+++ b/android-core/src/main/kotlin/com/mparticle/internal/Constants.kt
@@ -608,6 +608,8 @@ object Constants {
             const val IF_MODIFIED: String = "mp::ifmodified"
             const val IDENTITY_API_CONTEXT: String = "mp::identity::api::context"
             const val DEVICE_APPLICATION_STAMP: String = "mp::device-app-stamp"
+            const val DEVICE_CONSENT_STATE: String = "mp::device::consent"
+            const val DEVICE_BASED_CONSENT_ENABLED: String = "mp::device::consent::enabled"
             const val PREVIOUS_ANDROID_ID: String = "mp::previous::android::id"
             const val DISPLAY_PUSH_NOTIFICATIONS: String = "mp::displaypushnotifications"
             const val IDENTITY_CONNECTION_TIMEOUT: String = "mp::connection:timeout:identity"

--- a/android-core/src/test/kotlin/com/mparticle/external/ApiVisibilityTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/external/ApiVisibilityTest.kt
@@ -17,7 +17,7 @@ class ApiVisibilityTest {
                 publicMethodCount++
             }
         }
-        Assert.assertEquals(66, publicMethodCount)
+        Assert.assertEquals(69, publicMethodCount)
     }
 
     @Test

--- a/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
@@ -2,6 +2,8 @@ package com.mparticle.internal
 
 import com.mparticle.MParticle
 import com.mparticle.MockMParticle
+import com.mparticle.consent.ConsentState
+import com.mparticle.consent.GDPRConsent
 import com.mparticle.internal.KitManager.KitStatus
 import com.mparticle.internal.PushRegistrationHelper.PushRegistration
 import com.mparticle.internal.messages.BaseMPMessage
@@ -727,6 +729,40 @@ class ConfigManagerTest {
         Assert.assertEquals("my ETag", manager.etag)
         Assert.assertEquals("12345", manager.ifModified)
         Assert.assertNotNull(manager.configTimestamp)
+    }
+
+    @Test
+    fun testDeviceConsentOverridesMpidConsent() {
+        val mpid = ran.nextLong()
+        val mpidConsent = ConsentState.builder()
+            .addGDPRConsentState("mpid-purpose", GDPRConsent.builder(false).build())
+            .build()
+        val deviceConsent = ConsentState.builder()
+            .addGDPRConsentState("device-purpose", GDPRConsent.builder(true).build())
+            .build()
+
+        manager.setConsentState(mpidConsent, mpid)
+        Assert.assertFalse(manager.hasDeviceConsentOverride())
+        Assert.assertTrue(manager.getEffectiveConsentState(mpid).gdprConsentState.containsKey("mpid-purpose"))
+
+        manager.setDeviceConsentState(deviceConsent)
+        Assert.assertTrue(manager.hasDeviceConsentOverride())
+        Assert.assertTrue(manager.getEffectiveConsentState(mpid).gdprConsentState.containsKey("device-purpose"))
+        Assert.assertFalse(manager.getEffectiveConsentState(mpid).gdprConsentState.containsKey("mpid-purpose"))
+
+        manager.setDeviceConsentState(null)
+        Assert.assertFalse(manager.hasDeviceConsentOverride())
+        Assert.assertTrue(manager.getEffectiveConsentState(mpid).gdprConsentState.containsKey("mpid-purpose"))
+    }
+
+    @Test
+    fun testDeviceBasedConsentEnabledPersists() {
+        Assert.assertFalse(manager.isDeviceBasedConsentEnabled())
+        manager.setDeviceBasedConsentEnabled(true)
+        Assert.assertTrue(manager.isDeviceBasedConsentEnabled())
+
+        val reloadedManager = ConfigManager(context)
+        Assert.assertTrue(reloadedManager.isDeviceBasedConsentEnabled())
     }
 
     companion object {


### PR DESCRIPTION
# Add device-level consent state

## Summary

Adds a **device-level consent state** that, when set, supersedes user/MPID-level consent everywhere consent is evaluated. Previously consent could only be recorded per-user (per-MPID), meaning consent decisions were lost across identity changes and couldn't represent a single device-wide choice. This adds an optional device-scoped consent that takes precedence over per-user consent.

When device consent is set, it overrides user/MPID-level consent for:

* **Kit enablement** — consent forwarding rule evaluation (`shouldIncludeFromConsentRules`)
* **Consent forwarding to kits** — `onConsentStateUpdated` forwarded calls
* **Uploads** — the consent block included in batches, for all MPIDs

It is persisted device-wide (independent of the active MPID, stored in app-level `SharedPreferences`) and setting it triggers the same kit refresh as a user consent change. Set it to `null` to clear and revert to user/MPID-level consent.

`MParticleOptions.deviceBasedConsentEnabled(true)` additionally mirrors `MParticleUser.setConsentState()` into device storage, so existing consent-prompt code continues to work without changes when the MPID changes during checkout.

## How it works

A new `getEffectiveConsentState(mpid)` on `ConfigManager` is the single resolution point: it returns the device consent if present, otherwise falls back to the per-MPID consent. All consent-evaluation call sites now route through it.

`deviceBasedConsentEnabled` is persisted across launches. When enabled, `MParticleUserDelegate.setConsentState()` writes to both MPID storage and device storage so consent collected on an anonymous profile is retained after identity changes.

## Sample code

**Enable device mirroring at startup (recommended for consent-before-login flows):**

```java
MParticleOptions options = MParticleOptions.builder(context)
        .credentials("KEY", "SECRET")
        .deviceBasedConsentEnabled(true)
        .build();

MParticle.start(options);
```

```kotlin
val options = MParticleOptions.builder(context)
    .credentials("KEY", "SECRET")
    .deviceBasedConsentEnabled(true)
    .build()

MParticle.start(options)
```

**Set / update / clear at runtime:**

```java
// Set device-wide consent (supersedes any per-user consent)
ConsentState consent = ConsentState.builder()
        .addGDPRConsentState("data_sharing", GDPRConsent.builder(true)
                .document("privacy_policy_v3")
                .build())
        .build();
MParticle.getInstance().setDeviceConsentState(consent);

// Clear it — reverts to user/MPID-level consent
MParticle.getInstance().setDeviceConsentState(null);
```

```kotlin
// Set device-wide consent (supersedes any per-user consent)
val consent = ConsentState.builder()
    .addGDPRConsentState(
        "data_sharing",
        GDPRConsent.builder(true).document("privacy_policy_v3").build(),
    )
    .build()
MParticle.getInstance().setDeviceConsentState(consent)

// Clear it — reverts to user/MPID-level consent
MParticle.getInstance().setDeviceConsentState(null)
```

## Testing

Added unit tests covering device-consent override precedence and flag persistence (`ConfigManagerTest`), and updated the public API surface count (`ApiVisibilityTest`).

Related iOS PR: https://github.com/mParticle/mparticle-apple-sdk/pull/784