### PR TITLE
fix: Wait for User Attributes to persist before Rokt selectPlacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## [5.80.0](https://github.com/mParticle/mparticle-android-sdk/compare/v5.79.2...v5.80.0) (2026-06-25)
 
-
 ### Features
 
-* add device-based consent to override MPID-scoped consent ([#726](https://github.com/mParticle/mparticle-android-sdk/issues/726)) ([e92d352](https://github.com/mParticle/mparticle-android-sdk/commit/e92d3522a350be90a1f15eb3b81d5e6f089f1aed))
+- add device-based consent to override MPID-scoped consent ([#726](https://github.com/mParticle/mparticle-android-sdk/issues/726)) ([e92d352](https://github.com/mParticle/mparticle-android-sdk/commit/e92d3522a350be90a1f15eb3b81d5e6f089f1aed))
 
 ## Unreleased
+
+### Fixed
+
+- Restore async wait for user attributes to persist before Rokt `selectPlacements` delegates to the kit, fixing a regression where placement attributes could be missing in mParticle and Rokt.
 
 ### Added
 

--- a/android-kit-base/src/main/kotlin/com/mparticle/kits/RoktKitApiImpl.kt
+++ b/android-kit-base/src/main/kotlin/com/mparticle/kits/RoktKitApiImpl.kt
@@ -4,6 +4,7 @@ import android.graphics.Typeface
 import com.mparticle.MParticle
 import com.mparticle.MpRoktEventCallback
 import com.mparticle.RoktEvent
+import com.mparticle.TypedUserAttributeListener
 import com.mparticle.identity.IdentityApi
 import com.mparticle.identity.IdentityApiRequest
 import com.mparticle.identity.MParticleUser
@@ -50,17 +51,20 @@ internal class RoktKitApiImpl(private val roktListener: KitIntegration.RoktListe
             val kitConfig = kitIntegration.configuration
 
             confirmEmail(email, hashedEmail, user, instance.Identity(), kitConfig) {
-                val finalAttributes = prepareAttributes(mutableAttributes, user)
-                roktListener.selectPlacements(
-                    viewName,
-                    finalAttributes,
-                    mpRoktEventCallback,
-                    placeHolders,
-                    fontTypefaces,
-                    FilteredMParticleUser.getInstance(user?.id ?: 0L, kitIntegration),
-                    config,
-                    options,
-                )
+                val finalAttributes = applyPlacementAttributeMapping(mutableAttributes)
+                setRoktAttributesOnUser(finalAttributes, user) {
+                    ensureSandboxMode(finalAttributes)
+                    roktListener.selectPlacements(
+                        viewName,
+                        finalAttributes,
+                        mpRoktEventCallback,
+                        placeHolders,
+                        fontTypefaces,
+                        FilteredMParticleUser.getInstance(user?.id ?: 0L, kitIntegration),
+                        config,
+                        options,
+                    )
+                }
             }
         } catch (e: Exception) {
             Logger.warning("Failed to call execute for Rokt Kit: ${e.message}")
@@ -115,16 +119,19 @@ internal class RoktKitApiImpl(private val roktListener: KitIntegration.RoktListe
                 return
             }
             val user = instance.Identity().currentUser
-            val email = mutableAttributes["email"]
+            val email = getValueIgnoreCase(mutableAttributes, "email")
             val hashedEmail = getValueIgnoreCase(mutableAttributes, "emailsha256")
             val kitConfig = kitIntegration.configuration
 
             confirmEmail(email, hashedEmail, user, instance.Identity(), kitConfig) {
-                val finalAttributes = prepareAttributes(mutableAttributes, user)
-                roktListener.enrichAttributes(
-                    finalAttributes,
-                    FilteredMParticleUser.getInstance(user?.id ?: 0L, kitIntegration),
-                )
+                val finalAttributes = applyPlacementAttributeMapping(mutableAttributes)
+                setRoktAttributesOnUser(finalAttributes, user) {
+                    ensureSandboxMode(finalAttributes)
+                    roktListener.enrichAttributes(
+                        finalAttributes,
+                        FilteredMParticleUser.getInstance(user?.id ?: 0L, kitIntegration),
+                    )
+                }
             }
         } catch (e: Exception) {
             Logger.warning("Failed to call prepareAttributesAsync for Rokt Kit: ${e.message}")
@@ -142,7 +149,7 @@ internal class RoktKitApiImpl(private val roktListener: KitIntegration.RoktListe
         return null
     }
 
-    private fun prepareAttributes(finalAttributes: MutableMap<String, String>, user: MParticleUser?): MutableMap<String, String> {
+    private fun applyPlacementAttributeMapping(attributes: MutableMap<String, String>): MutableMap<String, String> {
         val kitConfig = kitIntegration.configuration
         val jsonArray = try {
             kitConfig?.placementAttributesMapping ?: org.json.JSONArray()
@@ -155,27 +162,51 @@ internal class RoktKitApiImpl(private val roktListener: KitIntegration.RoktListe
             val obj = jsonArray.optJSONObject(i) ?: continue
             val mapFrom = obj.optString("map")
             val mapTo = obj.optString("value")
-            if (finalAttributes.containsKey(mapFrom)) {
-                val value = finalAttributes.remove(mapFrom)
+            if (attributes.containsKey(mapFrom)) {
+                val value = attributes.remove(mapFrom)
                 if (value != null) {
-                    finalAttributes[mapTo] = value
+                    attributes[mapTo] = value
                 }
             }
         }
+        return attributes
+    }
 
+    private fun ensureSandboxMode(finalAttributes: MutableMap<String, String>) {
+        if (!finalAttributes.containsKey(Constants.MessageKey.SANDBOX_MODE_ROKT)) {
+            finalAttributes[Constants.MessageKey.SANDBOX_MODE_ROKT] =
+                Objects.toString(MPUtility.isDevEnv(), "false")
+        }
+    }
+
+    /**
+     * Persists placement attributes on the mParticle user, then invokes [onReady] after the
+     * attributes have been applied. This ensures the Rokt kit reads an up-to-date user profile
+     * when merging attributes for the placement.
+     */
+    private fun setRoktAttributesOnUser(finalAttributes: Map<String, String>, user: MParticleUser?, onReady: Runnable) {
         val objectAttributes = mutableMapOf<String, Any>()
         for ((key, value) in finalAttributes) {
             if (key != Constants.MessageKey.SANDBOX_MODE_ROKT) {
                 objectAttributes[key] = value
             }
         }
-        user?.setUserAttributes(objectAttributes)
-
-        if (!finalAttributes.containsKey(Constants.MessageKey.SANDBOX_MODE_ROKT)) {
-            finalAttributes[Constants.MessageKey.SANDBOX_MODE_ROKT] =
-                Objects.toString(MPUtility.isDevEnv(), "false")
+        if (user != null) {
+            user.setUserAttributes(objectAttributes)
+            user.getUserAttributes(
+                object : TypedUserAttributeListener {
+                    override fun onUserAttributesReceived(
+                        userAttributes: Map<String, Any?>,
+                        userAttributeLists: Map<String, List<String?>?>,
+                        mpid: Long,
+                    ) {
+                        onReady.run()
+                    }
+                },
+            )
+        } else {
+            onReady.run()
         }
-        return finalAttributes
     }
 
     private fun confirmEmail(

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/KitManagerImplTest.kt
@@ -10,6 +10,7 @@ import com.mparticle.MParticle
 import com.mparticle.MParticleOptions
 import com.mparticle.MpRoktEventCallback
 import com.mparticle.RoktEvent
+import com.mparticle.TypedUserAttributeListener
 import com.mparticle.WrapperSdk
 import com.mparticle.WrapperSdkVersion
 import com.mparticle.commerce.CommerceEvent
@@ -1277,6 +1278,7 @@ class KitManagerImplTest {
     @Test
     fun testRokt_selectPlacements_with_PlacementOptions() {
         val mockUser = mock(MParticleUser::class.java)
+        stubUserAttributesCallback(mockUser)
         `when`(mockIdentity!!.currentUser).thenReturn(mockUser)
 
         val manager: KitManagerImpl = MockKitManagerImpl()
@@ -1315,6 +1317,7 @@ class KitManagerImplTest {
     @Test
     fun testRokt_selectPlacements_without_PlacementOptions() {
         val mockUser = mock(MParticleUser::class.java)
+        stubUserAttributesCallback(mockUser)
         `when`(mockIdentity!!.currentUser).thenReturn(mockUser)
 
         val manager: KitManagerImpl = MockKitManagerImpl()
@@ -1757,6 +1760,14 @@ class KitManagerImplTest {
         runTest {
             val elements = result.toList()
             assertTrue(elements.isEmpty())
+        }
+    }
+
+    private fun stubUserAttributesCallback(user: MParticleUser) {
+        `when`(user.getUserAttributes(any())).thenAnswer { invocation ->
+            val listener = invocation.arguments[0] as TypedUserAttributeListener
+            listener.onUserAttributesReceived(emptyMap(), emptyMap(), 0L)
+            null
         }
     }
 

--- a/android-kit-base/src/test/kotlin/com/mparticle/kits/RoktKitApiImplTest.kt
+++ b/android-kit-base/src/test/kotlin/com/mparticle/kits/RoktKitApiImplTest.kt
@@ -2,6 +2,7 @@ package com.mparticle.kits
 
 import com.mparticle.MParticle
 import com.mparticle.identity.IdentityApi
+import com.mparticle.identity.MParticleUser
 import com.mparticle.internal.MPUtility
 import com.mparticle.mock.MockMParticle
 import com.mparticle.rokt.PlacementOptions
@@ -15,6 +16,7 @@ import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.withSettings
@@ -80,6 +82,61 @@ class RoktKitApiImplTest {
         assertEquals("55555", captured["minorcatid"])
         assertEquals("US", captured["country"])
         assertEquals(MPUtility.isDevEnv().toString(), captured["sandbox"])
+    }
+
+    @Test
+    fun testSelectPlacements_waitsForUserAttributesBeforeDelegating() {
+        val kitConfig = KitConfiguration.createKitConfiguration(JSONObject().put("id", 42))
+        val kitIntegration =
+            mock(
+                KitIntegration::class.java,
+                withSettings().extraInterfaces(KitIntegration.RoktListener::class.java),
+            )
+        `when`(kitIntegration.configuration).thenReturn(kitConfig)
+        val roktListener = kitIntegration as KitIntegration.RoktListener
+        val roktApi = RoktKitApiImpl(roktListener, kitIntegration)
+
+        val identityApi = mock(IdentityApi::class.java)
+        val user = mock(MParticleUser::class.java)
+        `when`(user.id).thenReturn(12345L)
+        `when`(identityApi.currentUser).thenReturn(user)
+        val instance = MockMParticle()
+        instance.setIdentityApi(identityApi)
+        MParticle.setInstance(instance)
+
+        var capturedListener: com.mparticle.TypedUserAttributeListener? = null
+        `when`(user.getUserAttributes(any())).thenAnswer { invocation ->
+            capturedListener = invocation.arguments[0] as com.mparticle.TypedUserAttributeListener
+            null
+        }
+
+        val attributes = mapOf("country" to "US")
+        roktApi.selectPlacements("Test", attributes, null, null, null, null, null)
+
+        verify(user).setUserAttributes(any())
+        verify(roktListener, never()).selectPlacements(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+
+        capturedListener!!.onUserAttributesReceived(emptyMap(), emptyMap(), 12345L)
+
+        verify(roktListener).selectPlacements(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Background
- When selectPlacements is called, placement attributes are written to the mParticle user profile and then forwarded to the Rokt kit, which merges profile attributes with the passed-in map before calling Rokt.execute().
- A fix in [#585](https://github.com/mParticle/mparticle-android-sdk/pull/585) ensured those user attributes were persisted before the kit ran, but that async wait was lost when Rokt handling moved into RoktKitApiImpl in [#586](https://github.com/mParticle/mparticle-android-sdk/pull/586).
- As a result, clients could see placement attributes missing in both mParticle and Rokt, especially when the kit reads from the user profile (e.g. Compose / prepareAttributesAsync flows).

## What Has Changed
- Restored setRoktAttributesOnUser() in RoktKitApiImpl to persist placement attributes on the user and wait for TypedUserAttributeListener before delegating to the Rokt kit.
- Applied the same async wait to both selectPlacements and prepareAttributesAsync.
- Split attribute preparation into applyPlacementAttributeMapping(), ensureSandboxMode(), and setRoktAttributesOnUser() for clarity.
- Fixed case-sensitive email lookup in prepareAttributesAsync to use getValueIgnoreCase, matching selectPlacements.
- Added a unit test verifying the kit is not invoked until the user-attribute callback fires.

## Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[ticket-number]  
