### PR TITLE
fix(braze): correct example app applicationId to match push category

### DIFF
--- a/kits/braze/braze-38/example/build.gradle
+++ b/kits/braze/braze-38/example/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        applicationId "com.mparticle.com.mparticle.kits.braze.example"
+        applicationId "com.mparticle.kits.braze.example"
         minSdk 16
         targetSdk 31
         versionCode 1

--- a/kits/braze/braze-39/example/build.gradle
+++ b/kits/braze/braze-39/example/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        applicationId "com.mparticle.com.mparticle.kits.braze.example"
+        applicationId "com.mparticle.kits.braze.example"
         minSdk 16
         targetSdk 31
         versionCode 1

--- a/kits/braze/braze-40/example/build.gradle
+++ b/kits/braze/braze-40/example/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        applicationId "com.mparticle.com.mparticle.kits.braze.example"
+        applicationId "com.mparticle.kits.braze.example"
         minSdk 16
         targetSdk 31
         versionCode 1

--- a/kits/braze/braze-41/example/build.gradle
+++ b/kits/braze/braze-41/example/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        applicationId "com.mparticle.com.mparticle.kits.braze.example"
+        applicationId "com.mparticle.kits.braze.example"
         minSdk 16
         targetSdk 31
         versionCode 1


### PR DESCRIPTION
## What

The `braze-38`, `braze-39`, `braze-40`, and `braze-41` example apps set:

```groovy
applicationId "com.mparticle.com.mparticle.kits.braze.example"   // duplicated "com.mparticle." prefix
```

while their `AndroidManifest.xml` uses `package="com.mparticle.kits.braze.example"` and the `MPReceiver` FCM `<category>` is also `com.mparticle.kits.braze.example`.

Since the effective package at runtime equals the `applicationId`, the legacy FCM `com.google.android.c2dm.intent.RECEIVE` intent-filter category no longer matched the app id, so push registration/receipt in the **sample apps** could fail.

## Change

Corrects the `applicationId` to `com.mparticle.kits.braze.example` across all four tracks, so `applicationId` = manifest `package` = push category.

## Notes

- Sample-app-only change; no kit/runtime source or tests affected.
- Surfaced by Cursor Bugbot on the `braze-42` PR ([#728](https://github.com/mParticle/mparticle-android-sdk/pull/728), fixed there); this PR cleans up the same pre-existing typo in the other Braze tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)