### PR TITLE
fix: align braze-38 SDK range with its directory major

### DIFF
--- a/kits/braze/braze-38/build.gradle
+++ b/kits/braze/braze-38/build.gradle
@@ -67,6 +67,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.braze:android-sdk-ui:[37.0.0,38.0.0)'
+    api 'com.braze:android-sdk-ui:[38.0.0,39.0.0)'
     testImplementation  files('libs/java-json.jar')
 }


### PR DESCRIPTION
## Summary

The kit directory suffix `N` (e.g. `kits/braze/braze-38`) encodes the **intended major version of the wrapped vendor SDK**. `braze/braze-38` pinned a range that resolved to the wrong major:

| Kit | Was | Now |
|---|---|---|
| `braze/braze-38` | `com.braze:android-sdk-ui:[37.0.0,38.0.0)` (→ 37.x) | `[38.0.0,39.0.0)` |

Siblings `braze-39/40/41` already align, and there is no `braze-37` directory, so the range was the defect.

## Verification

- CI `build-kits / Build braze-38` passes with the new range.
- Confirmed `com.braze:android-sdk-ui:38.0.0` is published, so the range resolves.
- README does not hardcode the wrapped SDK version — no doc changes.

## Scope change

This PR originally also bumped the GA kits (`ga-23`/`ga4-23`) to firebase-analytics major 23. That is **removed here** and moved to a dedicated PR, because firebase-analytics 23.x ships Kotlin 2.1/2.2 metadata that the repo's current Kotlin 2.0.20 compiler cannot read — so GA-23 must be coupled with a repo-wide Kotlin toolchain upgrade.

The pre-existing `cross-platform-tests` failure (fails on `:android:buildSrc:compileKotlin` + emulator infra, unrelated to this change) is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)