### PR TITLE
feat: upgrade Kotlin to 2.1.20 across core SDK and kits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Upgrade Kotlin to 2.1.20 across the core SDK, buildSrc, and all integrated kits.
 - Add support for qualified alpha, beta, and release candidate versions in release workflows.
 - Add Kotlin `MParticle.rokt` access and `RoktLayout` event callbacks for the Rokt kit.
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -162,7 +162,7 @@ cd kits/urbanairship/urbanairship-20 && ./gradlew -PisRelease=true testRelease
 ```
 
 **Adding a new isolated kit:** If a kit upgrades to a Kotlin version
-incompatible with the root KGP (2.0.20), remove it from
+incompatible with the root KGP (2.1.20), remove it from
 `settings-kits.gradle` with a comment, and add standalone build steps
 to the CI workflows following the urbanairship pattern.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     ext.coroutines_version = '1.9.0'
     ext.gradle_version = '8.3.2'
 
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$gradle_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.0.20"
+    kotlin("jvm") version "2.1.20"
     `kotlin-dsl`
 }
 
@@ -22,7 +22,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.3.2")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("com.vanniktech:gradle-maven-publish-plugin:0.31.0")
 }
 

--- a/kits/adjust/adjust-5/build.gradle
+++ b/kits/adjust/adjust-5/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/adobe/adobe/build.gradle
+++ b/kits/adobe/adobe/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/adobemedia/adobemedia-3/build.gradle
+++ b/kits/adobemedia/adobemedia-3/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/appsflyer/appsflyer-6/build.gradle
+++ b/kits/appsflyer/appsflyer-6/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/appsflyer/appsflyer-6/src/test/kotlin/com/mparticle/kits/AppsflyerKitTests.kt
+++ b/kits/appsflyer/appsflyer-6/src/test/kotlin/com/mparticle/kits/AppsflyerKitTests.kt
@@ -209,7 +209,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Denied"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -256,7 +256,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Unspecified"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -303,7 +303,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Granted"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -353,7 +353,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Granted"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val performanceConsent =
             GDPRConsent
@@ -418,7 +418,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Granted"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val performanceConsent =
             GDPRConsent
@@ -474,7 +474,7 @@ class AppsflyerKitTests {
             "[{\\\"jsmap\\\":null,\\\"map\\\":\\\"Performance\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_user_data\\\"},{\\\"jsmap\\\":null,\\\"map\\\":\\\"Marketing\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_personalization\\\"},{\\\"jsmap\\\":null,\\\"map\\\":\\\"testconsent\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_storage\\\"}]"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -558,7 +558,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Denied"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -615,7 +615,7 @@ class AppsflyerKitTests {
         map["defaultAdPersonalizationConsent"] = "Unspecified"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent

--- a/kits/apptentive/apptentive-6/build.gradle
+++ b/kits/apptentive/apptentive-6/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/apptimize/apptimize-3/build.gradle
+++ b/kits/apptimize/apptimize-3/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/branch/branch-5/build.gradle
+++ b/kits/branch/branch-5/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/braze/braze-38/build.gradle
+++ b/kits/braze/braze-38/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/braze/braze-38/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
+++ b/kits/braze/braze-38/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
@@ -1315,7 +1315,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1351,7 +1351,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1427,7 +1427,7 @@ class AppboyKitTests {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -1464,7 +1464,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1494,7 +1494,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1523,7 +1523,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product

--- a/kits/braze/braze-39/build.gradle
+++ b/kits/braze/braze-39/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/braze/braze-39/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
+++ b/kits/braze/braze-39/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
@@ -1315,7 +1315,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1351,7 +1351,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1427,7 +1427,7 @@ class AppboyKitTests {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -1464,7 +1464,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1494,7 +1494,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1523,7 +1523,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product

--- a/kits/braze/braze-40/build.gradle
+++ b/kits/braze/braze-40/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/braze/braze-40/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
+++ b/kits/braze/braze-40/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
@@ -1315,7 +1315,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1351,7 +1351,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1427,7 +1427,7 @@ class AppboyKitTests {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -1464,7 +1464,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1494,7 +1494,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1523,7 +1523,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product

--- a/kits/braze/braze-41/build.gradle
+++ b/kits/braze/braze-41/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/braze/braze-41/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
+++ b/kits/braze/braze-41/src/test/kotlin/com/mparticle/kits/AppboyKitTests.kt
@@ -1315,7 +1315,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1351,7 +1351,7 @@ class AppboyKitTests {
             "\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"google_ad_personalization\\\"}]"
 
         var kitConfiguration =
-            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            MockKitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
         kit.configuration = kitConfiguration
 
         val marketingConsent =
@@ -1427,7 +1427,7 @@ class AppboyKitTests {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -1464,7 +1464,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1494,7 +1494,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product
@@ -1523,7 +1523,7 @@ class AppboyKitTests {
         val kit = MockAppboyKit()
 
         kit.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
         kit.onKitCreate(settings, MockContextApplication())
         val product =
             Product

--- a/kits/clevertap/clevertap-7/build.gradle
+++ b/kits/clevertap/clevertap-7/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/comscore/comscore-6/build.gradle
+++ b/kits/comscore/comscore-6/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/ga/ga-23/build.gradle
+++ b/kits/ga/ga-23/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/ga/ga-23/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.kt
+++ b/kits/ga/ga-23/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.kt
@@ -176,7 +176,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -217,7 +217,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -258,7 +258,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val performanceConsent =
             GDPRConsent
@@ -299,7 +299,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val performanceConsent =
             GDPRConsent
@@ -341,7 +341,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -388,7 +388,7 @@ class GoogleAnalyticsFirebaseKitTest {
             "[{\\\"jsmap\\\":null,\\\"map\\\":\\\"Performance\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_user_data\\\"},{\\\"jsmap\\\":null,\\\"map\\\":\\\"Marketing\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_personalization\\\"},{\\\"jsmap\\\":null,\\\"map\\\":\\\"testconsent\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_storage\\\"}]"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -461,7 +461,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -511,7 +511,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Unspecified"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -550,7 +550,7 @@ class GoogleAnalyticsFirebaseKitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Unspecified"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent

--- a/kits/ga4/ga4-23/build.gradle
+++ b/kits/ga4/ga4-23/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/ga4/ga4-23/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
+++ b/kits/ga4/ga4-23/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseGA4KitTest.kt
@@ -150,7 +150,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -191,7 +191,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -232,7 +232,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val performanceConsent =
             GDPRConsent
@@ -273,7 +273,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val performanceConsent =
             GDPRConsent
@@ -315,7 +315,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -362,7 +362,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
             "[{\\\"jsmap\\\":null,\\\"map\\\":\\\"Performance\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_user_data\\\"},{\\\"jsmap\\\":null,\\\"map\\\":\\\"Marketing\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_personalization\\\"},{\\\"jsmap\\\":null,\\\"map\\\":\\\"testconsent\\\",\\\"maptype\\\":\\\"ConsentPurposes\\\",\\\"value\\\":\\\"ad_storage\\\"}]"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -435,7 +435,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Denied"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -485,7 +485,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Unspecified"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent
@@ -524,7 +524,7 @@ class GoogleAnalyticsFirebaseGA4KitTest {
         map["defaultAdPersonalizationConsentSDK"] = "Unspecified"
 
         kitInstance.configuration =
-            KitConfiguration.createKitConfiguration(JSONObject().put("as", map.toMutableMap()))
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(map as Map<*, *>)))
 
         val marketingConsent =
             GDPRConsent

--- a/kits/iterable/iterable-3/build.gradle
+++ b/kits/iterable/iterable-3/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified') || project.version.toString().contains('beta')) {
         project.version = '+'
     }

--- a/kits/kochava/kochava-5/build.gradle
+++ b/kits/kochava/kochava-5/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/leanplum/leanplum-7/build.gradle
+++ b/kits/leanplum/leanplum-7/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/localytics/localytics-6/build.gradle
+++ b/kits/localytics/localytics-6/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/onetrust/onetrust/build.gradle
+++ b/kits/onetrust/onetrust/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/optimizely/optimizely-3/build.gradle
+++ b/kits/optimizely/optimizely-3/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/radar/radar-3/build.gradle
+++ b/kits/radar/radar-3/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/kits/singular/singular-12/build.gradle
+++ b/kits/singular/singular-12/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }

--- a/tooling/common/src/main/java/com/mparticle/tooling/Config.kt
+++ b/tooling/common/src/main/java/com/mparticle/tooling/Config.kt
@@ -36,10 +36,10 @@ data class Config(
                 } else {
                     Config::class.java.declaredMethods
                         .firstOrNull {
-                            it.name.removePrefix("set").toLowerCase() ==
+                            it.name.removePrefix("set").lowercase() ==
                                 key
                                     ?.toString()
-                                    ?.toLowerCase()
+                                    ?.lowercase()
                         }?.invoke(config, json.opt(key.toString()))
                 }
             }


### PR DESCRIPTION
## Summary

- Upgrade Kotlin from 2.0.20 to 2.1.20 across the root build, `buildSrc`, and all integrated kits (the Rokt kit was already on 2.1.20; the isolated urbanairship-20 kit stays on 2.2.20).
- Root `kotlin-gradle-plugin` classpath now references `$kotlin_version` so the two declarations can no longer drift apart.
- Fix `tooling/common` compilation: `String.toLowerCase()` is an error in Kotlin 2.1 — replaced with `lowercase()`.
- Fix kit unit tests (appsflyer, braze 38-41, ga, ga4): `JSONObject().put("as", map)` resolved to the `put(String, Map)` overload under Kotlin 2.0 but to `put(String, Object)` under 2.1, leaving a raw `Map` where the config parser expects a nested `JSONObject`. Tests now construct the nested `JSONObject` explicitly, which is compiler-version independent.
- Update the `[Unreleased]` CHANGELOG entry and the root KGP version referenced in ONBOARDING.md.

## Test plan

- [x] `./gradlew build` (core, kit-base, tooling: assemble + unit tests + lint)
- [x] `./gradlew -p kits testRelease -c ../settings-kits.gradle -Pmparticle.kit.mparticleFromMavenLocalOnly=true` (all 24 kits)
- [x] `ktlintCheck` and `lint` for core and kits
- [x] Isolated urbanairship-20 kit `testRelease` against the new core from mavenLocal
- [ ] Instrumented tests via CI