### PR TITLE
fix(braze-42): honor replaceSkuWithProductName on recommended eCommerce path

### DIFF
--- a/kits/braze/braze-42/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/kits/braze/braze-42/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -190,7 +190,7 @@ open class AppboyKit :
         } else {
             val properties = BrazeProperties()
             val brazePropertiesSetter = BrazePropertiesSetter(properties, enableTypeDetection)
-            event.customAttributeStrings?.let { it ->
+            event.customAttributeStrings?.let {
                 for ((key, value) in it) {
                     newAttributes[key] = brazePropertiesSetter.parseValue(key, value)
                 }
@@ -202,7 +202,7 @@ open class AppboyKit :
                     object : IValueCallback<BrazeUser> {
                         override fun onSuccess(value: BrazeUser) {
                             val userAttributeSetter = UserAttributeSetter(value, enableTypeDetection)
-                            event.customAttributeStrings?.let { it ->
+                            event.customAttributeStrings?.let {
                                 for ((key, attributeValue) in it) {
                                     val hashedKey =
                                         KitUtils.hashForFiltering(event.eventType.value.toString() + event.eventName + key)
@@ -1018,7 +1018,7 @@ open class AppboyKit :
                 for (product in products) {
                     braze.logEcommerceEvent(
                         ProductViewedEvent(
-                            productId = product.sku,
+                            productId = recommendedProductId(product),
                             productName = product.name,
                             variantId = recommendedVariantId(product),
                             price = product.unitPrice,
@@ -1100,6 +1100,14 @@ open class AppboyKit :
         return if (variant.isNullOrEmpty()) product.sku else variant
     }
 
+    private fun recommendedProductId(product: Product): String =
+        try {
+            if (settings[REPLACE_SKU_AS_PRODUCT_NAME] == "True") product.name else product.sku
+        } catch (e: Exception) {
+            Logger.error(e, "The Braze kit threw an exception while searching for forward sku as product name flag.")
+            product.sku
+        }
+
     private fun recommendedImageUrl(product: Product): String? = recommendedProductAttribute(product, IMAGE_URL_ATTRIBUTES)
 
     private fun recommendedProductUrl(product: Product): String? = recommendedProductAttribute(product, PRODUCT_URL_ATTRIBUTES)
@@ -1136,7 +1144,7 @@ open class AppboyKit :
     private fun recommendedLineItems(products: List<Product>): List<EcommerceProduct> =
         products.map { product ->
             EcommerceProduct(
-                productId = product.sku,
+                productId = recommendedProductId(product),
                 productName = product.name,
                 variantId = recommendedVariantId(product),
                 price = product.unitPrice,
@@ -1151,7 +1159,7 @@ open class AppboyKit :
         val array = JSONArray()
         for (product in products) {
             val obj = JSONObject()
-            obj.put(RECOMMENDED_PRODUCT_ID_KEY, product.sku)
+            obj.put(RECOMMENDED_PRODUCT_ID_KEY, recommendedProductId(product))
             obj.put(RECOMMENDED_PRODUCT_NAME_KEY, product.name)
             obj.put(RECOMMENDED_VARIANT_ID_KEY, recommendedVariantId(product))
             obj.put(RECOMMENDED_QUANTITY_KEY, product.quantity.toLong().coerceAtLeast(1L))

--- a/kits/braze/braze-42/src/test/kotlin/com/mparticle/kits/RecommendedEcommerceTests.kt
+++ b/kits/braze/braze-42/src/test/kotlin/com/mparticle/kits/RecommendedEcommerceTests.kt
@@ -14,6 +14,8 @@ import com.mparticle.commerce.TransactionAttributes
 import com.mparticle.identity.IdentityApi
 import com.mparticle.kits.mocks.MockAppboyKit
 import com.mparticle.kits.mocks.MockKitConfiguration
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -57,6 +59,14 @@ class RecommendedEcommerceTests {
                     "customProductKey" to "customProductValue",
                 ),
             ).build()
+
+    private fun kitWithReplaceSkuFlag(): MockAppboyKit {
+        val settings = hashMapOf<String, String?>(AppboyKit.REPLACE_SKU_AS_PRODUCT_NAME to "True")
+        return MockAppboyKit().apply {
+            configuration = KitConfiguration.createKitConfiguration(JSONObject().put("as", JSONObject(settings as Map<*, *>)))
+            useEcommerceRecommendedEvents = true
+        }
+    }
 
     @Test
     fun testAddToCartLogsCartUpdatedAddEvent() {
@@ -146,6 +156,33 @@ class RecommendedEcommerceTests {
     }
 
     @Test
+    fun testViewDetailHonorsReplaceSkuWithProductNameFlag() {
+        kitWithReplaceSkuFlag().logEvent(
+            CommerceEvent
+                .Builder(Product.DETAIL, productWithUrls())
+                .currency("USD")
+                .build(),
+        )
+        Assert.assertEquals(1, Braze.ecommerceEvents.size)
+        val event = Braze.ecommerceEvents[0] as ProductViewedEvent
+        Assert.assertEquals("product name", event.productId)
+        Assert.assertEquals("product name", event.productName)
+    }
+
+    @Test
+    fun testLineItemsHonorReplaceSkuWithProductNameFlag() {
+        kitWithReplaceSkuFlag().logEvent(
+            CommerceEvent
+                .Builder(Product.ADD_TO_CART, productWithUrls())
+                .currency("USD")
+                .build(),
+        )
+        Assert.assertEquals(1, Braze.ecommerceEvents.size)
+        val event = Braze.ecommerceEvents[0] as CartUpdatedEvent
+        Assert.assertEquals("product name", event.products[0].productId)
+    }
+
+    @Test
     fun testPurchaseLogsOrderPlacedEvent() {
         val transactionAttributes =
             TransactionAttributes("order-42")
@@ -194,6 +231,20 @@ class RecommendedEcommerceTests {
         Assert.assertEquals(99.0, refund?.properties?.get("total_value"))
         Assert.assertEquals("android", refund?.properties?.get("source"))
         Assert.assertNotNull(refund?.properties?.get("products"))
+    }
+
+    @Test
+    fun testRefundProductsJsonHonorsReplaceSkuWithProductNameFlag() {
+        kitWithReplaceSkuFlag().logEvent(
+            CommerceEvent
+                .Builder(Product.REFUND, productWithUrls())
+                .currency("USD")
+                .transactionAttributes(TransactionAttributes("order-42").setRevenue(99.0))
+                .build(),
+        )
+        val refund = Braze.events["ecommerce.order_refunded"]
+        val products = refund?.properties?.get("products") as JSONArray
+        Assert.assertEquals("product name", products.getJSONObject(0).getString("product_id"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
Follow-up to #728 addressing [Cursor Bugbot's "SKU replacement flag ignored" finding](https://github.com/mParticle/mparticle-android-sdk/pull/728#discussion_r3532420188).

- Recommended eCommerce forwarding (`useEcommerceRecommendedEvents`) always used `product.sku` as `productId`, while legacy `logPurchase` honors `replaceSkuWithProductName`. The same commerce event could therefore identify products differently in Braze depending on which forwarding path ran.
- Adds `recommendedProductId()`, mirroring the legacy flag check, and uses it everywhere the recommended path emits a product identifier: line items (`recommendedLineItems`), `ProductViewedEvent`, and the `order_refunded` JSON payload (`recommendedProductsJson`).
- Also removes a redundant explicit `it ->` lambda label in `logEvent` flagged in [review](https://github.com/mParticle/mparticle-android-sdk/pull/728#discussion_r3572121933).

Stacked on #728 — this branch is based on `feat/braze-42-recommended-ecommerce` and should be retargeted to `workstation/6.0-Release` once #728 merges.

## Test plan
- [x] `RecommendedEcommerceTests` — added coverage for the flag on the cart/line-item, product-detail, and refund paths (12/12 tests pass)
- [x] `ktlintCheck` passes on the kit