### PR TITLE
docs: address 6.0 merge review comments

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v5.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Trunk Check
         uses: trunk-io/trunk-action@04ba50e7658c81db7356da96657e6e77f220bfa3 # v1.3.1
         with:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can grab the Core SDK via Maven Central. Please see the badge above and foll
 
 ```groovy
 dependencies {
-    implementation 'com.mparticle:android-core:5.80.0'
+    implementation 'com.mparticle:android-core:6.0.0-rc.1'
 }
 ```
 
@@ -31,8 +31,8 @@ Several integrations require additional client-side add-on libraries called "kit
 ```groovy
 dependencies {
     implementation (
-        'com.mparticle:android-example-kit:5.80.0',
-        'com.mparticle:android-another-kit:5.80.0'
+        'com.mparticle:android-example-kit:6.0.0-rc.1',
+        'com.mparticle:android-another-kit:6.0.0-rc.1'
     )
 }
 ```


### PR DESCRIPTION
## Summary

Follow-ups from review comments on #734 (the `main` → `workstation/6.0-Release` merge):

- **README.md**: dependency snippets showed `5.80.0` (inherited from main during the merge); updated to `6.0.0-rc.1` to match the 6.0 branch version.
- **`.github/workflows/pull-request.yml`**: the Trunk Check job's checkout pin `df4cb1c0…` carried a stale `#v5.0.0` comment (inherited from main, where dependabot bumped the SHA to v6.0.3 without updating the comment); corrected to `# v6.0.3`.

The third comment (duplicate `Unreleased` CHANGELOG section) was already fixed in #734 before merge.

Note: the same stale `#v5.0.0` comment exists on `main` — worth a separate fix there.

## Test plan

- [x] `trunk check` clean on both files
- [ ] CI green