### PR TITLE
chore: dedupe Maven Central Sonatype credentials in release-publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -71,14 +71,15 @@ jobs:
       - name: Publish Rokt kit to Maven local (so rokt-sdk-plus resolves it locally)
         run: ./gradlew :kits:android-rokt:rokt:publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-kits.gradle
 
-      # Published under the com.rokt namespace, so this step uses the Rokt Maven Central
-      # credentials/signing key (separate from the com.mparticle secrets used above).
+      # Published under the com.rokt namespace, so this step signs with the Rokt signing key.
+      # The Sonatype account is shared with the com.mparticle publish (that account owns both
+      # namespaces), so it reuses the non-prefixed SONATYPE_NEXUS_* credentials.
       - name: Publish rokt-sdk-plus to Maven Central
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ROKT_MAVEN_CENTRAL_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ROKT_MAVEN_CENTRAL_SIGNING_KEY_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ROKT_SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ROKT_SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
         run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-rokt-sdk-plus.gradle
 
       - name: Create GitHub release


### PR DESCRIPTION
## Background

The release-publish workflow carried two pairs of Sonatype credentials for Maven Central:

- `SONATYPE_NEXUS_USERNAME` / `SONATYPE_NEXUS_PASSWORD` — used by the core + kits publish steps (`com.mparticle`).
- `ROKT_SONATYPE_NEXUS_USERNAME` / `ROKT_SONATYPE_NEXUS_PASSWORD` — used only by the `rokt-sdk-plus` publish step (`com.rokt`).

Both pairs resolve to the same Sonatype account, which owns both the `com.mparticle` and `com.rokt` namespaces, so the `ROKT_`-prefixed pair is redundant.

## What changed

- The `Publish rokt-sdk-plus to Maven Central` step now reads the shared `SONATYPE_NEXUS_USERNAME` / `SONATYPE_NEXUS_PASSWORD` secrets instead of the `ROKT_`-prefixed duplicates.
- The Rokt signing key (`ROKT_MAVEN_CENTRAL_SIGNING_KEY` / `..._PASSWORD`) is intentionally left in place — it is a distinct key kept for `com.rokt` artifact provenance, not a duplicate.
- No GitHub secrets were added, changed, or removed. `ROKT_SONATYPE_NEXUS_*` are now unreferenced and can be deleted separately if desired.

## Test plan

- [ ] Next release (`VERSION` change on `main`) publishes `com.mparticle:*` and `com.rokt:rokt-sdk-plus` to Maven Central with the shared Sonatype credentials.