### PR TITLE
fix(adobemedia): write resolved dependency versions into POM and re-include in publish

### DIFF
--- a/kits/adobemedia/adobemedia-3/build.gradle
+++ b/kits/adobemedia/adobemedia-3/build.gradle
@@ -94,3 +94,22 @@ dependencies {
     api 'com.adobe.marketing.mobile:identity'
     api 'com.adobe.marketing.mobile:signal'
 }
+
+// The Adobe extensions above take their versions from the sdk-bom, so they are declared without
+// an explicit version. Without version mapping the generated POM lists them with an empty
+// <version>, which Maven Central rejects. Map each dependency to the version resolved on the
+// release variant classpaths so the published POM carries concrete versions.
+afterEvaluate {
+    publishing {
+        publications.withType(org.gradle.api.publish.maven.MavenPublication).configureEach {
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('releaseCompileClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionOf('releaseRuntimeClasspath')
+                }
+            }
+        }
+    }
+}

--- a/kits/matrix.json
+++ b/kits/matrix.json
@@ -12,6 +12,12 @@
     "example_kotlin_project": ":kits:android-adobe:adobe:example-kotlin"
   },
   {
+    "name": "adobemedia-3",
+    "local_path": "kits/adobemedia/adobemedia-3",
+    "kit_project": ":kits:android-adobemedia:adobemedia-3",
+    "example_kotlin_project": ":kits:android-adobemedia:adobemedia-3:example-kotlin"
+  },
+  {
     "name": "appsflyer-6",
     "local_path": "kits/appsflyer/appsflyer-6",
     "kit_project": ":kits:android-appsflyer:appsflyer-6",

--- a/settings-kit-examples.gradle
+++ b/settings-kit-examples.gradle
@@ -3,6 +3,7 @@ apply from: 'settings-kits.gradle'
 
 include ':kits:adjust:adjust-5:example-kotlin',
         ':kits:adobe:adobe:example-kotlin',
+        ':kits:adobemedia:adobemedia-3:example-kotlin',
         ':kits:appsflyer:appsflyer-6:example-kotlin',
         ':kits:apptentive:apptentive-6:example-kotlin',
         ':kits:apptimize:apptimize-3:example-kotlin',
@@ -25,6 +26,7 @@ include ':kits:adjust:adjust-5:example-kotlin',
 
 project(':kits:adjust:adjust-5:example-kotlin').projectDir = file('kits/adjust/adjust-5/example/example-kotlin')
 project(':kits:adobe:adobe:example-kotlin').projectDir = file('kits/adobe/adobe/example/example-kotlin')
+project(':kits:adobemedia:adobemedia-3:example-kotlin').projectDir = file('kits/adobemedia/adobemedia-3/example/example-kotlin')
 project(':kits:appsflyer:appsflyer-6:example-kotlin').projectDir = file('kits/appsflyer/appsflyer-6/example/example-kotlin')
 project(':kits:apptentive:apptentive-6:example-kotlin').projectDir = file('kits/apptentive/apptentive-6/example/example-kotlin')
 project(':kits:apptimize:apptimize-3:example-kotlin').projectDir = file('kits/apptimize/apptimize-3/example/example-kotlin')

--- a/settings-kits.gradle
+++ b/settings-kits.gradle
@@ -3,7 +3,7 @@
 include (
         ':kits:adjust:adjust-5',
         ':kits:adobe:adobe',
-        //  ':kits:adobemedia:adobemedia-3',  // Adobe BOM leaves dependency versions unresolved in POM -- excluded until pinned
+        ':kits:adobemedia:adobemedia-3',
         ':kits:appsflyer:appsflyer-6',
         ':kits:apptentive:apptentive-6',
         ':kits:apptimize:apptimize-3',


### PR DESCRIPTION
## Background

`adobemedia-3` resolves its Adobe Experience Platform extensions through the `com.adobe.marketing.mobile:sdk-bom` (declared with a version range), so the individual extensions (`core`, `analytics`, `media`, `userprofile`, `lifecycle`, `identity`, `signal`) are declared **without** explicit versions — the BOM supplies them at build time.

The generated Maven POM therefore listed those dependencies with an empty `<version>`. Maven Central rejects version-less dependencies (`Dependency version information is missing for dependency: com.adobe.marketing.mobile:core`, …), and because Central Portal deployments are atomic, that single failure blocked the entire kits bundle. As a stopgap, #739 excluded `adobemedia-3` from the 6.0.0 publish.

## What changed

- **`kits/adobemedia/adobemedia-3/build.gradle`** — add a `versionMapping` block (scoped to this module only) that maps each published dependency to the version resolved on the `releaseCompileClasspath` / `releaseRuntimeClasspath`. The published POM now carries concrete versions while `build.gradle` keeps the readable `sdk-bom` range (auto-tracking 3.x, parity with the iOS SPM `.upToNextMajor(from: "3.0.0")`).
- **`settings-kits.gradle`, `kits/matrix.json`, `settings-kit-examples.gradle`** — reverse the #739 exclusion so the kit is built, tested, and published again.

No `VERSION` change here — the fix ships in the next release bump (Release – Draft), so the full kits bundle re-publishes at a fresh version with `adobemedia-3` included.

## Validation

Generated the POM locally and confirmed every dependency now has a concrete version:

```
sdk-bom     -> 3.20.0 (import)
core        -> 3.8.0
analytics   -> 3.0.2
media       -> 3.1.2
userprofile -> 3.0.1
lifecycle   -> 3.0.2
identity    -> 3.0.2
signal      -> 3.0.1
```

`./gradlew -c settings-kits.gradle :kits:android-adobemedia:adobemedia-3:generatePomFileForMavenPublication -PVERSION=6.0.0` → no version-less `<dependency>` entries remain.

## Test plan

- [ ] CI: `build-kits` matrix runs `:kits:android-adobemedia:adobemedia-3:testRelease` green.
- [ ] Next release publishes `com.mparticle:adobemedia-3` to Maven Central (POM validation passes).