### PR TITLE
ci: make Gradle caching work by running the suite on main

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -44,6 +44,11 @@ jobs:
           distribution: zulu
           java-version: "17"
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: true
+
       - name: Publish core SDK to Maven Local
         run: ./gradlew publishMavenPublicationToMavenLocal
 

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -38,8 +38,10 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a #v2.9.0
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          cache-read-only: true
       # AVD cache disabled: causes indefinite hangs on emulator shutdown (see
       # ReactiveCircus/android-emulator-runner#373, #385, #362; WordPress/gutenberg#66771)
       - name: Enable KVM group perms

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,11 @@
 name: "Build and Test"
 
-on: [workflow_dispatch, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -17,6 +22,7 @@ jobs:
   trunk-check:
     name: Trunk code check
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -26,6 +32,7 @@ jobs:
           check-mode: pull_request
   pr-check-hadcoded-secrets:
     name: "Check PR for hardcoded secrets"
+    if: github.event_name == 'pull_request'
     uses: mParticle/mparticle-workflows/.github/workflows/security-hardcoded-secrets.yml@main
 
   instrumented-core:
@@ -75,6 +82,8 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: "Run Unit Tests"
         run: ./gradlew test
       - name: "Print Android Unit Tests Report"
@@ -101,6 +110,8 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: "Run Android Core SDK Lint"
         run: ./gradlew lint
       - name: "Setup Android Kit Lint"
@@ -128,6 +139,8 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: "Run Android Core SDK Kotlin Lint"
         run: ./gradlew ktlintCheck
       - name: "Setup Android Kit Kotlin Lint"
@@ -143,6 +156,7 @@ jobs:
 
   security-checks:
     name: "Security Lint Checks"
+    if: github.event_name == 'pull_request'
     uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
     with:
       base_branch: main
@@ -164,6 +178,8 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
+      - name: "Setup Gradle"
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: "Generate Core Release Build"
         run: ./gradlew publishMavenPublicationToMavenLocal
       - name: "Run Kit-Base Release Tests and Build"
@@ -179,6 +195,7 @@ jobs:
 
   automerge-dependabot:
     name: "Save PR Number for Dependabot Automerge"
+    if: github.event_name == 'pull_request'
     needs:
       [
         instrumented-core,

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -113,7 +113,7 @@ jobs:
           echo "${{ steps.compose-version.outputs.new-version }}" > VERSION
 
       - name: Publish to Maven local (smoke test)
-        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ steps.compose-version.outputs.new-version }}
+        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ steps.compose-version.outputs.new-version }} --no-build-cache
 
       - name: Generate changelog entry
         id: changelog

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -54,13 +54,13 @@ jobs:
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Publish core to Maven local (required before kits can compile)
-        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.final_version }}
+        run: ./gradlew publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.final_version }} --no-build-cache
 
       - name: Publish core to Maven Central
-        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }}
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} --no-build-cache
 
       - name: Publish kits to Maven Central
-        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-kits.gradle
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-kits.gradle --no-build-cache
 
       # rokt-sdk-plus (com.rokt:rokt-sdk-plus) is an umbrella over the mParticle Rokt kit + the
       # Rokt Payment Extension. The "Publish core to Maven local" step above already placed
@@ -69,7 +69,7 @@ jobs:
       # Maven Central propagation. com.rokt:payment-extension (+ roktsdk) come from Central,
       # released independently from the ROKT sdk-android-source repo.
       - name: Publish Rokt kit to Maven local (so rokt-sdk-plus resolves it locally)
-        run: ./gradlew :kits:android-rokt:rokt:publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-kits.gradle
+        run: ./gradlew :kits:android-rokt:rokt:publishMavenPublicationToMavenLocal -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-kits.gradle --no-build-cache
 
       # Published under the com.rokt namespace, so this step signs with the Rokt signing key.
       # The Sonatype account is shared with the com.mparticle publish (that account owns both
@@ -80,7 +80,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ROKT_MAVEN_CENTRAL_SIGNING_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-rokt-sdk-plus.gradle
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository -PVERSION=${{ needs.setup-and-version.outputs.final_version }} -c settings-rokt-sdk-plus.gradle --no-build-cache
 
       - name: Create GitHub release
         uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ android.useAndroidX=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2560m
 #-XX:ThreadStackSize=4096 -XX:CompilerThreadStackSize=4096
+org.gradle.caching=true
 android.defaults.buildfeatures.buildconfig=true
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 JAVA_VERSION=17


### PR DESCRIPTION
## Background

No Gradle cache entry has ever existed for this repo — the cache listing holds only Trunk entries. `Unit Tests` reports `116 actionable tasks: 116 executed` and re-downloads the Gradle distribution every run; the instrumented jobs log `Gradle User Home cache not found. Will initialize empty.`

The cause is structural, which is why just adding `setup-gradle` would have fixed nothing: `setup-gradle` is read-only off the default branch, and an entry written on a PR ref is visible only to that PR — but this workflow never ran on a push to `main`. No run was ever permitted to *write* the cache that PR jobs read.

## What changed

- Run this workflow on pushes to `main`, matching the other Rokt Android repos. Main runs may write, so the ordinary suite populates the cache — no bespoke warming job needed.
- Gate the four jobs that require a PR context to `pull_request` only: `trunk-check` (`check-mode: pull_request`), `pr-check-hadcoded-secrets`, `security-checks` (diff-aware against a base branch) and `automerge-dependabot` (reads the PR number). `kit-compatibility-test` and `pr-notify` were already gated.
- Add `setup-gradle` to the remaining Gradle jobs and replace the end-of-life `gradle/gradle-build-action@v2.9.0` in `instrumented-tests.yml`. Pinned to the SHA the release workflows already use, so no new action version enters the supply chain.
- `org.gradle.caching=true` — without it, a warm dependency cache still leaves `116 executed`.
- Pass `--no-build-cache` on every publish invocation in `release-publish.yml` and `release-draft.yml`, so released artifacts are always built from scratch and never assembled from cached task outputs.

`cache-read-only: true` is kept on `build-kits.yml` and `instrumented-tests.yml`, and only there. setup-gradle keys entries per job invocation, so `build-kits`' 22-kit matrix would otherwise write 22 entries per main commit and churn through the 10 GB repo limit.

## Validation

Local populate pass, then `clean` and rebuild:

```
PASS A  2m 55s   42 actionable tasks: 40 executed, 2 from cache
PASS B  3s       42 actionable tasks: 12 executed, 23 from cache, 7 up-to-date
```

`compileReleaseKotlin`, `compileReleaseJavaWithJavac` and `minifyReleaseWithR8` all `FROM-CACHE`, so outputs are correct as well as reused. `actionlint` and `trunk check` clean.
