### PR TITLE
ci: run the lint jobs on ubuntu instead of macos

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -90,7 +90,7 @@ jobs:
   lint-checks:
     name: "Lint Checks"
     timeout-minutes: 20
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -117,7 +117,7 @@ jobs:
   kotlin-lint-checks:
     name: "Kotlin Lint Checks"
     timeout-minutes: 15
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Background

`Lint Checks` and `Kotlin Lint Checks` are the last two jobs on `macos-latest`, which GitHub bills at a **10× multiplier**. On the most recent full run they accounted for ~12.7 minutes of wall time — roughly 127 billed minutes, the most expensive thing in the suite for the cheapest work in it.

The runner is a leftover. `git log -S` traces it to the 2021 Actions migration (`b198d1e`), where `macos-latest` was picked for the **emulator** job, because macOS was then the only runner with hardware-accelerated Android emulation. The emulator jobs have since moved to `ubuntu-latest` with explicit KVM enablement, so the one workload that genuinely needed macOS no longer uses it — the lint jobs just inherited the runner.

Nothing they run is platform-specific: Android Lint, ktlint and `publishMavenPublicationToMavenLocal`. There is no `darwin`, `xcode`, `brew` or `os.name` reference anywhere in the build.

## What changed

- `lint-checks` and `kotlin-lint-checks`: `runs-on: macos-latest` → `ubuntu-latest`.

## Validation

`kit-compatibility-test` already runs `publishMavenPublicationToMavenLocal` plus kit release builds on `ubuntu-latest` and passes — a heavier Gradle workload than lint, on the same toolchain — so the toolchain is proven on Linux in this repo. `ubuntu-latest` also has more memory than `macos-latest` (16 GB vs 14 GB).

I cannot prove this locally, having no Linux runner, so **CI on this PR is the real test**. If either job fails for a genuinely platform-specific reason, close this PR and leave the runner alone.

Independent of #742, which also touches `pull-request.yml`; the two edit different lines and I verified they merge cleanly in either order.
