### PR TITLE
ci: guard pr-notify against Dependabot runs explicitly

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -196,7 +196,8 @@ jobs:
   pr-notify:
     if: >
       github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
     needs:
       - instrumented-core
       - instrumented-kit-base


### PR DESCRIPTION
## Background

Dependabot-triggered runs resolve `secrets` against a separate, repository-scoped store that `GCHAT_PRS_WEBHOOK` is not in, so on a Dependabot run `gchat_webhook` arrives blank and the notifier fails with `Input required and not supplied: webhookUrl`.

**That does not happen today — but only incidentally.** `pr-notify` needs `security-checks`; the shared `security-checks` workflow already guards on this same condition, so it skips on Dependabot PRs; and because `pr-notify` has no `always()`, a skipped dependency skips it too. Verified as *skipping* rather than failing on #722, #720 and #705.

Nothing local to this repo expresses that constraint, so two ordinary edits would silently turn every Dependabot PR red: adding `always()` to `pr-notify` (a reasonable-looking change, used elsewhere to keep a notifier alive when an upstream job is skipped by a path filter), or dropping `security-checks` from its `needs` while reshuffling required checks.

## What changed

- `pull-request.yml` — added `github.actor != 'dependabot[bot]'` to the `pr-notify` job's `if`.

`github.actor` is what GitHub uses to decide which secrets store a run reads from, so the guard matches the exact circumstance under which the webhook is unavailable. A human pushing to a Dependabot branch still gets the notification.

## Validation

`actionlint` and `trunk check` clean. **No behaviour change:** `pr-notify` already skipped on Dependabot PRs and still does; it already ran on human PRs and still does. This only makes the existing protection intentional and local rather than a side effect of the `needs` graph.

Being human-authored, this PR exercises the happy path — `Notify GChat` running and succeeding here is the regression signal.
