### PR TITLE
fix(singular): raise singular-12 sample app minSdk to 21

### DIFF
--- a/kits/singular/singular-12/example/example-kotlin/build.gradle
+++ b/kits/singular/singular-12/example/example-kotlin/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId 'com.mparticle.kits.singular.example.kotlin'
-        minSdk 16
+        minSdk 21
         targetSdk 35
         versionCode 1
         versionName '1.0'


### PR DESCRIPTION
## What

One line — the singular-12 Kotlin sample app's `minSdk` goes from 16 to 21.

```diff
 kits/singular/singular-12/example/example-kotlin/build.gradle
     applicationId 'com.mparticle.kits.singular.example.kotlin'
-    minSdk 16
+    minSdk 21
```

## Why

`build-kits / Build singular-12` has failed on **every PR since 2026-07-23** with no code change on our side — it currently blocks #742, #743, #744 and #722.

The kit declares Singular with an open version range, so 12.15.0 was picked up automatically. That release raised its own `minSdk` to 21:

```
Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than
version 21 declared in library [com.singular.sdk:singular_sdk:12.15.0]
```

Manifest merger enforces `minSdk` compatibility only for **application** modules; library modules downgrade it to a warning. The sample app is the sole application module in this kit, so it is the only thing that can fail.

## Scope: sample app only

The job runs three Gradle steps. Steps 1–2 already pass; only step 3 fails:

| # | Step | Result |
|---|---|---|
| 1 | `publishMavenPublicationToMavenLocal` | ✅ |
| 2 | `singular-12:testRelease` | ✅ |
| 3 | `example-kotlin:assembleDebug` | ❌ **the failure** |

## No externally visible change

- Sample apps are not published.
- The kit keeps `minSdkVersion 16` — untouched.
- The Singular version range is untouched.

Verified the publishable artifact is unaffected:

```
> Task :kits:singular:singular-12:processReleaseManifest
> Task :kits:singular:singular-12:bundleReleaseAar
BUILD SUCCESSFUL
```

## Verification

Reproduced the CI steps locally (JDK 17), using `--rerun-tasks` to rule out Gradle caching:

| Config | `processDebugMainManifest` |
|---|---|
| `minSdk 21` (this PR) | ✅ BUILD SUCCESSFUL |
| `minSdk 16` (control) | ❌ reproduces the exact CI error |

## Reviewer note

A customer on `minSdk` 16–20 who adds singular-12 will hit this same manifest merger error in **their own** build, because Singular is an `api` dependency and therefore transitive in the published POM.

This PR deliberately does **not** raise the published kit's `minSdk` — that is a breaking change and warrants its own decision. Flagging so it is tracked rather than forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)