### PR TITLE
ci: build core SDK once and share Maven Local across kit matrix

### DIFF
--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -21,9 +21,47 @@ jobs:
       - id: set
         run: echo "matrix=$(jq -c . kits/matrix.json)" >> "$GITHUB_OUTPUT"
 
+  # Builds the core SDK once and shares the resulting Maven Local repository with
+  # every build-kits matrix job, instead of each of them rebuilding it.
+  publish-core:
+    name: Publish core SDK to Maven Local
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set SDK version
+        run: |
+          echo "ORG_GRADLE_PROJECT_VERSION=$(head -n 1 VERSION)" >> "$GITHUB_ENV"
+          echo "ORG_GRADLE_PROJECT_version=$(head -n 1 VERSION)" >> "$GITHUB_ENV"
+
+      - name: Install JDK 17
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: zulu
+          java-version: "17"
+
+      # Writable, unlike build-kits below: one job, so one cache entry per run.
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
+      - name: Publish core SDK to Maven Local
+        run: ./gradlew publishMavenPublicationToMavenLocal
+
+      - name: Archive Maven Local repository
+        run: tar -czf maven-local.tar.gz -C "$HOME/.m2" repository
+
+      - name: Upload Maven Local repository
+        uses: actions/upload-artifact@v7
+        with:
+          name: maven-local-core
+          path: maven-local.tar.gz
+          retention-days: 1
+          compression-level: 0
+
   build-kits:
     name: Build ${{ matrix.kit.name }}
-    needs: load-matrix
+    needs: [load-matrix, publish-core]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -35,8 +73,8 @@ jobs:
 
       - name: Set SDK version
         run: |
-          echo "ORG_GRADLE_PROJECT_VERSION=$(head -n 1 VERSION)" >> $GITHUB_ENV
-          echo "ORG_GRADLE_PROJECT_version=$(head -n 1 VERSION)" >> $GITHUB_ENV
+          echo "ORG_GRADLE_PROJECT_VERSION=$(head -n 1 VERSION)" >> "$GITHUB_ENV"
+          echo "ORG_GRADLE_PROJECT_version=$(head -n 1 VERSION)" >> "$GITHUB_ENV"
 
       - name: Install JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
@@ -49,8 +87,16 @@ jobs:
         with:
           cache-read-only: true
 
-      - name: Publish core SDK to Maven Local
-        run: ./gradlew publishMavenPublicationToMavenLocal
+      - name: Download Maven Local repository
+        uses: actions/download-artifact@v7
+        with:
+          name: maven-local-core
+
+      - name: Restore core SDK into Maven Local
+        run: |
+          mkdir -p "$HOME/.m2"
+          tar -xzf maven-local.tar.gz -C "$HOME/.m2"
+          rm maven-local.tar.gz
 
       - name: Run kit unit tests
         if: ${{ matrix.kit.skip_unit_tests != true }}

--- a/.github/workflows/build-kits.yml
+++ b/.github/workflows/build-kits.yml
@@ -52,7 +52,7 @@ jobs:
         run: tar -czf maven-local.tar.gz -C "$HOME/.m2" repository
 
       - name: Upload Maven Local repository
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-local-core
           path: maven-local.tar.gz
@@ -88,7 +88,7 @@ jobs:
           cache-read-only: true
 
       - name: Download Maven Local repository
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: maven-local-core
 


### PR DESCRIPTION
## Summary

All 22 `build-kits` matrix jobs each ran `./gradlew publishMavenPublicationToMavenLocal`, rebuilding the identical core SDK 22 times per workflow run.

This adds a single `publish-core` job that does the publish once, archives `~/.m2/repository`, and uploads it as an artifact. The matrix jobs download and untar it into `$HOME/.m2` instead of rebuilding.

## Changes

- New `publish-core` job: publishes core SDK → `tar -czf maven-local.tar.gz` → uploads as `maven-local-core` (1-day retention, `compression-level: 0` since the tar is already gzipped).
- `build-kits` now `needs: [load-matrix, publish-core]`; its Gradle publish step is replaced by download + untar.
- Quoted `$GITHUB_ENV` to satisfy shellcheck SC2086, which the pre-existing step tripped.

## Why the artifact is complete

The root publish emits exactly four coordinates — `android-core`, `android-kit-base`, `android-kit-plugin`, `android-plugin` — plus their `maven-metadata-local.xml`. Nothing else writes to `~/.m2/repository` (Gradle's dependency cache lives in `~/.gradle`), so archiving the whole `repository` dir can't miss anything. `KitPlugin` restricts `mavenLocal()` to `includeGroup 'com.mparticle'` and excludes that group from Maven Central, so those four are precisely what kit builds need from there.

## Testing

Published to an isolated repo at throwaway version `6.0.0-citest`, tarred (1.2 MB), restored, and confirmed `diff -r` identical. Then built both consumer paths against **only** the restored copy via `-Dmaven.repo.local`:

- `:kits:android-adjust:adjust-5:testRelease` (`settings-kits.gradle`) — BUILD SUCCESSFUL
- `:kits:android-adjust:adjust-5:example-kotlin:assembleDebug` (`settings-kit-examples.gradle`) — BUILD SUCCESSFUL

Since `6.0.0-citest` exists nowhere else, resolution demonstrably came from the tarball. `trunk check` clean on the changed file.

Only `adjust-5` was exercised locally; the other 21 kits resolve `com.mparticle:*` through the same `KitPlugin` mechanism, so this PR's own workflow run is the real proof.

## Trade-off

Matrix jobs now wait on `publish-core` before starting, but this drops 21 core SDK builds. The publish is ~22s warm locally and several minutes cold on a runner with no Gradle cache.

## Not included

Deliberately out of scope, happy to follow up:

1. The same duplicate publish exists in `pull-request.yml` (lint, kotlin-lint, kit-compatibility) and `daily.yml` — 6 more redundant core builds, two on `macos-latest` at 10× billing.
2. `build-kits.yml` has no Gradle caching at all, so every matrix job still cold-downloads third-party dependencies. Likely a bigger win than this change, but needs a decision on cache-write scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)