### PR TITLE
docs(kits): correct v6 Maven coordinates and source links

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -116,10 +116,10 @@ needed:
 
 ```groovy
 include(
-        ':kits:adjust-kit',
-        ':kits:adobe-kit'
-        /* ':kits:adobemedia-kit',
-            ':kits:appboy-kit',
+        ':kits:adjust:adjust-5',
+        ':kits:adobe:adobe',
+        /* ':kits:appsflyer:appsflyer-6',
+            ':kits:braze:braze-41',
             ...                     */
 )
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-[![Maven Central Status](https://maven-badges.herokuapp.com/maven-central/com.mparticle/android-core/badge.svg?style=flat-square)](https://search.maven.org/#search%7Cga%7C1%7Cmparticle)
+[![Maven Central](https://img.shields.io/maven-central/v/com.mparticle/android-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.mparticle/android-core)
 
 A single SDK to collect analytics data and send it to 100+ marketing, analytics, and data platforms. Simplify your data integration with a single API.
 
@@ -20,7 +20,7 @@ You can grab the Core SDK via Maven Central. Please see the badge above and foll
 
 ```groovy
 dependencies {
-    implementation 'com.mparticle:android-core:6.0.0-rc.1'
+    implementation 'com.mparticle:android-core:6.0.0'
 }
 ```
 
@@ -30,52 +30,37 @@ Several integrations require additional client-side add-on libraries called "kit
 
 ```groovy
 dependencies {
-    implementation (
-        'com.mparticle:android-example-kit:6.0.0-rc.1',
-        'com.mparticle:android-another-kit:6.0.0-rc.1'
-    )
+    implementation 'com.mparticle:appsflyer-6:6.0.0'
+    implementation 'com.mparticle:braze-41:6.0.0'
 }
 ```
 
-Kits are deployed as individual artifacts in Maven Central, and each has a dedicated repository if you'd like to view the source code. Review the table below to see if you need to include any kits:
+Kits maintained by mParticle are developed in this monorepo under the [`kits/`](kits) directory and deployed as individual Maven Central
+artifacts. The table below lists kits with a final v6 artifact available on Maven Central:
 
-| Kit                                                                                                                                          | Maven Artifact                                                                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Adjust](https://github.com/mparticle-integrations/mparticle-android-integration-adjust)                                                     | [`android-adjust-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-adjust-kit%22)                                         |
-| [Adobe](https://github.com/mparticle-integrations/mparticle-android-integration-adobe)                                                       | [`android-adobe-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-adobe-kit%22)                                           |
-| [AdobeMedia](https://github.com/mparticle-integrations/mparticle-android-integration-adobe-media)                                            | [`android-adobemedia-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-adobemedia-kit%22)                                 |
-| [Appboy](https://github.com/mparticle-integrations/mparticle-android-integration-appboy)                                                     | [`android-appboy-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-appboy-kit%22)                                         |
-| [AppsFlyer](https://github.com/mparticle-integrations/mparticle-android-integration-appsflyer)                                               | [`android-appsflyer-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-appsflyer-kit%22)                                   |
-| [Apptentive](https://github.com/mparticle-integrations/mparticle-android-integration-apptentive)                                             | [`android-apptentive-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-apptentive-kit%22)                                 |
-| [Apptimize](https://github.com/mparticle-integrations/mparticle-android-integration-apptimize)                                               | [`android-apptimize-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-apptimize-kit%22)                                   |
-| [Apteligent](https://github.com/mparticle-integrations/mparticle-android-integration-apteligent)                                             | [`android-apteligent-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-apteligent-kit%22)                                 |
-| [Blueshift](https://github.com/blueshift-labs/mparticle-android-integration-blueshift)                                                       | [`android-blueshift-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-blueshift-kit%22)                                   |
-| [Branch Metrics](https://github.com/mparticle-integrations/mparticle-android-integration-branch)                                             | [`android-branch-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-branch-kit%22)                                         |
-| [Button](https://github.com/mparticle-integrations/mparticle-android-integration-button)                                                     | [`android-button-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-button-kit%22)                                         |
-| [CleverTap](https://github.com/mparticle-integrations/mparticle-android-integration-clevertap)                                               | [`android-clevertap-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-clevertap-kit%22)                                   |
-| [ComScore](https://github.com/mparticle-integrations/mparticle-android-integration-comscore)                                                 | [`android-comscore-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-comscore-kit%22)                                     |
-| [Flurry](https://github.com/mparticle-integrations/mparticle-android-integration-flurry)                                                     | [`android-flurry-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-flurry-kit%22)                                         |
-| [ForeSee](https://github.com/mparticle-integrations/mparticle-android-integration-foresee)                                                   | [`android-foresee-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-foresee-kit%22)                                       |
-| [Google Analytics for Firebase](https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase)           | [`android-googleanalyticsfirebase-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-googleanalyticsfirebase-kit%22)       |
-| [Google Analytics for Firebase - GA4](https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4) | [`android-googleanalyticsfirebasega4-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-googleanalyticsfirebasega4-kit%22) |
-| [Iterable](https://github.com/mparticle-integrations/mparticle-android-integration-iterable)                                                 | [`android-iterable-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-iterable-kit%22)                                     |
-| [Kochava](https://github.com/mparticle-integrations/mparticle-android-integration-kochava)                                                   | [`android-kochava-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-kochava-kit%22)                                       |
-| [Leanplum](https://github.com/mparticle-integrations/mparticle-android-integration-leanplum)                                                 | [`android-leanplum-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-leanplum-kit%22)                                     |
-| [Localytics](https://github.com/mparticle-integrations/mparticle-android-integration-localytics)                                             | [`android-localytics-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-localytics-kit%22)                                 |
-| [Neura](https://github.com/NeuraLabs/mparticle-android-integration-neura)                                                                    | [`android-neura-kit`](https://search.maven.org/search?q=g:com.theneura%20AND%20a:android-mparticle-sdk)                                                                 |
-| [OneTrust](https://github.com/mparticle-integrations/mparticle-android-integration-onetrust)                                                 | [`android-onetrust-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-onetrust-kit%22)                                     |
-| [Optimizely](https://github.com/mparticle-integrations/mparticle-android-integration-optimizely)                                             | [`android-optimizely-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-optimizely-kit%22)                                 |
-| [Pilgrim](https://github.com/mparticle-integrations/mparticle-android-integration-pilgrim)                                                   | [`android-pilgrim-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-pilgrim-kit%22)                                       |
-| [Radar](https://github.com/mparticle-integrations/mparticle-android-integration-radar)                                                       | [`android-radar-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-radar-kit%22)                                           |
-| [Responsys](https://github.com/mparticle-integrations/mparticle-android-integration-responsys)                                               | [`android-responsys-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-responsys-kit%22)                                   |
-| [Reveal Mobile](https://github.com/mparticle-integrations/mparticle-android-integration-revealmobile)                                        | [`android-revealmobile-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-revealmobile-kit%22)                             |
-| [Singular](https://github.com/mparticle-integrations/mparticle-android-integration-singular)                                                 | [`android-singular-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-singular-kit%22)                                     |
-| [Skyhook](https://github.com/mparticle-integrations/mparticle-android-integration-skyhook)                                                   | [`android-skyhook-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-skyhook-kit%22)                                       |
-| [Swrve](https://github.com/swrve-services/mparticle-android-integration-swrve)                                                               | [`android-swrve-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-swrve-kit%22)                                           |
-| [Taplytics Mobile](https://github.com/mparticle-integrations/mparticle-android-integration-taplytics)                                        | [`android-taplytics-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-taplytics-kit%22)                                   |
-| [Tune](https://github.com/mparticle-integrations/mparticle-android-integration-tune)                                                         | [`android-tune-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-tune-kit%22)                                             |
-| [Urban Airship](https://github.com/mparticle-integrations/mparticle-android-integration-urbanairship)                                        | [`android-urbanairship-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-urbanairship-kit%22)                             |
-| [Wootric](https://github.com/mparticle-integrations/mparticle-android-integration-wootric)                                                   | [`android-wootric-kit`](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mparticle%22%20AND%20a%3A%22android-wootric-kit%22)                                       |
+| Kit                                        | Maven artifact                                                                                           |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| [Adjust](kits/adjust/adjust-5)             | [`com.mparticle:adjust-5`](https://central.sonatype.com/artifact/com.mparticle/adjust-5)                 |
+| [Adobe](kits/adobe/adobe)                  | [`com.mparticle:adobe`](https://central.sonatype.com/artifact/com.mparticle/adobe)                       |
+| [AppsFlyer](kits/appsflyer/appsflyer-6)    | [`com.mparticle:appsflyer-6`](https://central.sonatype.com/artifact/com.mparticle/appsflyer-6)           |
+| [Apptentive](kits/apptentive/apptentive-6) | [`com.mparticle:apptentive-6`](https://central.sonatype.com/artifact/com.mparticle/apptentive-6)         |
+| [Apptimize](kits/apptimize/apptimize-3)    | [`com.mparticle:apptimize-3`](https://central.sonatype.com/artifact/com.mparticle/apptimize-3)           |
+| [Branch Metrics](kits/branch/branch-5)     | [`com.mparticle:branch-5`](https://central.sonatype.com/artifact/com.mparticle/branch-5)                 |
+| [Braze 38](kits/braze/braze-38)            | [`com.mparticle:braze-38`](https://central.sonatype.com/artifact/com.mparticle/braze-38)                 |
+| [Braze 39](kits/braze/braze-39)            | [`com.mparticle:braze-39`](https://central.sonatype.com/artifact/com.mparticle/braze-39)                 |
+| [Braze 40](kits/braze/braze-40)            | [`com.mparticle:braze-40`](https://central.sonatype.com/artifact/com.mparticle/braze-40)                 |
+| [Braze 41](kits/braze/braze-41)            | [`com.mparticle:braze-41`](https://central.sonatype.com/artifact/com.mparticle/braze-41)                 |
+| [CleverTap](kits/clevertap/clevertap-7)    | [`com.mparticle:clevertap-7`](https://central.sonatype.com/artifact/com.mparticle/clevertap-7)           |
+| [comScore](kits/comscore/comscore-6)       | [`com.mparticle:comscore-6`](https://central.sonatype.com/artifact/com.mparticle/comscore-6)             |
+| [Iterable](kits/iterable/iterable-3)       | [`com.mparticle:iterable-3`](https://central.sonatype.com/artifact/com.mparticle/iterable-3)             |
+| [Kochava](kits/kochava/kochava-5)          | [`com.mparticle:kochava-5`](https://central.sonatype.com/artifact/com.mparticle/kochava-5)               |
+| [Leanplum](kits/leanplum/leanplum-7)       | [`com.mparticle:leanplum-7`](https://central.sonatype.com/artifact/com.mparticle/leanplum-7)             |
+| [Localytics](kits/localytics/localytics-6) | [`com.mparticle:localytics-6`](https://central.sonatype.com/artifact/com.mparticle/localytics-6)         |
+| [OneTrust](kits/onetrust/onetrust)         | [`com.mparticle:onetrust`](https://central.sonatype.com/artifact/com.mparticle/onetrust)                 |
+| [Optimizely](kits/optimizely/optimizely-3) | [`com.mparticle:optimizely-3`](https://central.sonatype.com/artifact/com.mparticle/optimizely-3)         |
+| [Radar](kits/radar/radar-3)                | [`com.mparticle:radar-3`](https://central.sonatype.com/artifact/com.mparticle/radar-3)                   |
+| [Rokt](kits/rokt/rokt)                     | [`com.mparticle:android-rokt-kit`](https://central.sonatype.com/artifact/com.mparticle/android-rokt-kit) |
+| [Singular](kits/singular/singular-12)      | [`com.mparticle:singular-12`](https://central.sonatype.com/artifact/com.mparticle/singular-12)           |
 
 ### Google Play Services Ads
 
@@ -183,7 +168,7 @@ buildscript {
     }
     dependencies {
         ...
-        classpath 'com.mparticle:android-plugin:5.12.10'
+        classpath 'com.mparticle:android-plugin:6.0.0'
     }
 }
 ```

--- a/kits/adjust/adjust-5/README.md
+++ b/kits/adjust/adjust-5/README.md
@@ -1,6 +1,6 @@
 # Adjust Kit Integration
 
-This repository contains the [Adjust](https://www.adjust.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Adjust](https://www.adjust.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Adjust](https://www.adjust.com/) integration for t
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-adjust-kit:5+'
+        implementation 'com.mparticle:adjust-5:6.0.0'
     }
     ```
 

--- a/kits/adobe/adobe/README.md
+++ b/kits/adobe/adobe/README.md
@@ -1,6 +1,6 @@
 # Adobe Kit Integration
 
-This repository contains the Adobe integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the Adobe integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the Adobe integration for the [mParticle Android SDK](h
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-adobe-kit:5+'
+        implementation 'com.mparticle:adobe:6.0.0'
     }
     ```
 

--- a/kits/appsflyer/appsflyer-6/README.md
+++ b/kits/appsflyer/appsflyer-6/README.md
@@ -1,6 +1,6 @@
 # AppsFlyer Kit Integration
 
-This repository contains the [AppsFlyer](https://www.appsflyer.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [AppsFlyer](https://www.appsflyer.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [AppsFlyer](https://www.appsflyer.com/) integration
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-appsflyer-kit:5+'
+        implementation 'com.mparticle:appsflyer-6:6.0.0'
     }
     ```
 

--- a/kits/apptentive/apptentive-6/README.md
+++ b/kits/apptentive/apptentive-6/README.md
@@ -1,6 +1,6 @@
 # Apptentive Kit Integration
 
-This repository contains the [Apptentive](https://www.apptentive.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Apptentive](https://www.apptentive.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Apptentive](https://www.apptentive.com/) integrati
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-apptentive-kit:5+'
+        implementation 'com.mparticle:apptentive-6:6.0.0'
     }
     ```
 

--- a/kits/apptimize/apptimize-3/README.md
+++ b/kits/apptimize/apptimize-3/README.md
@@ -1,6 +1,6 @@
 # Apptimize Kit Integration
 
-This repository contains the [Apptimize](https://www.apptimize.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Apptimize](https://www.apptimize.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -18,7 +18,7 @@ This repository contains the [Apptimize](https://www.apptimize.com/) integration
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-apptimize-kit:5+'
+        implementation 'com.mparticle:apptimize-3:6.0.0'
     }
     ```
 

--- a/kits/branch/branch-5/README.md
+++ b/kits/branch/branch-5/README.md
@@ -1,6 +1,6 @@
 # Branch Kit Integration
 
-This repository contains the [Branch](https://www.branch.io/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Branch](https://www.branch.io/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Branch](https://www.branch.io/) integration for th
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-branch-kit:5+'
+        implementation 'com.mparticle:branch-5:6.0.0'
     }
     ```
 

--- a/kits/branch/branch-5/SampleApplication/app/build.gradle
+++ b/kits/branch/branch-5/SampleApplication/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     api project(':local-mParticle-Branch-kit')
 
     // Uncomment below to use published version instead
-    // implementation 'com.mparticle:android-branch-kit:5+'
+    // implementation 'com.mparticle:branch-5:6.0.0'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/kits/braze/braze-38/README.md
+++ b/kits/braze/braze-38/README.md
@@ -1,17 +1,17 @@
 # Braze (formerly Appboy) Kit Integration
 
-This repository contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Example App
 
-This repository contains an [example app](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/tree/master/example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
+This directory includes an [example app](example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
 
 - [Instrumenting Push](https://docs.mparticle.com/developers/sdk/android/push-notifications)
 - [Braze Documentation](https://docs.mparticle.com/integrations/braze/event)
 
 ## 1. Adding the integration
 
-[See a full build.gradle example here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/build.gradle)
+[See a full build.gradle example here](example/build.gradle)
 
 1. The Braze Kit requires that you add Braze's Maven server to your buildscript:
 
@@ -28,7 +28,7 @@ This repository contains an [example app](https://github.com/mparticle-integrati
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-appboy-kit:5+'
+        implementation 'com.mparticle:braze-38:6.0.0'
     }
     ```
 
@@ -38,7 +38,7 @@ mParticle's SDK takes care of registering for push notifications and passing tok
 
 ## 3. Displaying Push
 
-[See a full example of an AndroidManifest.xml here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/src/main/AndroidManifest.xml).
+[See a full example of an AndroidManifest.xml here](example/src/main/AndroidManifest.xml).
 
 mParticle's SDK also takes care of capturing incoming push notifications and passing the resulting `Intent` to Braze's `BrazePushReceiver`. Follow the [mParticle push notification documentation](https://docs.mparticle.com/developers/sdk/android/push-notifications#display-push-notifications) to ensure you add the correct services and receivers to your app's AndroidManifest.xml.
 

--- a/kits/braze/braze-38/example/build.gradle
+++ b/kits/braze/braze-38/example/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     // REQUIRED: Add the Braze (formerly Appboy) kit here
     // this will also pull in mParticle's Core SDK (com.mparticle:android-core) as a transitive dependency
-    implementation 'com.mparticle:android-appboy-kit:5.6.5'
+    implementation 'com.mparticle:braze-38:6.0.0'
 
     // REQUIRED for Firebase
     implementation 'com.google.firebase:firebase-messaging:17.3.4'

--- a/kits/braze/braze-39/README.md
+++ b/kits/braze/braze-39/README.md
@@ -1,17 +1,17 @@
 # Braze (formerly Appboy) Kit Integration
 
-This repository contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Example App
 
-This repository contains an [example app](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/tree/master/example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
+This directory includes an [example app](example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
 
 - [Instrumenting Push](https://docs.mparticle.com/developers/sdk/android/push-notifications)
 - [Braze Documentation](https://docs.mparticle.com/integrations/braze/event)
 
 ## 1. Adding the integration
 
-[See a full build.gradle example here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/build.gradle)
+[See a full build.gradle example here](example/build.gradle)
 
 1. The Braze Kit requires that you add Braze's Maven server to your buildscript:
 
@@ -28,7 +28,7 @@ This repository contains an [example app](https://github.com/mparticle-integrati
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-appboy-kit:5+'
+        implementation 'com.mparticle:braze-39:6.0.0'
     }
     ```
 
@@ -38,7 +38,7 @@ mParticle's SDK takes care of registering for push notifications and passing tok
 
 ## 3. Displaying Push
 
-[See a full example of an AndroidManifest.xml here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/src/main/AndroidManifest.xml).
+[See a full example of an AndroidManifest.xml here](example/src/main/AndroidManifest.xml).
 
 mParticle's SDK also takes care of capturing incoming push notifications and passing the resulting `Intent` to Braze's `BrazePushReceiver`. Follow the [mParticle push notification documentation](https://docs.mparticle.com/developers/sdk/android/push-notifications#display-push-notifications) to ensure you add the correct services and receivers to your app's AndroidManifest.xml.
 

--- a/kits/braze/braze-39/example/build.gradle
+++ b/kits/braze/braze-39/example/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     // REQUIRED: Add the Braze (formerly Appboy) kit here
     // this will also pull in mParticle's Core SDK (com.mparticle:android-core) as a transitive dependency
-    implementation 'com.mparticle:android-appboy-kit:5.6.5'
+    implementation 'com.mparticle:braze-39:6.0.0'
 
     // REQUIRED for Firebase
     implementation 'com.google.firebase:firebase-messaging:17.3.4'

--- a/kits/braze/braze-40/README.md
+++ b/kits/braze/braze-40/README.md
@@ -1,17 +1,17 @@
 # Braze (formerly Appboy) Kit Integration
 
-This repository contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Example App
 
-This repository contains an [example app](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/tree/master/example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
+This directory includes an [example app](example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
 
 - [Instrumenting Push](https://docs.mparticle.com/developers/sdk/android/push-notifications)
 - [Braze Documentation](https://docs.mparticle.com/integrations/braze/event)
 
 ## 1. Adding the integration
 
-[See a full build.gradle example here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/build.gradle)
+[See a full build.gradle example here](example/build.gradle)
 
 1. The Braze Kit requires that you add Braze's Maven server to your buildscript:
 
@@ -28,7 +28,7 @@ This repository contains an [example app](https://github.com/mparticle-integrati
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:braze-40:5+'
+        implementation 'com.mparticle:braze-40:6.0.0'
     }
     ```
 
@@ -38,7 +38,7 @@ mParticle's SDK takes care of registering for push notifications and passing tok
 
 ## 3. Displaying Push
 
-[See a full example of an AndroidManifest.xml here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/src/main/AndroidManifest.xml).
+[See a full example of an AndroidManifest.xml here](example/src/main/AndroidManifest.xml).
 
 mParticle's SDK also takes care of capturing incoming push notifications and passing the resulting `Intent` to Braze's `BrazePushReceiver`. Follow the [mParticle push notification documentation](https://docs.mparticle.com/developers/sdk/android/push-notifications#display-push-notifications) to ensure you add the correct services and receivers to your app's AndroidManifest.xml.
 

--- a/kits/braze/braze-40/example/build.gradle
+++ b/kits/braze/braze-40/example/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     // REQUIRED: Add the Braze (formerly Appboy) kit here
     // this will also pull in mParticle's Core SDK (com.mparticle:android-core) as a transitive dependency
-    implementation 'com.mparticle:braze-40:5+'
+    implementation 'com.mparticle:braze-40:6.0.0'
 
     // REQUIRED for Firebase
     implementation 'com.google.firebase:firebase-messaging:17.3.4'

--- a/kits/braze/braze-41/README.md
+++ b/kits/braze/braze-41/README.md
@@ -1,17 +1,17 @@
 # Braze (formerly Appboy) Kit Integration
 
-This repository contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Braze](https://www.braze.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Example App
 
-This repository contains an [example app](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/tree/master/example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
+This directory includes an [example app](example) showing how to implement mParticle, Braze, and Firebase Cloud Messaging. The key changes you need to make to your app are below, and please also reference mParticle and Braze's documentation:
 
 - [Instrumenting Push](https://docs.mparticle.com/developers/sdk/android/push-notifications)
 - [Braze Documentation](https://docs.mparticle.com/integrations/braze/event)
 
 ## 1. Adding the integration
 
-[See a full build.gradle example here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/build.gradle)
+[See a full build.gradle example here](example/build.gradle)
 
 1. The Braze Kit requires that you add Braze's Maven server to your buildscript:
 
@@ -28,7 +28,7 @@ This repository contains an [example app](https://github.com/mparticle-integrati
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:braze-41:5+'
+        implementation 'com.mparticle:braze-41:6.0.0'
     }
     ```
 
@@ -38,7 +38,7 @@ mParticle's SDK takes care of registering for push notifications and passing tok
 
 ## 3. Displaying Push
 
-[See a full example of an AndroidManifest.xml here](https://github.com/mparticle-integrations/mparticle-android-integration-appboy/blob/master/example/src/main/AndroidManifest.xml).
+[See a full example of an AndroidManifest.xml here](example/src/main/AndroidManifest.xml).
 
 mParticle's SDK also takes care of capturing incoming push notifications and passing the resulting `Intent` to Braze's `BrazePushReceiver`. Follow the [mParticle push notification documentation](https://docs.mparticle.com/developers/sdk/android/push-notifications#display-push-notifications) to ensure you add the correct services and receivers to your app's AndroidManifest.xml.
 

--- a/kits/braze/braze-41/example/build.gradle
+++ b/kits/braze/braze-41/example/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     // REQUIRED: Add the Braze (formerly Appboy) kit here
     // this will also pull in mParticle's Core SDK (com.mparticle:android-core) as a transitive dependency
-    implementation 'com.mparticle:braze-41:5+'
+    implementation 'com.mparticle:braze-41:6.0.0'
 
     // REQUIRED for Firebase
     implementation 'com.google.firebase:firebase-messaging:17.3.4'

--- a/kits/clevertap/clevertap-7/README.md
+++ b/kits/clevertap/clevertap-7/README.md
@@ -1,6 +1,6 @@
 # CleverTap Kit Integration
 
-This repository contains the [CleverTap](https://www.clevertap.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [CleverTap](https://www.clevertap.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [CleverTap](https://www.clevertap.com/) integration
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-clevertap-kit:5+'
+        implementation 'com.mparticle:clevertap-7:6.0.0'
     }
     ```
 

--- a/kits/comscore/comscore-6/README.md
+++ b/kits/comscore/comscore-6/README.md
@@ -1,6 +1,6 @@
 # comScore Kit Integration
 
-This repository contains the [comScore](https://www.comscore.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [comScore](https://www.comscore.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [comScore](https://www.comscore.com/) integration f
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-comscore-kit:5+'
+        implementation 'com.mparticle:comscore-6:6.0.0'
     }
     ```
 

--- a/kits/iterable/iterable-3/README.md
+++ b/kits/iterable/iterable-3/README.md
@@ -1,6 +1,6 @@
 # Iterable Kit Integration
 
-This repository contains the [Iterable](https://www.iterable.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Iterable](https://www.iterable.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 mParticle's Iterable integration is predominantly server-side. This kit is an optional add-on to handle Iterable deep links.
 
@@ -10,7 +10,7 @@ mParticle's Iterable integration is predominantly server-side. This kit is an op
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-iterable-kit:5+'
+        implementation 'com.mparticle:iterable-3:6.0.0'
     }
     ```
 

--- a/kits/kochava/kochava-5/README.md
+++ b/kits/kochava/kochava-5/README.md
@@ -1,6 +1,6 @@
 # Kochava Kit Integration
 
-This repository contains the [Kochava](https://www.kochava.com) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Kochava](https://www.kochava.com) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Kochava](https://www.kochava.com) integration for 
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-kochava-kit:5+'
+        implementation 'com.mparticle:kochava-5:6.0.0'
     }
     ```
 

--- a/kits/leanplum/leanplum-7/README.md
+++ b/kits/leanplum/leanplum-7/README.md
@@ -1,6 +1,6 @@
 # Leanplum Kit Integration
 
-This repository contains the [Leanplum](https://www.leanplum.com/) integration for the [mParticle Android SDK](https://github.com/mParticle.mparticle-android-sdk).
+This directory contains the [Leanplum](https://www.leanplum.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -17,7 +17,7 @@ This repository contains the [Leanplum](https://www.leanplum.com/) integration f
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-leanplum-kit:5+'
+        implementation 'com.mparticle:leanplum-7:6.0.0'
     }
     ```
 
@@ -32,7 +32,7 @@ Leanplum is deprecating GCM support, but it is still available. While we recomme
 
     ```groovy
     dependencies {
-        implementation ('com.mparticle:android-leanplum-kit:REPLACE-ME') {
+        implementation ('com.mparticle:leanplum-7:6.0.0') {
                 exclude module: 'leanplum-fcm'
         }
         implementation 'com.leanplum:leanplum-gcm:4.1.1'

--- a/kits/leanplum/leanplum-7/leanplum-example/build.gradle
+++ b/kits/leanplum/leanplum-7/leanplum-example/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:11.6.2'
 
     //In a typical app:
-    //implementation 'com.mparticle:android-leanplum-kit:+'
+    //implementation 'com.mparticle:leanplum-7:6.0.0'
 
     //if you're building the entire mParticle SDK
     implementation project(':kits:android-leanplum-kit')

--- a/kits/localytics/localytics-6/README.md
+++ b/kits/localytics/localytics-6/README.md
@@ -1,6 +1,6 @@
 # Localytics Kit Integration
 
-This repository contains the [Localytics](https://www.localytics.com) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Localytics](https://www.localytics.com) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -17,7 +17,7 @@ This repository contains the [Localytics](https://www.localytics.com) integratio
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-localytics-kit:5+'
+        implementation 'com.mparticle:localytics-6:6.0.0'
     }
     ```
 

--- a/kits/onetrust/onetrust/README.md
+++ b/kits/onetrust/onetrust/README.md
@@ -2,7 +2,7 @@
 
 [See here for more information](https://github.com/mParticle/mparticle-android-sdk/wiki/Kit-Development) on how to use this example to write a new kit.
 
-This repository contains the [OneTrust](https://www.onetrust.com) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [OneTrust](https://www.onetrust.com) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -10,7 +10,7 @@ This repository contains the [OneTrust](https://www.onetrust.com) integration fo
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-onetrust-kit:5+'
+        implementation 'com.mparticle:onetrust:6.0.0'
         // Implement the SDK version that corresponds to the published version you're using'
         implementation 'com.onetrust.cmp:native-sdk:X.X.0.0'
 

--- a/kits/optimizely/optimizely-3/README.md
+++ b/kits/optimizely/optimizely-3/README.md
@@ -1,6 +1,6 @@
 # Optimizely Kit Integration
 
-This repository contains the [Optimizely](https://developers.optimizely.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Optimizely](https://developers.optimizely.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Optimizely](https://developers.optimizely.com/) in
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-optimizely-kit:5+'
+        implementation 'com.mparticle:optimizely-3:6.0.0'
     }
     ```
 

--- a/kits/radar/radar-3/README.md
+++ b/kits/radar/radar-3/README.md
@@ -1,6 +1,6 @@
 # Radar Kit Integration
 
-This repository contains the [Radar](https://www.onradar.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Radar](https://www.onradar.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Radar](https://www.onradar.com/) integration for t
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-radar-kit:5+'
+        implementation 'com.mparticle:radar-3:6.0.0'
     }
     ```
 

--- a/kits/rokt/rokt/README.md
+++ b/kits/rokt/rokt/README.md
@@ -1,6 +1,6 @@
 # Rokt Kit Integration
 
-This repository contains the [Rokt](https://docs.rokt.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Rokt](https://docs.rokt.com/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -8,7 +8,7 @@ This repository contains the [Rokt](https://docs.rokt.com/) integration for the 
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-rokt-kit:6+'
+        implementation 'com.mparticle:android-rokt-kit:6.0.0'
     }
     ```
 

--- a/kits/singular/singular-12/README.md
+++ b/kits/singular/singular-12/README.md
@@ -1,6 +1,6 @@
 # Singular Kit Integration
 
-This repository contains the [Singular](https://www.singular.net/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
+This directory contains the [Singular](https://www.singular.net/) integration for the [mParticle Android SDK](https://github.com/mParticle/mparticle-android-sdk).
 
 ## Adding the integration
 
@@ -17,7 +17,7 @@ This repository contains the [Singular](https://www.singular.net/) integration f
 
     ```groovy
     dependencies {
-        implementation 'com.mparticle:android-singular-kit:5+'
+        implementation 'com.mparticle:singular-12:6.0.0'
     }
     ```
 


### PR DESCRIPTION
## Background

The Android SDK v6 migration brought mParticle-maintained kits into this
monorepo and changed the Maven coordinates for most kits. Existing
documentation still directs users to retired standalone repositories and v5
artifacts, which can lead them to install outdated integrations.

## What Has Changed

- Pin core SDK, kit, and Android plugin examples to version `6.0.0`.
- Replace retired kit repository and search links with monorepo source paths
  and direct Maven Central artifact pages.
- Correct published kit READMEs, onboarding paths, and the maintained Branch,
  Braze, and Leanplum sample dependencies.
- Remove unavailable, obsolete, and unsupported kits from the published kit
  list.

## Screenshots/Video

N/A — documentation and build example changes only.

## Checklist

- [x] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally