### PR TITLE
fix(testutils): never generate empty random user identities

### DIFF
--- a/android-core/src/test/java/com/mparticle/testutils/RandomUtilsTest.java
+++ b/android-core/src/test/java/com/mparticle/testutils/RandomUtilsTest.java
@@ -1,0 +1,65 @@
+package com.mparticle.testutils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.mparticle.MParticle;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Guards the invariants that random identity generation must hold for the identity tests to be
+ * deterministic.
+ *
+ * <p>An empty identity map is not an innocuous edge case: {@code MParticleIdentityClientImpl.modify()}
+ * short-circuits and returns 200 without issuing an HTTP request when there are no identity
+ * changes, so a test that awaits the modify request hangs and then fails on an unrelated
+ * assertion. That was the cause of the intermittent
+ * {@code MParticleIdentityClientImplTest.testModifyMessage} failures.
+ */
+public class RandomUtilsTest {
+    private static final int ITERATIONS = 1000;
+
+    private final RandomUtils randomUtils = new RandomUtils();
+
+    @Test
+    public void testRandomUserIdentitiesNeverEmpty() {
+        for (int i = 0; i < ITERATIONS; i++) {
+            assertNonEmptyAndAliasFree(randomUtils.getRandomUserIdentities());
+        }
+    }
+
+    @Test
+    public void testBoundedRandomUserIdentitiesNeverEmpty() {
+        int poolSize = MParticle.IdentityType.values().length;
+        for (int max = 1; max <= poolSize + 1; max++) {
+            // Fewer iterations per bound: the pre-fix failure rate here was 1-in-22, so this is
+            // still overwhelmingly likely to catch a regression.
+            for (int i = 0; i < ITERATIONS / 10; i++) {
+                Map<MParticle.IdentityType, String> identities =
+                        randomUtils.getRandomUserIdentities(max);
+                assertNonEmptyAndAliasFree(identities);
+                assertTrue(
+                        "expected at most " + max + " identities but got " + identities.size(),
+                        identities.size() <= max);
+            }
+        }
+    }
+
+    @Test
+    public void testMockRandomUserIdentitiesNeverEmpty() {
+        for (int i = 0; i < ITERATIONS; i++) {
+            assertNonEmptyAndAliasFree(
+                    com.mparticle.mock.utils.RandomUtils.getInstance().getRandomUserIdentities());
+        }
+    }
+
+    private void assertNonEmptyAndAliasFree(Map<MParticle.IdentityType, String> identities) {
+        assertFalse("random user identities must never be empty", identities.isEmpty());
+        assertFalse(
+                "Alias is not a settable user identity and must never be generated",
+                identities.containsKey(MParticle.IdentityType.Alias));
+    }
+}

--- a/testutils/src/main/java/com/mparticle/mock/utils/RandomUtils.java
+++ b/testutils/src/main/java/com/mparticle/mock/utils/RandomUtils.java
@@ -7,6 +7,8 @@ import com.mparticle.MParticle;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +26,21 @@ public class RandomUtils {
 
     private static RandomUtils instance;
 
+    /**
+     * Every IdentityType that can legitimately appear in a user identity map. Alias is excluded
+     * from the pool rather than removed after the draw -- removing it afterwards can leave the
+     * map empty, which silently changes the meaning of any request built from it.
+     */
+    private static final List<MParticle.IdentityType> ASSIGNABLE_IDENTITY_TYPES =
+            assignableIdentityTypes();
+
+    private static List<MParticle.IdentityType> assignableIdentityTypes() {
+        List<MParticle.IdentityType> types =
+                new ArrayList<MParticle.IdentityType>(Arrays.asList(MParticle.IdentityType.values()));
+        types.remove(MParticle.IdentityType.Alias);
+        return Collections.unmodifiableList(types);
+    }
+
     public static RandomUtils getInstance() {
         if (instance == null) {
             instance = new RandomUtils();
@@ -31,16 +48,19 @@ public class RandomUtils {
         return instance;
     }
 
+    /**
+     * @return between 1 and the number of assignable IdentityTypes distinct random user
+     * identities. Never empty.
+     */
     public Map<MParticle.IdentityType, String> getRandomUserIdentities() {
-        Map<MParticle.IdentityType, String> randomIdentities = new HashMap<MParticle.IdentityType, String>();
+        int poolSize = ASSIGNABLE_IDENTITY_TYPES.size();
+        int numIdentities = randomInt(1, poolSize + 1);
 
-        int identityTypeLength = MParticle.IdentityType.values().length;
-        int numIdentities = randomInt(1, identityTypeLength);
-        Set<Integer> identityIndices = randomIntSet(0, identityTypeLength, numIdentities);
+        Map<MParticle.IdentityType, String> randomIdentities = new HashMap<MParticle.IdentityType, String>();
+        Set<Integer> identityIndices = randomIntSet(0, poolSize, numIdentities);
         for (Integer identityIndex : identityIndices) {
-            randomIdentities.put(MParticle.IdentityType.values()[identityIndex], getAlphaNumericString(randomInt(1, 55)));
+            randomIdentities.put(ASSIGNABLE_IDENTITY_TYPES.get(identityIndex), getAlphaNumericString(randomInt(1, 55)));
         }
-        randomIdentities.remove(MParticle.IdentityType.Alias);
         return randomIdentities;
     }
 

--- a/testutils/src/main/java/com/mparticle/testutils/RandomUtils.java
+++ b/testutils/src/main/java/com/mparticle/testutils/RandomUtils.java
@@ -2,7 +2,11 @@ package com.mparticle.testutils;
 
 import com.mparticle.MParticle;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -16,20 +20,39 @@ public class RandomUtils {
     private static final String sNumbers = "0123456789";
     private static final String sCharacters = " ,.";
 
+    /**
+     * Every IdentityType that can legitimately appear in a user identity map. Alias is excluded
+     * from the pool rather than removed after the draw -- removing it afterwards can leave the
+     * map empty, which silently changes the meaning of any request built from it.
+     */
+    private static final List<MParticle.IdentityType> ASSIGNABLE_IDENTITY_TYPES =
+            assignableIdentityTypes();
+
+    private static List<MParticle.IdentityType> assignableIdentityTypes() {
+        List<MParticle.IdentityType> types =
+                new ArrayList<MParticle.IdentityType>(Arrays.asList(MParticle.IdentityType.values()));
+        types.remove(MParticle.IdentityType.Alias);
+        return Collections.unmodifiableList(types);
+    }
+
     public Map<MParticle.IdentityType, String> getRandomUserIdentities() {
         return getRandomUserIdentities(null);
     }
 
+    /**
+     * @param max the most identities to return, or null for no limit
+     * @return between 1 and {@code max} distinct random user identities. Never empty.
+     */
     public Map<MParticle.IdentityType, String> getRandomUserIdentities(Integer max) {
-        Map<MParticle.IdentityType, String> randomIdentities = new HashMap<MParticle.IdentityType, String>();
+        int poolSize = ASSIGNABLE_IDENTITY_TYPES.size();
+        int upperBound = (max != null && max < poolSize) ? Math.max(1, max) : poolSize;
+        int numIdentities = randomInt(1, upperBound + 1);
 
-        int identityTypeLength = MParticle.IdentityType.values().length;
-        int numIdentities = randomInt(1, (max != null && max < identityTypeLength) ? max : identityTypeLength);
-        Set<Integer> identityIndices = randomIntSet(0, identityTypeLength, numIdentities);
+        Map<MParticle.IdentityType, String> randomIdentities = new HashMap<MParticle.IdentityType, String>();
+        Set<Integer> identityIndices = randomIntSet(0, poolSize, numIdentities);
         for (Integer identityIndex : identityIndices) {
-            randomIdentities.put(MParticle.IdentityType.values()[identityIndex], getAlphaNumericString(randomInt(1, 55)));
+            randomIdentities.put(ASSIGNABLE_IDENTITY_TYPES.get(identityIndex), getAlphaNumericString(randomInt(1, 55)));
         }
-        randomIdentities.remove(MParticle.IdentityType.Alias);
         return randomIdentities;
     }
 


### PR DESCRIPTION
### Summary

`RandomUtils.getRandomUserIdentities()` could return an **empty** map, which makes `MParticleIdentityClientImplTest.testModifyMessage` fail intermittently. This was **3 of the 21 instrumented-test failures** across the last 150 `pull-request.yml` runs (2026-04-03 → 2026-08-03).

### Root cause

Both `RandomUtils` classes drew indices from the full 22-value `IdentityType` enum and removed `Alias` *afterwards*:

```java
int numIdentities = randomInt(1, identityTypeLength);   // [1, 21]
...
randomIdentities.remove(MParticle.IdentityType.Alias);  // can empty the map
```

Draw exactly one index and have it be `Alias` → empty map. P ≈ 1/462 per call for the no-arg overload; **1/22** for `getRandomUserIdentities(2)`, because `randomInt(1, 2)` always returns 1.

An empty map is not benign: `MParticleIdentityClientImpl.modify()` short-circuits at `:118-121` and returns 200 **without issuing an HTTP request** when `identity_changes` is empty. The test's mock therefore never observes `MODIFY_PATH`, its latch never counts down, and it fails on an unrelated assertion — the observed `AssertionError: null` at `MParticleIdentityClientImplTest.kt:306`. The failing CI log confirms it: Mock Server Requests contains only `/config` and `/v1/identify`, no modify.

### Fix

Exclude `Alias` from the candidate pool rather than removing it after the draw, so the result can never be empty. Applied to both copies (`testutils` for instrumented tests, `mock.utils` for JVM tests).

Also makes the `max` bound **inclusive**, which fixes a latent `ArithmeticException` (divide-by-zero) on `getRandomUserIdentities(1)`.

### Behaviour change to note for reviewers

`getRandomUserIdentities(2)` previously always returned exactly 1 identity; it now returns 1–2. That matches what "max" reads like, and the three call sites (`IdentityApiTest.kt:361,375,389`) only round-trip the map and compare, so they don't depend on the count.

### Test placement

The new `RandomUtilsTest` lives in `android-core/src/test/`, not in `testutils`. The `testutils` module has **no test source set**, so a `@Test` in its `src/main` is never discovered by any test task — the pre-existing `testRandomInt` in `mock/utils/RandomUtils.java` is dead code. The new test covers both `RandomUtils` classes.

### Verification

| Check | Result |
|---|---|
| `./gradlew test` (all modules) | 786 tests, 0 failures |
| `RandomUtilsTest` vs. **pre-fix** code | 3/3 **fail** — guard is effective |
| `RandomUtilsTest` vs. fixed code | 3/3 pass |
| `./gradlew ktlintCheck` | pass |
| `trunk check` on changed files | no issues |
| Instrumented tests, all affected classes | 38/38 pass |

Every call site of the changed method is covered: the four `androidTest` classes (`MParticleIdentityClientImplTest`, `IdentityApiTest`, `IdentityApiStartTest`, `MParticleJSInterfaceITest`, 15 call sites) were in the 38-test run, and the 3 JVM call sites in `MParticleJSInterfaceTest` passed (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
