### PR TITLE
fix(core): bound BaseHandler.disable() instead of spinning indefinitely

### DIFF
--- a/android-core/src/androidTest/kotlin/com.mparticle/internal/BaseHandlerDisableTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/internal/BaseHandlerDisableTest.kt
@@ -1,0 +1,132 @@
+package com.mparticle.internal
+
+import android.os.HandlerThread
+import android.os.Message
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression tests for [BaseHandler.disable].
+ *
+ * `disable()` used to wait for an in-flight message with an unbounded, non-yielding spin:
+ *
+ * ```
+ * while (handling) {
+ * }
+ * ```
+ *
+ * A loop like that never lets the runtime suspend the thread, so it can starve the garbage
+ * collector: if the handler thread is itself blocked on an allocation that needs a collection the
+ * spinning thread is preventing, neither side can progress. That is not theoretical -- it was
+ * observed with the test thread in state R at 100% CPU holding the mutator lock at this line, while
+ * the upload handler sat inside `handleMessage()` in an allocating call, so `handling` never
+ * cleared.
+ *
+ * It matters well beyond the SDK's own shutdown path: `MParticle.reset()` calls it, and
+ * `BaseAbstractTest.beforeImpl()` calls `MParticle.reset()` in the `@Before` of every instrumented
+ * test. One wedge there stalls the entire `connectedAndroidTest` run, which is why CI saw
+ * instrumented jobs burn their whole `timeout-minutes` budget and get reported as "cancelled" with
+ * no test report and no stack trace.
+ */
+@RunWith(AndroidJUnit4::class)
+class BaseHandlerDisableTest {
+
+    /**
+     * Generous relative to the 5s drain timeout, so this asserts "bounded" rather than asserting an
+     * exact duration that would be sensitive to emulator scheduling.
+     */
+    private val disableMustReturnWithinMs = 30_000L
+
+    /**
+     * `disable()` is called on a separate thread rather than on the test thread on purpose. Against
+     * the unfixed implementation it never returns, and calling it here would hang the test thread
+     * itself -- reproducing the very failure this test exists to catch, rather than reporting it.
+     * On a worker thread the failure is a clean, readable assertion instead.
+     *
+     * The worker is a daemon so it cannot hold the process open. In the failing case it does keep
+     * spinning for the remainder of the run, but that only happens when the bug is already present.
+     */
+    @Test
+    fun disableReturnsEvenWhileAMessageIsStillBeingHandled() {
+        val thread = HandlerThread("mp-basehandler-disable-test").apply { start() }
+        val messageIsBeingHandled = CountDownLatch(1)
+        val releaseHandlerThread = CountDownLatch(1)
+        try {
+            val handler = object : BaseHandler(thread.looper) {
+                override fun handleMessageImpl(msg: Message?) {
+                    messageIsBeingHandled.countDown()
+                    // Stay inside handleMessage() for the whole of the disable() call below, so
+                    // that `handling` is true the entire time it is observed. This is the condition
+                    // the old spin loop could not escape.
+                    releaseHandlerThread.await(disableMustReturnWithinMs * 2, TimeUnit.MILLISECONDS)
+                }
+            }
+
+            handler.sendMessage(handler.obtainMessage(1))
+            assertTrue(
+                "Handler never picked up the message, so the scenario under test was never set up",
+                messageIsBeingHandled.await(10, TimeUnit.SECONDS),
+            )
+
+            val disableReturned = CountDownLatch(1)
+            Thread {
+                handler.disable(true)
+                disableReturned.countDown()
+            }.apply {
+                name = "mp-basehandler-disable-caller"
+                isDaemon = true
+            }.start()
+
+            assertTrue(
+                "disable() did not return within ${disableMustReturnWithinMs}ms with a message in " +
+                    "flight; it is spinning instead of giving up waiting",
+                disableReturned.await(disableMustReturnWithinMs, TimeUnit.MILLISECONDS),
+            )
+        } finally {
+            releaseHandlerThread.countDown()
+            thread.quitSafely()
+        }
+    }
+
+    /**
+     * Bounding the wait must not turn into not waiting at all: a message that finishes well within
+     * the drain timeout should still have completed by the time `disable()` returns.
+     *
+     * Safe to run on the test thread -- the in-flight message finishes in 500ms, so this cannot hang
+     * even against the unfixed implementation.
+     */
+    @Test
+    fun disableStillWaitsForAnInFlightMessageToFinish() {
+        val thread = HandlerThread("mp-basehandler-disable-drain-test").apply { start() }
+        val messageIsBeingHandled = CountDownLatch(1)
+        val finishedHandling = CountDownLatch(1)
+        try {
+            val handler = object : BaseHandler(thread.looper) {
+                override fun handleMessageImpl(msg: Message?) {
+                    messageIsBeingHandled.countDown()
+                    Thread.sleep(500)
+                    finishedHandling.countDown()
+                }
+            }
+
+            handler.sendMessage(handler.obtainMessage(1))
+            assertTrue(
+                "Handler never picked up the message, so the scenario under test was never set up",
+                messageIsBeingHandled.await(10, TimeUnit.SECONDS),
+            )
+
+            handler.disable(true)
+
+            assertTrue(
+                "disable() returned before the in-flight message finished",
+                finishedHandling.count == 0L,
+            )
+        } finally {
+            thread.quitSafely()
+        }
+    }
+}

--- a/android-core/src/main/java/com/mparticle/internal/BaseHandler.java
+++ b/android-core/src/main/java/com/mparticle/internal/BaseHandler.java
@@ -3,6 +3,7 @@ package com.mparticle.internal;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.os.SystemClock;
 
 import com.mparticle.internal.listeners.InternalListenerManager;
 
@@ -11,6 +12,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 public class BaseHandler extends Handler {
+    /**
+     * Longest that {@link #disable(boolean)} will wait for an in-flight message to finish before
+     * giving up and returning. The handler is already flagged disabled and its queue already
+     * cleared by that point, so returning early only means one in-flight message may still be
+     * completing on the handler thread.
+     */
+    private static final long DISABLE_DRAIN_TIMEOUT_MS = 5000;
+
     private volatile boolean disabled;
     private volatile boolean handling;
 
@@ -24,7 +33,18 @@ public class BaseHandler extends Handler {
     public void disable(boolean disable) {
         this.disabled = disable;
         removeCallbacksAndMessages(null);
-        while (handling) {
+        // Wait for any in-flight handleMessage() to finish, but never spin without yielding: a
+        // tight `while (handling) {}` loop contains no suspend point, so it can starve the
+        // garbage collector indefinitely. If the handler thread is itself blocked waiting on a
+        // GC that this thread is preventing, neither side can progress. Thread.yield() gives the
+        // runtime a suspend point, and the deadline bounds the wait either way.
+        long deadline = SystemClock.uptimeMillis() + DISABLE_DRAIN_TIMEOUT_MS;
+        while (handling && SystemClock.uptimeMillis() < deadline) {
+            Thread.yield();
+        }
+        if (handling) {
+            Logger.error("Handler: " + getClass().getName() + " still had a message in flight after "
+                    + DISABLE_DRAIN_TIMEOUT_MS + "ms; giving up waiting for it to drain.");
         }
     }
 


### PR DESCRIPTION
## Summary

`BaseHandler.disable()` waited for an in-flight message with an unbounded, non-yielding spin:

```java
while (handling) {
}
```

That loop contains no suspend point, so the runtime can never suspend the thread. If the handler thread is itself blocked on an allocation that needs a GC the spinning thread is preventing, neither side can progress — a livelock.

This is the root cause of the instrumented-test jobs that burn their full `timeout-minutes` and get reported as **`cancelled`** with no test report and no stack trace. **24 such timeouts in the last two months (~12% of `instrumented-core` attempts, 22% of workflow runs), ~576 wasted runner-minutes.**

## Evidence

Reproduced locally and captured with `debuggerd -j` while stalled:

```
"Instr: androidx.test.runner.AndroidJUnitRunner" state=R utm=20829
  | held mutexes= "mutator lock"(shared held)
  at com.mparticle.internal.BaseHandler.disable(BaseHandler.java:27)
  at com.mparticle.internal.MessageManager.disable(MessageManager.java:1041)
  at com.mparticle.MParticle.reset(MParticle.java:1239)
  at com.mparticle.AccessUtils.reset(AccessUtils.java:19)
  at com.mparticle.testutils.BaseAbstractTest.clearStorage(BaseAbstractTest.java:133)
  at com.mparticle.testutils.BaseAbstractTest.beforeImpl(BaseAbstractTest.java:73)   <- @Before
```

`top -H` showed that thread in state **R at 100% CPU for 3m09s** — a spin, not a wait. Meanwhile `mParticleUploadHandler` was inside `handleMessage()` in `DatabaseUtils` → `String.toUpperCase` → `CaseMapper.toUpperCase`, an **allocating** call, so `handling` never cleared.

Two things this explains that no other theory did:

- **Why there is never any log output.** A busy-spin logs nothing.
- **Why the hang appeared at a different test each time.** It is reached from `MParticle.reset()` in `BaseAbstractTest.beforeImpl()` — the `@Before` of every instrumented test — so the apparent "hang site" is just whichever test happened to run next. Locally it stalled at `BatchSessionInfoTest#testProperSessionAttachedToBatch` twice and `MParticleTest#testEnableLocationTracking` twice.

The first of those matches PR #750 attempt 1 exactly: `testDontIncludeDefaultMpidSessionEnd` passes, then silence.

## Before / after

| | Unfixed | Fixed |
|---|---|---|
| Pristine `main`, full suite | **2/2 stalled** (>10 min, >6 min) | — |
| Full suite × 5 | **1 hard stall, 2 livelock events** | **0 stalls, 0 livelock events** |
| Full suite × 5 (repeat) | — | **0 stalls, 0 livelock events** |
| Targeted regression test | **0/5 pass** | **10/10 pass** |
| Tests / failures | 239 / 5 | 239 / **4** |

The 4 remaining failures are pre-existing on API 36 (CI runs API 28), identical before and after, and unrelated to this change.

## Note on why a per-test timeout does not fix this

Worth recording, because it is counter-intuitive: AndroidJUnitRunner's `timeout_msec` **cannot** rescue this. The runner cancels a test by interrupting its thread, and a busy-spin never observes an interrupt. A pristine run stalled for 10 minutes with `timeout_msec=30000` set. A spin has to be bounded in the code itself.

## Regression test

`BaseHandlerDisableTest` calls `disable()` on a worker thread rather than the test thread. Against the unfixed code that fails in 30s with `disable() did not return within 30000ms with a message in flight; it is spinning instead of giving up waiting`, rather than hanging the suite the way the bug does. The second case guards the opposite direction — that bounding the wait does not become never waiting.

## Follow-ups, deliberately not in this PR

- A `HangWatchdog` JUnit rule that dumps all thread stacks at 45s and 75s. It caught this livelock autonomously with a stack pointing straight at `BaseHandler.java:27`, and two dumps 30s apart distinguish spinning from blocked. Rides into failure messages via the existing `CaptureLogcatOnFailingTest`.
- `MPLatch.await()` discards the result of its 5s bounded wait, so ~95 call sites silently continue on timeout. Four tests take exactly 5.2s every run and are not verifying what they claim.
- `Matcher.isMatch()` rethrows as `Error`, which slips past the `catch (Exception)` handling in `MockServer` and unwinds a network thread invisibly.
- `MockServer.blockers` is dead code that reads like the blocking mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)