### PR TITLE
feat: report mParticle API usage through the Rokt kit

### DIFF
--- a/android-core/src/main/java/com/mparticle/MParticle.java
+++ b/android-core/src/main/java/com/mparticle/MParticle.java
@@ -148,6 +148,7 @@ public class MParticle {
      * @param interval in seconds
      */
     public void setUpdateInterval(int interval) {
+        MParticle.logRoktApiUsage("SET_UPLOAD_INTERVAL");
         long intervalMillis = interval * 1000L;
         if ((intervalMillis >= 1 && mConfigManager.getUploadInterval() != intervalMillis)) {
             upload();
@@ -281,6 +282,45 @@ public class MParticle {
         MParticle.instance = instance;
     }
 
+    // Rokt public-API-usage diagnostics are suppressed while SDK/kit internals invoke a public API
+    // (auto-upload, the Rokt kit's attribute enrichment, deferred push-token modify, etc.) so only
+    // genuine partner calls are reported. Synchronous by design: logRoktApiUsage runs at each
+    // instrumented method's first line, on the caller's thread, before any dispatch — so this flag
+    // is active for that call. ponytail: covers synchronous re-entry only, which is exactly how the
+    // instrumented methods emit; async internal paths that need it call withoutRoktApiUsage directly.
+    private static final ThreadLocal<Boolean> sSuppressRoktApiUsage = new ThreadLocal<>();
+
+    /**
+     * @hide Internal: forwards a bounded, non-PII public-API-usage diagnostic code to the Rokt kit
+     * (only when the kit is active). No-op when mParticle isn't started, Rokt isn't integrated, or
+     * the call originates from SDK/kit internals (see {@link #withoutRoktApiUsage(Runnable)}).
+     * Reads the static instance directly so it stays quiet (no getInstance() warning) on the hot path.
+     * Not intended for partner use.
+     */
+    public static void logRoktApiUsage(@Nullable String code) {
+        if (Boolean.TRUE.equals(sSuppressRoktApiUsage.get())) {
+            return;
+        }
+        MParticle mp = instance;
+        if (mp != null && mp.mKitManager != null) {
+            mp.mKitManager.logRoktApiDiagnostic(code);
+        }
+    }
+
+    /**
+     * @hide Internal: run SDK/kit work that invokes public APIs without emitting Rokt usage
+     * diagnostics, so internal re-entry isn't misreported as a partner call. Not for partner use.
+     */
+    public static void withoutRoktApiUsage(@NonNull Runnable action) {
+        boolean previous = Boolean.TRUE.equals(sSuppressRoktApiUsage.get());
+        sSuppressRoktApiUsage.set(true);
+        try {
+            action.run();
+        } finally {
+            sSuppressRoktApiUsage.set(previous);
+        }
+    }
+
     /**
      * Switch the SDK to a new API key and secret.
      * Will first batch all events that have not been sent to mParticle into upload records,
@@ -291,6 +331,7 @@ public class MParticle {
      @param options Required to initialize the SDK properly
      */
     public static void switchWorkspace(@NonNull MParticleOptions options) {
+        MParticle.logRoktApiUsage("SWITCH_WORKSPACE");
         synchronized (MParticle.class) {
             MParticle localInstance = instance;
             if (localInstance == null) {
@@ -446,6 +487,7 @@ public class MParticle {
      * Force upload all queued messages to the mParticle server.
      */
     public void upload() {
+        MParticle.logRoktApiUsage("UPLOAD");
         mMessageManager.doUpload();
     }
 
@@ -454,6 +496,7 @@ public class MParticle {
      * automatically retrieved upon installation from Google Play.
      */
     public void setInstallReferrer(@Nullable String referrer) {
+        MParticle.logRoktApiUsage("SET_INSTALL_REFERRER");
         InstallReferrerHelper.setInstallReferrer(mAppContext, referrer);
     }
 
@@ -468,6 +511,7 @@ public class MParticle {
     }
 
     public void logEvent(@NonNull BaseEvent event) {
+        MParticle.logRoktApiUsage("LOG_EVENT");
         if (event instanceof MPEvent && event.isShouldUploadEvent()) {
             logMPEvent((MPEvent) event);
         } else if (event instanceof CommerceEvent && event.isShouldUploadEvent()) {
@@ -519,6 +563,7 @@ public class MParticle {
      * @param contextInfo    An MPProduct or any set of data to associate with this increase in LTV (optional)
      */
     public void logLtvIncrease(@NonNull BigDecimal valueIncreased, @Nullable String eventName, @Nullable Map<String, String> contextInfo) {
+        MParticle.logRoktApiUsage("LOG_LTV_INCREASE");
         if (valueIncreased == null) {
             Logger.error("ValueIncreased must not be null.");
             return;
@@ -528,11 +573,13 @@ public class MParticle {
         }
         contextInfo.put(MessageKey.RESERVED_KEY_LTV, valueIncreased.toPlainString());
         contextInfo.put(Constants.MethodName.METHOD_NAME, Constants.MethodName.LOG_LTV);
-        logEvent(
+        final Map<String, String> ltvContextInfo = contextInfo;
+        // Internal re-entry: this is LOG_LTV_INCREASE, not a partner LOG_EVENT call.
+        withoutRoktApiUsage(() -> logEvent(
                 new MPEvent.Builder(eventName == null ? "Increase LTV" : eventName, EventType.Transaction)
-                        .customAttributes(contextInfo)
+                        .customAttributes(ltvContextInfo)
                         .build()
-        );
+        ));
     }
 
     /**
@@ -572,6 +619,7 @@ public class MParticle {
      * @param screenEvent an event object, the name of the event will be used as the screen name
      */
     public void logScreen(@NonNull MPEvent screenEvent) {
+        MParticle.logRoktApiUsage("LOG_SCREEN");
         screenEvent.setScreenEvent(true);
         if (MPUtility.isEmpty(screenEvent.getEventName())) {
             Logger.error("screenName is required for logScreen.");
@@ -598,6 +646,7 @@ public class MParticle {
      * @param breadcrumb
      */
     public void leaveBreadcrumb(@NonNull String breadcrumb) {
+        MParticle.logRoktApiUsage("LEAVE_BREADCRUMB");
         if (mConfigManager.isEnabled()) {
             if (MPUtility.isEmpty(breadcrumb)) {
                 Logger.error("breadcrumb is required for leaveBreadcrumb.");
@@ -630,6 +679,7 @@ public class MParticle {
      * @param errorAttributes a Map of data attributes to associate with this error
      */
     public void logError(@NonNull String message, @Nullable Map<String, String> errorAttributes) {
+        MParticle.logRoktApiUsage("LOG_ERROR");
         if (mConfigManager.isEnabled()) {
             if (MPUtility.isEmpty(message)) {
                 Logger.error("message is required for logErrorEvent.");
@@ -646,6 +696,7 @@ public class MParticle {
     }
 
     public void logNetworkPerformance(@NonNull String url, long startTime, @NonNull String method, long length, long bytesSent, long bytesReceived, @Nullable String requestString, int responseCode) {
+        MParticle.logRoktApiUsage("LOG_NETWORK_PERFORMANCE");
         if (mConfigManager.isEnabled()) {
             mAppStateManager.ensureActiveSession();
             mMessageManager.logNetworkPerformanceEvent(startTime, method, url, length, bytesSent, bytesReceived, requestString);
@@ -694,6 +745,7 @@ public class MParticle {
      */
     @NonNull
     public Map<Integer, AttributionResult> getAttributionResults() {
+        MParticle.logRoktApiUsage("GET_ATTRIBUTION_INFO");
         return mKitManager.getAttributionResults();
     }
 
@@ -706,6 +758,7 @@ public class MParticle {
      * @param message   the name of the error event to be tracked
      */
     public void logException(@NonNull Exception exception, @Nullable Map<String, String> eventData, @Nullable String message) {
+        MParticle.logRoktApiUsage("LOG_EXCEPTION");
         if (mConfigManager.isEnabled()) {
             mAppStateManager.ensureActiveSession();
             JSONObject eventDataJSON = MPUtility.enforceAttributeConstraints(eventData);
@@ -821,6 +874,7 @@ public class MParticle {
      * @param value the attribute value. This value will be converted to its String representation as dictated by its <code>toString()</code> method.
      */
     public void setSessionAttribute(@NonNull String key, @Nullable Object value) {
+        MParticle.logRoktApiUsage("SET_SESSION_ATTRIBUTE");
         if (key == null) {
             Logger.warning("setSessionAttribute called with null key. Ignoring...");
             return;
@@ -845,6 +899,7 @@ public class MParticle {
      * @param value the attribute value
      */
     public void incrementSessionAttribute(@NonNull String key, int value) {
+        MParticle.logRoktApiUsage("INCREMENT_SESSION_ATTRIBUTE");
         if (key == null) {
             Logger.warning("incrementSessionAttribute called with null key. Ignoring...");
             return;
@@ -875,6 +930,7 @@ public class MParticle {
      * @param optOutStatus set to <code>true</code> to opt out of event tracking
      */
     public void setOptOut(@NonNull Boolean optOutStatus) {
+        MParticle.logRoktApiUsage("SET_OPT_OUT");
         if (optOutStatus != null) {
             if (optOutStatus != mConfigManager.getOptedOut()) {
                 if (!optOutStatus) {
@@ -916,6 +972,7 @@ public class MParticle {
      * @param state the device-level consent state, or {@code null} to clear the override
      */
     public void setDeviceConsentState(@Nullable ConsentState state) {
+        MParticle.logRoktApiUsage("SET_DEVICE_CONSENT_STATE");
         ConsentState oldState = mConfigManager.getEffectiveConsentState(mConfigManager.getMpid());
         mConfigManager.setDeviceConsentState(state);
         ConsentState newState = mConfigManager.getEffectiveConsentState(mConfigManager.getMpid());
@@ -945,6 +1002,7 @@ public class MParticle {
      */
     @Nullable
     public Uri getSurveyUrl(final int kitId) {
+        MParticle.logRoktApiUsage("GET_SURVEY_URL");
         return mKitManager.getSurveyUrl(kitId, null, null);
     }
 
@@ -1009,6 +1067,7 @@ public class MParticle {
     @SuppressLint("AddJavascriptInterface")
     @RequiresApi(17)
     public void registerWebView(@NonNull WebView webView, String requiredBridgeName) {
+        MParticle.logRoktApiUsage("REGISTER_WEBVIEW");
         MParticleJSInterface.registerWebView(webView, requiredBridgeName);
     }
 
@@ -1022,6 +1081,7 @@ public class MParticle {
      * @see MParticle.LogLevel
      */
     public static void setLogLevel(@NonNull LogLevel level) {
+        MParticle.logRoktApiUsage("SET_LOG_LEVEL");
         if (level != null) {
             Logger.setMinLogLevel(level, true);
         }
@@ -1100,6 +1160,7 @@ public class MParticle {
      * @see MParticle.ServiceProviders
      */
     public boolean isKitActive(int serviceProviderId) {
+        MParticle.logRoktApiUsage("IS_KIT_ACTIVE");
         return mKitManager.isKitActive(serviceProviderId);
     }
 
@@ -1112,6 +1173,7 @@ public class MParticle {
      */
     @Nullable
     public Object getKitInstance(int kitId) {
+        MParticle.logRoktApiUsage("GET_KIT_INSTANCE");
         return mKitManager.getKitInstance(kitId);
     }
 
@@ -1131,6 +1193,7 @@ public class MParticle {
      * @param intent
      */
     public void logNotification(@NonNull Intent intent) {
+        MParticle.logRoktApiUsage("LOG_NOTIFICATION");
         if (mConfigManager.isEnabled()) {
             ProviderCloudMessage message = ProviderCloudMessage.createMessage(intent, ConfigManager.getPushKeys(mAppContext));
             mMessageManager.logNotification(message, getAppState());
@@ -1161,6 +1224,7 @@ public class MParticle {
      * @param intent
      */
     public void logNotificationOpened(@NonNull Intent intent) {
+        MParticle.logRoktApiUsage("LOG_NOTIFICATION_OPENED");
         logNotification(ProviderCloudMessage.createMessage(intent, ConfigManager.getPushKeys(mAppContext)),
                 true, MParticle.getAppState(), ProviderCloudMessage.FLAG_READ | ProviderCloudMessage.FLAG_DIRECT_OPEN);
     }
@@ -1219,6 +1283,7 @@ public class MParticle {
      * @param context
      */
     public static void reset(@NonNull Context context) {
+        MParticle.logRoktApiUsage("RESET");
         reset(context, true, false);
     }
 
@@ -1604,9 +1669,10 @@ public class MParticle {
     }
 
     private void sendPushTokenModifyRequest(MParticleUser user, @Nullable String instanceId, @Nullable String oldInstanceId) {
-        Identity().modify(new Builder(user)
+        // Internal SDK bookkeeping (push-token refresh) — must not be reported as a partner MODIFY call.
+        withoutRoktApiUsage(() -> Identity().modify(new Builder(user)
                 .pushToken(instanceId, oldInstanceId)
-                .build());
+                .build()));
     }
 
     class Builder extends IdentityApiRequest.Builder {
@@ -1641,6 +1707,7 @@ public class MParticle {
      *                      also pass a null or empty map here to remove all of the attributes.
      */
     public void setIntegrationAttributes(int integrationId, @Nullable Map<String, String> attributes) {
+        MParticle.logRoktApiUsage("SET_INTEGRATION_ATTRIBUTES");
         this.Internal().getConfigManager().setIntegrationAttributes(integrationId, attributes);
     }
 
@@ -1658,6 +1725,7 @@ public class MParticle {
      */
     @NonNull
     public Map<String, String> getIntegrationAttributes(int integrationId) {
+        MParticle.logRoktApiUsage("GET_INTEGRATION_ATTRIBUTES");
         return this.Internal().getConfigManager().getIntegrationAttributes(integrationId);
     }
 

--- a/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityApi.java
@@ -108,6 +108,7 @@ public class IdentityApi {
      */
     @NonNull
     public List<MParticleUser> getUsers() {
+        MParticle.logRoktApiUsage("GET_USERS");
         List<MParticleUser> users = new ArrayList<MParticleUser>();
         Set<Long> mpids = mConfigManager.getMpids();
         mpids.remove(Constants.TEMPORARY_MPID);
@@ -165,6 +166,7 @@ public class IdentityApi {
      */
     @NonNull
     public MParticleTask<IdentityApiResult> logout(@Nullable final IdentityApiRequest logoutRequest) {
+        MParticle.logRoktApiUsage("LOGOUT");
         return makeIdentityRequest(logoutRequest, new IdentityNetworkRequestRunnable() {
             @Override
             public IdentityHttpResponse request(IdentityApiRequest request) throws Exception {
@@ -200,6 +202,7 @@ public class IdentityApi {
      */
     @NonNull
     public MParticleTask<IdentityApiResult> login(@Nullable final IdentityApiRequest loginRequest) {
+        MParticle.logRoktApiUsage("LOGIN");
         return makeIdentityRequest(loginRequest, new IdentityNetworkRequestRunnable() {
             @Override
             public IdentityHttpResponse request(IdentityApiRequest request) throws Exception {
@@ -223,6 +226,7 @@ public class IdentityApi {
      */
     @NonNull
     public MParticleTask<IdentityApiResult> identify(@Nullable final IdentityApiRequest identifyRequest) {
+        MParticle.logRoktApiUsage("IDENTIFY");
         return makeIdentityRequest(identifyRequest, new IdentityNetworkRequestRunnable() {
             @Override
             public IdentityHttpResponse request(IdentityApiRequest request) throws Exception {
@@ -246,6 +250,7 @@ public class IdentityApi {
      */
     @NonNull
     public BaseIdentityTask modify(@NonNull final IdentityApiRequest updateRequest) {
+        MParticle.logRoktApiUsage("MODIFY");
         boolean devMode = MPUtility.isDevEnv() || MPUtility.isAppDebuggable(mContext);
         final BaseIdentityTask task = new BaseIdentityTask();
 
@@ -296,6 +301,7 @@ public class IdentityApi {
      * @return
      */
     public boolean aliasUsers(@NonNull AliasRequest aliasRequest) {
+        MParticle.logRoktApiUsage("ALIAS_USERS");
         if (aliasRequest.getDestinationMpid() == 0 || aliasRequest.getSourceMpid() == 0) {
             Logger.error("AliasRequest does not have a valid destinationMpid and a valid sourceMpid");
             return false;

--- a/android-core/src/main/java/com/mparticle/identity/MParticleUserImpl.java
+++ b/android-core/src/main/java/com/mparticle/identity/MParticleUserImpl.java
@@ -94,21 +94,25 @@ public class MParticleUserImpl implements MParticleUser {
 
     @Override
     public boolean setUserAttributeList(String key, Object value) {
+        MParticle.logRoktApiUsage("SET_USER_ATTRIBUTE_LIST");
         return mUserDelegate.setUserAttributeList(key, value, getId());
     }
 
     @Override
     public boolean incrementUserAttribute(String key, Number value) {
+        MParticle.logRoktApiUsage("INCREMENT_USER_ATTRIBUTE");
         return mUserDelegate.incrementUserAttribute(key, value, getId());
     }
 
     @Override
     public boolean removeUserAttribute(String key) {
+        MParticle.logRoktApiUsage("REMOVE_USER_ATTRIBUTE");
         return mUserDelegate.removeUserAttribute(key, getId());
     }
 
     @Override
     public boolean setUserTag(@NonNull String tag) {
+        MParticle.logRoktApiUsage("SET_USER_TAG");
         return setUserAttribute(tag, null);
     }
 
@@ -120,11 +124,13 @@ public class MParticleUserImpl implements MParticleUser {
 
     @Override
     public ConsentState getConsentState() {
+        MParticle.logRoktApiUsage("GET_CONSENT_STATE");
         return mUserDelegate.getConsentState(getId());
     }
 
     @Override
     public void setConsentState(ConsentState state) {
+        MParticle.logRoktApiUsage("SET_CONSENT_STATE");
         mUserDelegate.setConsentState(state, getId());
     }
 
@@ -145,6 +151,7 @@ public class MParticleUserImpl implements MParticleUser {
 
     @Override
     public AudienceTask<AudienceResponse> getUserAudiences() {
+        MParticle.logRoktApiUsage("GET_USER_AUDIENCES");
         return mUserDelegate.getUserAudiences(getId());
     }
 

--- a/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
+++ b/android-core/src/main/java/com/mparticle/internal/KitFrameworkWrapper.java
@@ -24,6 +24,7 @@ import com.mparticle.consent.ConsentState;
 import com.mparticle.identity.IdentityApiRequest;
 import com.mparticle.identity.MParticleUser;
 import com.mparticle.internal.listeners.InternalListenerManager;
+import com.mparticle.rokt.RoktApiDiagnosticsForwarder;
 import com.mparticle.rokt.RoktOptions;
 
 import org.json.JSONArray;
@@ -476,6 +477,23 @@ public class KitFrameworkWrapper implements KitManager {
             return mKitManager.getKitInstance(kitId);
         }
         return null;
+    }
+
+    /**
+     * Forwards a bounded public-API-usage diagnostic code to the Rokt kit, but only when the kit is
+     * active. Core stays decoupled from kit types via the {@link RoktApiDiagnosticsForwarder}
+     * interface. No-op when Rokt isn't integrated/active.
+     */
+    public void logRoktApiDiagnostic(String code) {
+        if (code == null || code.isEmpty()) {
+            return;
+        }
+        if (isKitActive(MParticle.ServiceProviders.ROKT)) {
+            Object kit = getKitInstance(MParticle.ServiceProviders.ROKT);
+            if (kit instanceof RoktApiDiagnosticsForwarder) {
+                ((RoktApiDiagnosticsForwarder) kit).onMParticleApiCall(code);
+            }
+        }
     }
 
     @Override

--- a/android-core/src/main/java/com/mparticle/media/MPMediaAPI.java
+++ b/android-core/src/main/java/com/mparticle/media/MPMediaAPI.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.mparticle.MParticle;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -37,6 +39,7 @@ public class MPMediaAPI {
      * @param playing Is your app currently playing music for the user.
      */
     public void setAudioPlaying(boolean playing) {
+        MParticle.logRoktApiUsage("SET_AUDIO_PLAYING");
         mAudioPlaying.set(playing);
         if (playing) {
             mCallbacks.onAudioPlaying();
@@ -46,6 +49,7 @@ public class MPMediaAPI {
     }
 
     public boolean getAudioPlaying() {
+        MParticle.logRoktApiUsage("GET_AUDIO_PLAYING");
         return mAudioPlaying.get();
     }
 }

--- a/android-core/src/main/java/com/mparticle/messaging/MPMessagingAPI.java
+++ b/android-core/src/main/java/com/mparticle/messaging/MPMessagingAPI.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.mparticle.MPService;
+import com.mparticle.MParticle;
 import com.mparticle.internal.ConfigManager;
 import com.mparticle.internal.Logger;
 import com.mparticle.internal.MPUtility;
@@ -76,10 +77,12 @@ public class MPMessagingAPI {
      * Unregister the application for FCM notifications.
      */
     public void disablePushNotifications() {
+        MParticle.logRoktApiUsage("DISABLE_PUSH_NOTIFICATIONS");
         ConfigManager.getInstance(mContext).clearPushRegistration();
     }
 
     public void displayPushNotificationByDefault(@Nullable Boolean enabled) {
+        MParticle.logRoktApiUsage("DISPLAY_PUSH_NOTIFICATION_BY_DEFAULT");
         ConfigManager.getInstance(mContext).setDisplayPushNotifications(enabled);
     }
 
@@ -91,6 +94,7 @@ public class MPMessagingAPI {
      * @see PushAnalyticsReceiver
      */
     public void registerPushAnalyticsReceiver(@NonNull PushAnalyticsReceiver receiver) {
+        MParticle.logRoktApiUsage("REGISTER_PUSH_ANALYTICS_RECEIVER");
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(BROADCAST_NOTIFICATION_RECEIVED);
         intentFilter.addAction(BROADCAST_NOTIFICATION_TAPPED);
@@ -105,6 +109,7 @@ public class MPMessagingAPI {
      * @see PushAnalyticsReceiver
      */
     public void unregisterPushAnalyticsReceiver(@Nullable PushAnalyticsReceiver receiver) {
+        MParticle.logRoktApiUsage("UNREGISTER_PUSH_ANALYTICS_RECEIVER");
         LocalBroadcastManager.getInstance(mContext).unregisterReceiver(receiver);
     }
 }

--- a/android-core/src/main/kotlin/com/mparticle/rokt/RoktApiDiagnosticsForwarder.kt
+++ b/android-core/src/main/kotlin/com/mparticle/rokt/RoktApiDiagnosticsForwarder.kt
@@ -1,0 +1,10 @@
+package com.mparticle.rokt
+
+/**
+ * Implemented by the Rokt kit so mParticle core can forward a bounded, non-PII public-API-usage
+ * diagnostic code into the Rokt SDK — without core depending on any kit types. Core resolves the
+ * live Rokt kit via `getKitInstance` and calls this only when the kit is active.
+ */
+interface RoktApiDiagnosticsForwarder {
+    fun onMParticleApiCall(code: String)
+}

--- a/android-core/src/test/kotlin/com/mparticle/MParticleTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/MParticleTest.kt
@@ -504,6 +504,26 @@ class MParticleTest {
         verify(instance.mKitManager).setWrapperSdkVersion(WrapperSdkVersion(expectedSdk, expectedVersion))
     }
 
+    @Test
+    fun logRoktApiUsage_forwardsToKitManager_butIsSuppressedForInternalCalls() {
+        val instance: MParticle = InnerMockMParticle()
+        MParticle.setInstance(instance)
+
+        // A genuine partner call forwards the code to the (active-kit-gated) kit manager.
+        MParticle.logRoktApiUsage("SELECT_PLACEMENTS")
+        verify(instance.mKitManager, Mockito.times(1)).logRoktApiDiagnostic("SELECT_PLACEMENTS")
+
+        // An SDK/kit-internal call routed through withoutRoktApiUsage must NOT be reported.
+        MParticle.withoutRoktApiUsage {
+            MParticle.logRoktApiUsage("LOG_EVENT")
+        }
+        verify(instance.mKitManager, Mockito.times(0)).logRoktApiDiagnostic("LOG_EVENT")
+
+        // Suppression is scoped: a later partner call is reported again.
+        MParticle.logRoktApiUsage("CLOSE")
+        verify(instance.mKitManager, Mockito.times(1)).logRoktApiDiagnostic("CLOSE")
+    }
+
     inner class InnerMockMParticle : MParticle() {
         init {
             mConfigManager = ConfigManager(MockContext())

--- a/android-core/src/test/kotlin/com/mparticle/external/ApiVisibilityTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/external/ApiVisibilityTest.kt
@@ -17,7 +17,7 @@ class ApiVisibilityTest {
                 publicMethodCount++
             }
         }
-        Assert.assertEquals(65, publicMethodCount)
+        Assert.assertEquals(67, publicMethodCount)
     }
 
     @Test

--- a/android-core/src/test/kotlin/com/mparticle/internal/KitFrameworkWrapperTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/KitFrameworkWrapperTest.kt
@@ -12,6 +12,7 @@ import com.mparticle.WrapperSdk
 import com.mparticle.WrapperSdkVersion
 import com.mparticle.commerce.CommerceEvent
 import com.mparticle.internal.PushRegistrationHelper.PushRegistration
+import com.mparticle.rokt.RoktApiDiagnosticsForwarder
 import com.mparticle.testutils.RandomUtils
 import org.json.JSONArray
 import org.junit.Assert
@@ -32,6 +33,43 @@ import kotlin.test.assertEquals
 
 @RunWith(PowerMockRunner::class)
 class KitFrameworkWrapperTest {
+    private fun newWrapper(): KitFrameworkWrapper = KitFrameworkWrapper(
+        Mockito.mock(Context::class.java),
+        Mockito.mock(ReportingManager::class.java),
+        Mockito.mock(ConfigManager::class.java),
+        Mockito.mock(AppStateManager::class.java),
+        true,
+        Mockito.mock(MParticleOptions::class.java),
+    )
+
+    @Test
+    fun logRoktApiDiagnostic_forwardsToActiveRoktKit() {
+        val wrapper = newWrapper()
+        val mockKitManager = Mockito.mock(KitManager::class.java)
+        wrapper.setKitManager(mockKitManager)
+        val forwarder = Mockito.mock(RoktApiDiagnosticsForwarder::class.java)
+        `when`(mockKitManager.isKitActive(MParticle.ServiceProviders.ROKT)).thenReturn(true)
+        `when`(mockKitManager.getKitInstance(MParticle.ServiceProviders.ROKT)).thenReturn(forwarder)
+
+        wrapper.logRoktApiDiagnostic("LOG_EVENT")
+
+        verify(forwarder, times(1)).onMParticleApiCall("LOG_EVENT")
+    }
+
+    @Test
+    fun logRoktApiDiagnostic_noOpWhenRoktKitInactive() {
+        val wrapper = newWrapper()
+        val mockKitManager = Mockito.mock(KitManager::class.java)
+        wrapper.setKitManager(mockKitManager)
+        val forwarder = Mockito.mock(RoktApiDiagnosticsForwarder::class.java)
+        `when`(mockKitManager.isKitActive(MParticle.ServiceProviders.ROKT)).thenReturn(false)
+        `when`(mockKitManager.getKitInstance(MParticle.ServiceProviders.ROKT)).thenReturn(forwarder)
+
+        wrapper.logRoktApiDiagnostic("LOG_EVENT")
+
+        verify(forwarder, times(0)).onMParticleApiCall(Mockito.anyString())
+    }
+
     @Test
     @Throws(Exception::class)
     fun testLoadKitLibrary() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ JAVA_VERSION=17
 # SDK VERSION) and are the single source of truth shared by the Rokt kit (com.rokt:roktsdk) and
 # the rokt-sdk-plus umbrella (com.rokt:payment-extension). Bump together when adopting a new
 # Rokt SDK release.
-roktSdkVersion=6.0.1
-roktPaymentExtensionVersion=6.0.1
+roktSdkVersion=6.0.3
+roktPaymentExtensionVersion=6.0.3

--- a/kits/rokt/rokt/build.gradle
+++ b/kits/rokt/rokt/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
     implementation 'androidx.compose.runtime:runtime'
-    api "com.rokt:roktsdk:${project.findProperty('roktSdkVersion') ?: '6.0.1'}"
+    api "com.rokt:roktsdk:${project.findProperty('roktSdkVersion') ?: '6.0.3'}"
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testImplementation  files('libs/java-json.jar')

--- a/kits/rokt/rokt/src/main/kotlin/com/mparticle/kits/Rokt.kt
+++ b/kits/rokt/rokt/src/main/kotlin/com/mparticle/kits/Rokt.kt
@@ -33,6 +33,7 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
         fontTypefaces: Map<String, WeakReference<Typeface>>? = null,
         config: RoktConfig? = null,
     ) {
+        MParticle.logRoktApiUsage("SELECT_PLACEMENTS")
         if (isEnabled()) {
             val resolved = resolveRoktKit()
             if (resolved != null) {
@@ -59,10 +60,13 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
      * @param identifier The placement identifier to listen for events
      * @return A Flow emitting RoktEvent objects
      */
-    fun events(identifier: String): Flow<RoktEvent> = if (isEnabled()) {
-        resolveRoktKit()?.second?.events(identifier) ?: flowOf()
-    } else {
-        flowOf()
+    fun events(identifier: String): Flow<RoktEvent> {
+        MParticle.logRoktApiUsage("ROKT_EVENTS")
+        return if (isEnabled()) {
+            resolveRoktKit()?.second?.events(identifier) ?: flowOf()
+        } else {
+            flowOf()
+        }
     }
 
     /**
@@ -73,16 +77,19 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
      * @param paymentExtension The payment extension implementation to register
      * @return true if the Rokt SDK accepts the payment extension configuration
      */
-    fun registerPaymentExtension(paymentExtension: PaymentExtension): Boolean = if (isEnabled()) {
-        val resolved = resolveRoktKit()
-        if (resolved != null) {
-            resolved.second.registerPaymentExtension(paymentExtension)
+    fun registerPaymentExtension(paymentExtension: PaymentExtension): Boolean {
+        MParticle.logRoktApiUsage("REGISTER_PAYMENT_EXTENSION")
+        return if (isEnabled()) {
+            val resolved = resolveRoktKit()
+            if (resolved != null) {
+                resolved.second.registerPaymentExtension(paymentExtension)
+            } else {
+                Logger.warning("Rokt Kit is not available. Make sure the Rokt Kit is included in your app.")
+                false
+            }
         } else {
-            Logger.warning("Rokt Kit is not available. Make sure the Rokt Kit is included in your app.")
             false
         }
-    } else {
-        false
     }
 
     /**
@@ -98,6 +105,7 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
         attributes: Map<String, String> = emptyMap(),
         config: RoktConfig? = null,
     ) {
+        MParticle.logRoktApiUsage("SELECT_SHOPPABLE_ADS")
         if (isEnabled()) {
             val resolved = resolveRoktKit()
             if (resolved != null) {
@@ -123,6 +131,7 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
      * @param success Whether the purchase was successful
      */
     fun purchaseFinalized(identifier: String, catalogItemId: String, success: Boolean) {
+        MParticle.logRoktApiUsage("PURCHASE_FINALIZED")
         if (isEnabled()) {
             resolveRoktKit()?.second?.purchaseFinalized(identifier, catalogItemId, success)
         }
@@ -132,6 +141,7 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
      * Close any active Rokt placements.
      */
     fun close() {
+        MParticle.logRoktApiUsage("ROKT_CLOSE")
         if (isEnabled()) {
             resolveRoktKit()?.second?.close()
         }
@@ -148,6 +158,7 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
      * @param sessionId The session id to be set. Must be a non-empty string.
      */
     fun setSessionId(sessionId: String) {
+        MParticle.logRoktApiUsage("ROKT_SET_SESSION_ID")
         if (isEnabled()) {
             resolveRoktKit()?.second?.setSessionId(sessionId)
         }
@@ -158,10 +169,13 @@ class Rokt internal constructor(private val mKitManager: KitManager) {
      *
      * @return The session id or null if no session is present or SDK is not initialized.
      */
-    fun getSessionId(): String? = if (isEnabled()) {
-        resolveRoktKit()?.second?.getSessionId()
-    } else {
-        null
+    fun getSessionId(): String? {
+        MParticle.logRoktApiUsage("ROKT_GET_SESSION_ID")
+        return if (isEnabled()) {
+            resolveRoktKit()?.second?.getSessionId()
+        } else {
+            null
+        }
     }
 
     /**

--- a/kits/rokt/rokt/src/main/kotlin/com/mparticle/kits/RoktKit.kt
+++ b/kits/rokt/rokt/src/main/kotlin/com/mparticle/kits/RoktKit.kt
@@ -18,6 +18,7 @@ import com.mparticle.internal.Logger
 import com.mparticle.kits.KitIntegration.CommerceListener
 import com.mparticle.kits.KitIntegration.IdentityListener
 import com.mparticle.kits.KitIntegration.RoktListener
+import com.mparticle.rokt.RoktApiDiagnosticsForwarder
 import com.rokt.roktsdk.PlacementOptions
 import com.rokt.roktsdk.Rokt
 import com.rokt.roktsdk.Rokt.SdkFrameworkType.Android
@@ -53,12 +54,18 @@ class RoktKit :
     CommerceListener,
     IdentityListener,
     RoktListener,
-    RoktKitBridge {
+    RoktKitBridge,
+    RoktApiDiagnosticsForwarder {
     private var applicationContext: Context? = null
     private var hashedEmailUserIdentityType: String? = null
     override fun getName(): String = NAME
 
     override fun getInstance(): RoktKit = this
+
+    /** Forwards a bounded public-API-usage diagnostic code from mParticle core into the Rokt SDK. */
+    override fun onMParticleApiCall(code: String) {
+        Rokt.logMParticleApiCall(code)
+    }
 
     private var deferredAttributes: CompletableDeferred<Map<String, String>>? = null
 
@@ -415,7 +422,11 @@ class RoktKit :
         val event = MPEvent.Builder(eventName, MParticle.EventType.Other)
             .customAttributes(attributes)
             .build()
-        MParticle.getInstance()?.logEvent(event)
+        // Kit-internal telemetry (forwarding a Rokt engagement as an mParticle event) — not a
+        // partner LOG_EVENT call, so suppress the usage diagnostic.
+        MParticle.withoutRoktApiUsage {
+            MParticle.getInstance()?.logEvent(event)
+        }
     }
 
     private fun getStringForIdentity(identityType: IdentityType): String = when (identityType) {

--- a/kits/rokt/rokt/src/main/kotlin/com/mparticle/kits/RoktKitRequestHelper.kt
+++ b/kits/rokt/rokt/src/main/kotlin/com/mparticle/kits/RoktKitRequestHelper.kt
@@ -2,8 +2,10 @@ package com.mparticle.kits
 
 import android.graphics.Typeface
 import com.mparticle.MParticle
+import com.mparticle.MParticleTask
 import com.mparticle.identity.IdentityApi
 import com.mparticle.identity.IdentityApiRequest
+import com.mparticle.identity.IdentityApiResult
 import com.mparticle.identity.MParticleUser
 import com.mparticle.internal.Logger
 import com.mparticle.internal.MPUtility
@@ -213,19 +215,26 @@ internal object RoktKitRequestHelper {
                 }
 
                 val identityRequest = identityBuilder.build()
-                val task = identityApi.identify(identityRequest)
-
-                task.addFailureListener { result ->
-                    Logger.error("Failed to sync email from selectPlacement to user: ${result?.errors}")
+                // Kit-internal identity sync (email carried on selectPlacement) — suppress so it
+                // isn't reported as a partner IDENTIFY call.
+                var identifyTask: MParticleTask<IdentityApiResult>? = null
+                MParticle.withoutRoktApiUsage { identifyTask = identityApi.identify(identityRequest) }
+                val task = identifyTask
+                if (task == null) {
                     runnable.run()
-                }
+                } else {
+                    task.addFailureListener { result ->
+                        Logger.error("Failed to sync email from selectPlacement to user: ${result?.errors}")
+                        runnable.run()
+                    }
 
-                task.addSuccessListener { result ->
-                    Logger.debug(
-                        "Updated email identity based on selectPlacement's attributes: " +
-                            result.user.userIdentities[MParticle.IdentityType.Email],
-                    )
-                    runnable.run()
+                    task.addSuccessListener { result ->
+                        Logger.debug(
+                            "Updated email identity based on selectPlacement's attributes: " +
+                                result.user.userIdentities[MParticle.IdentityType.Email],
+                        )
+                        runnable.run()
+                    }
                 }
             } else {
                 runnable.run()

--- a/kits/rokt/rokt/src/test/kotlin/com/mparticle/kits/RoktKitTests.kt
+++ b/kits/rokt/rokt/src/test/kotlin/com/mparticle/kits/RoktKitTests.kt
@@ -85,6 +85,17 @@ class RoktKitTests {
     }
 
     @Test
+    fun onMParticleApiCall_forwards_the_code_to_Rokt_logMParticleApiCall() {
+        mockkObject(Rokt)
+        every { Rokt.logMParticleApiCall(any()) } just runs
+
+        roktKit.onMParticleApiCall("LOG_EVENT")
+
+        verify { Rokt.logMParticleApiCall("LOG_EVENT") }
+        unmockkObject(Rokt)
+    }
+
+    @Test
     fun test_prepareFinalAttributes_filters_out_null_user_attributes() {
         val mockFilterUser = mock(FilteredMParticleUser::class.java)
         Mockito.`when`(mockFilterUser.userIdentities).thenReturn(HashMap())

--- a/rokt-sdk-plus/build.gradle
+++ b/rokt-sdk-plus/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'mparticle.android.library.publish'
 // The umbrella tracks the mParticle SDK release line; the Rokt artifacts ride their own line.
 def mpVersion = (project.findProperty('VERSION') ?: '0.0.0').toString()
 def roktPaymentExtensionVersion =
-        (project.findProperty('roktPaymentExtensionVersion') ?: '6.0.1').toString()
+        (project.findProperty('roktPaymentExtensionVersion') ?: '6.0.3').toString()
 
 mparticleMavenPublish {
     groupId.set('com.rokt')


### PR DESCRIPTION
## Background

Rokt diagnostics can identify native SDK API usage, but calls made through mParticle are not currently distinguishable. This adds bounded, non-sensitive API identifiers only when the Rokt kit is active. Android port of mParticle/mparticle-apple-sdk#813; requires Rokt SDK `6.0.3`, which exposes the public `Rokt.logMParticleApiCall` entry point.

## What Has Changed

- Instrument public mParticle core, identity, user, session, messaging, media, and Rokt-facade APIs to forward a fixed, uppercase code vocabulary through the **active** Rokt kit only (no-op otherwise), via a decoupled `RoktApiDiagnosticsForwarder` interface so `android-core` stays free of kit types.
- **Reported APIs match iOS #813**: dropped identifiers iOS deliberately excludes (single-attribute `setUserAttribute`) and Android-only internal machinery that would misreport SDK plumbing as partner calls (identity getters, identity-state listeners); renamed `SET_UPDATE_INTERVAL` → `SET_UPLOAD_INTERVAL`; added `RESET`, `SET_LOG_LEVEL`, `GET_INTEGRATION_ATTRIBUTES`, `GET_ATTRIBUTION_INFO`, `IS_KIT_ACTIVE`, `GET_KIT_INSTANCE`.
- Kept Android-specific public APIs that are neither internal nor noisy (install referrer, non-auto push toggles, media audio state); dropped internally/auto-fired ones (location tracking, uncaught-exception toggles, push registration, `enablePushNotifications`).
- The mParticle **Rokt facade** (`kits/rokt/rokt/.../Rokt.kt`) reports a distinct `[MP_API_*]` set (`SELECT_PLACEMENTS`, `SELECT_SHOPPABLE_ADS`, `PURCHASE_FINALIZED`, `ROKT_EVENTS`, `ROKT_CLOSE`, `ROKT_SET_SESSION_ID`, `ROKT_GET_SESSION_ID`, `REGISTER_PAYMENT_EXTENSION`) — additive by design with the native SDK's own `[API_*]` diagnostics, so drop-offs between the facade call and the native call are observable.
- **Never over-log**: diagnostics are suppressed while SDK/kit internals invoke public APIs — auto-upload, `logLtvIncrease` → `logEvent`, push-token `modify`, and the Rokt kit's attribute enrichment / event + identity forwarding — via `MParticle.withoutRoktApiUsage`.
- **No delay / no crash / no retry**: forwarding is a bounded synchronous lookup on the caller thread; the code is validated and buffered inside the Rokt SDK (`logMParticleApiCall`). API arguments and values are never included — code identifiers only.

## Testing

- `:android-core:testDebugUnitTest` for `MParticleTest` and `KitFrameworkWrapperTest` pass locally, including new tests for active-kit gating and internal-call suppression.
- Note: the Rokt-kit module build could not be run in the authoring sandbox (Maven Central `429` rate-limiting on `com.rokt:roktsdk:6.0.3`); it will be validated in CI.

## Checklist

- [x] Self-review completed
- [x] Tests added or updated
- [ ] Tested locally (core: yes; rokt kit: pending CI — see note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)