### PR TITLE
docs(rokt): session management guidance for the kit

### DIFF
--- a/kits/rokt/rokt/README.md
+++ b/kits/rokt/rokt/README.md
@@ -74,6 +74,36 @@ RoktLayout(
 )
 ```
 
+## Session management
+
+Rokt sessions are managed automatically. Placements shown to the same user share one session, and **the kit ends the Rokt session whenever the mParticle user changes**:
+
+| Identity transition | Rokt session |
+|---|---|
+| Anonymous user is identified (e.g. unknown on the payment page, known on the confirmation page) | **Kept** — same person, in-session state survives |
+| A different user identifies or logs in | **Ended** — the next placement starts a new session |
+| The current user logs out | **Ended** |
+
+No integration code is needed for this behaviour.
+
+### Self-service terminals (kiosks, shared devices)
+
+Where a queue of unrelated customers uses one device, the recommended pattern is to **log the user out (or identify the next customer) between transactions** — the kit resets the Rokt session at that boundary, so each customer's placements and events land on their own session.
+
+A manual reset is also available for explicit control, called on the Rokt SDK directly:
+
+```kotlin
+import com.rokt.roktsdk.Rokt
+
+Rokt.clearSession()
+```
+
+Notes:
+
+- The new session begins on the **next** `selectPlacements` call; `clearSession` only ends the current one.
+- Calling `clearSession` with no active session (or before init) is a no-op, and it is safe to combine with the automatic behaviour — both converge on the same idempotent reset.
+- Avoid enabling Rokt experience caching on shared terminals: a cached experience belongs to the customer it was fetched for.
+
 ## Documentation
 
 [Rokt integration](https://docs.rokt.com/developers/integration-guides/android/overview)


### PR DESCRIPTION
## What

Kit README section documenting session management — Android counterpart of [mParticle/mparticle-apple-sdk#821](https://github.com/mParticle/mparticle-apple-sdk/pull/821):

- the automatic identity-driven behaviour introduced in #762, as a transition table (anonymous→known keeps the session; a different known user or a logout ends it)
- the recommended self-service-terminal pattern: log out (or identify the next customer) between transactions
- the manual `Rokt.clearSession()` escape hatch (called on the Rokt SDK directly — Android has no MPRokt facade), when the new session begins, no-op/idempotency notes, and the collision-safety of combining manual + automatic
- the caching recommendation for shared terminals

Docs only. **Stacked on #762** — its base is that branch; retargets cleanly once #762 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
