### PR TITLE
ci: add changelog details to generated release pull requests

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -147,8 +147,30 @@ jobs:
           token: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
           commit-message: "chore: prepare release ${{ steps.compose-version.outputs.new-version }}"
           branch: release-prep/${{ steps.compose-version.outputs.new-version }}
-          title: "Prepare release ${{ steps.compose-version.outputs.new-version }}"
+          title: "chore: prepare release ${{ steps.compose-version.outputs.new-version }}"
           base: ${{ github.ref_name }}
           body: |
-            Preparing for release ${{ steps.compose-version.outputs.new-version }} from `${{ github.ref_name }}`.
-            - Bumped version to ${{ steps.compose-version.outputs.new-version }}
+            ## Release ${{ steps.compose-version.outputs.new-version }}
+
+            ### Release details
+
+            - Version: `${{ steps.compose-version.outputs.new-version }}`
+            - Bump type: `${{ github.event.inputs.bump-type }}`
+            - Base branch: `${{ github.ref_name }}`
+
+            ### Files updated
+
+            - `VERSION` set to `${{ steps.compose-version.outputs.new-version }}`
+            - `CHANGELOG.md` updated with the generated release notes
+
+            ### Validation
+
+            The Release – Draft workflow successfully smoke-tested Maven local publication for the core SDK, aggregate kits, and isolated kits before opening this PR.
+
+            ## Changelog
+
+            ${{ steps.changelog.outputs.release-notes }}
+
+            ---
+
+            **On merge:** The [Release – Publish](https://github.com/${{ github.repository }}/actions/workflows/release-publish.yml) workflow will publish the core SDK, aggregate and isolated kits, and `rokt-sdk-plus` to Maven Central, tag the release, and create the GitHub release.


### PR DESCRIPTION
## Background

Automated Android release PRs currently mention only the version bump even though the workflow also updates the changelog and validates Maven-local publication. Reviewers need the same release context already included across the other Rokt and mParticle SDK repositories.

## What Has Changed

- Use a conventional title for generated release PRs.
- Include the release version, bump type, base branch, and files updated in each generated description.
- Embed generated changelog notes and summarize pre-PR Maven-local validation.
- Explain the Maven Central, tagging, and GitHub release steps triggered after merge.

## Screenshots/Video

N/A — no visual changes

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally