### PR TITLE
feat(rokt): bump Rokt SDK and payment extension to 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## [Unreleased]
 
-### Kits
-
-#### Rokt
-
-##### Changed
-
-- Bump Rokt SDK (`com.rokt:roktsdk`) and payment extension (`com.rokt:payment-extension`) to 6.1.1 ([#774](https://github.com/mParticle/mparticle-android-sdk/pull/774))
-
 ## [6.0.3] - 2026-08-28
 
 ### Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ##### Changed
 
-- Bump Rokt SDK (`com.rokt:roktsdk`) and payment extension (`com.rokt:payment-extension`) to 6.1.1
+- Bump Rokt SDK (`com.rokt:roktsdk`) and payment extension (`com.rokt:payment-extension`) to 6.1.1 ([#774](https://github.com/mParticle/mparticle-android-sdk/pull/774))
 
 ## [6.0.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Kits
+
+#### Rokt
+
+##### Changed
+
+- Bump Rokt SDK (`com.rokt:roktsdk`) and payment extension (`com.rokt:payment-extension`) to 6.1.1
+
 ## [6.0.3] - 2026-08-28
 
 ### Core

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ JAVA_VERSION=17
 # SDK VERSION) and are the single source of truth shared by the Rokt kit (com.rokt:roktsdk) and
 # the rokt-sdk-plus umbrella (com.rokt:payment-extension). Bump together when adopting a new
 # Rokt SDK release.
-roktSdkVersion=6.0.3
-roktPaymentExtensionVersion=6.0.3
+roktSdkVersion=6.1.1
+roktPaymentExtensionVersion=6.1.1

--- a/kits/rokt/rokt/README.md
+++ b/kits/rokt/rokt/README.md
@@ -44,9 +44,9 @@ Kotlin:
 ```kotlin
 import com.mparticle.MParticle
 import com.mparticle.kits.rokt
-import com.rokt.payment.extension.StripePaymentExtension
+import com.rokt.payment.extension.RoktPaymentExtension
 
-MParticle.getInstance()?.rokt?.registerPaymentExtension(StripePaymentExtension())
+MParticle.getInstance()?.rokt?.registerPaymentExtension(RoktPaymentExtension())
 MParticle.getInstance()?.rokt?.selectShoppableAds(
     identifier = "RoktShoppableExperience",
     attributes = attributes,
@@ -56,7 +56,7 @@ MParticle.getInstance()?.rokt?.selectShoppableAds(
 Java:
 
 ```java
-MParticleRokt.Rokt().registerPaymentExtension(new StripePaymentExtension());
+MParticleRokt.Rokt().registerPaymentExtension(new RoktPaymentExtension());
 MParticleRokt.Rokt().selectShoppableAds("RoktShoppableExperience", attributes);
 ```
 

--- a/kits/rokt/rokt/build.gradle
+++ b/kits/rokt/rokt/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
     implementation 'androidx.compose.runtime:runtime'
-    api "com.rokt:roktsdk:${project.findProperty('roktSdkVersion') ?: '6.0.3'}"
+    api "com.rokt:roktsdk:${project.findProperty('roktSdkVersion') ?: '6.1.1'}"
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testImplementation  files('libs/java-json.jar')

--- a/rokt-sdk-plus/build.gradle
+++ b/rokt-sdk-plus/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'mparticle.android.library.publish'
 // The umbrella tracks the mParticle SDK release line; the Rokt artifacts ride their own line.
 def mpVersion = (project.findProperty('VERSION') ?: '0.0.0').toString()
 def roktPaymentExtensionVersion =
-        (project.findProperty('roktPaymentExtensionVersion') ?: '6.0.3').toString()
+        (project.findProperty('roktPaymentExtensionVersion') ?: '6.1.1').toString()
 
 mparticleMavenPublish {
     groupId.set('com.rokt')


### PR DESCRIPTION
## Summary
- Pin `com.rokt:roktsdk` and `com.rokt:payment-extension` from 6.0.3 to **6.1.1**, the versions published from [sdk-android-source 6.1.1](https://github.com/ROKT/sdk-android-source/releases/tag/6.1.1).
- mParticle `VERSION` is unchanged. Cut the next Android SDK release from **Release – Draft** after this merges.
- Compatibility check against 6.1.1:
  - Public `RoktEvent.PlacementFailure` is unchanged (LayoutFailure diagnostics are internal).
  - `setSession` / `getSession` are additive (6.1.0); existing `setSessionId` / `getSessionId` still compile (deprecated).
  - `payment-extension:6.1.1` depends on `roktsdk:6.1.1`; Kotlin 2.1.20 and Compose BOM `2026.05.01` match this kit.
- Kit README samples now use `RoktPaymentExtension`, the class published by the payment extension.

## Test plan
- [x] Rokt kit `compileReleaseKotlin` against 6.1.1
- [x] Rokt kit `testRelease` (all unit tests passed)
- [x] Published `android-rokt-kit` POM pins `com.rokt:roktsdk:6.1.1`
- [x] `rokt-sdk-plus` compiles against `payment-extension:6.1.1`
- [ ] CI kit compatibility + unit tests on this PR
- [ ] After merge, run **Release – Draft** (patch) to publish the new mParticle version

Note: open PR #760 also bumps Rokt to 6.1.0 for `setSession` / `getSession`. Rebase that PR onto 6.1.1 after this lands.


Made with [Cursor](https://cursor.com)