### PR TITLE
feat(network): pin GoDaddy R1 and G2 roots instead of the G2 intermediate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can grab the Core SDK via Maven Central. Please see the badge above and foll
 
 ```groovy
 dependencies {
-    implementation 'com.mparticle:android-core:5.55.9'
+    implementation 'com.mparticle:android-core:5.55.10'
 }
 ```
 
@@ -27,8 +27,8 @@ Several integrations require additional client-side add-on libraries called "kit
 ```groovy
 dependencies {
     implementation (
-        'com.mparticle:android-example-kit:5.55.9',
-        'com.mparticle:android-another-kit:5.55.9'
+        'com.mparticle:android-example-kit:5.55.10',
+        'com.mparticle:android-another-kit:5.55.10'
     )
 }
 ```

--- a/android-core/src/androidTest/kotlin/com.mparticle/networking/NetworkOptionsManagerTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/networking/NetworkOptionsManagerTest.kt
@@ -29,12 +29,18 @@ class NetworkOptionsManagerTest {
         certificate in refinedNetworkOptions.domainMappings[MParticleBaseClientImpl.Endpoint.IDENTITY]!!
             .certificates
         ) {
-            if (certificate.alias == "intca") {
-                Assert.assertEquals(certificate.certificate, Constants.GODADDY_INTERMEDIATE_CRT)
-            } else if (certificate.alias == "rootca") {
-                Assert.assertEquals(certificate.certificate, Constants.GODADDY_ROOT_CRT)
-            } else if (certificate.alias == "fiddlerroot") {
-                Assert.assertEquals(certificate.certificate, Constants.FIDDLER_ROOT_CRT)
+            if (certificate.alias == "godaddy_root_g2") {
+                Assert.assertEquals(certificate.certificate, Constants.GODADDY_ROOT_G2_CRT)
+            } else if (certificate.alias == "godaddy_tls_root_r1") {
+                Assert.assertEquals(certificate.certificate, Constants.GODADDY_TLS_ROOT_R1_CRT)
+            } else if (certificate.alias == "godaddy_root_class2") {
+                Assert.assertEquals(certificate.certificate, Constants.GODADDY_CLASS_2_ROOT_CRT)
+            } else if (certificate.alias == "lets_encrypt_root_x1") {
+                Assert.assertEquals(certificate.certificate, Constants.LETS_ENCRYPTS_ROOT_X1_CRT)
+            } else if (certificate.alias == "lets_encrypt_root_x2_self") {
+                Assert.assertEquals(certificate.certificate, Constants.LETS_ENCRYPTS_ROOT_X2_SELF_SIGN_CRT)
+            } else if (certificate.alias == "lets_encrypt_root_x2_cross") {
+                Assert.assertEquals(certificate.certificate, Constants.LETS_ENCRYPTS_ROOT_X2_CROSS_SIGN_CRT)
             } else {
                 Assert.fail("unknown certificate")
             }

--- a/android-core/src/main/java/com/mparticle/internal/Constants.java
+++ b/android-core/src/main/java/com/mparticle/internal/Constants.java
@@ -41,80 +41,159 @@ public class Constants {
     public static final int LIMIT_MAX_MESSAGE_SIZE = 100 * 1024;
     public static final int LIMIT_MAX_UPLOAD_SIZE = 2 * LIMIT_MAX_MESSAGE_SIZE;
 
-    public final static String GODADDY_INTERMEDIATE_CRT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\n" +
-            "EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\n" +
-            "EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\n" +
-            "ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\n" +
-            "MDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\n" +
-            "EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\n" +
-            "CxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\n" +
-            "EypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\n" +
-            "MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\n" +
-            "BNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\n" +
-            "K/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\n" +
-            "cSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\n" +
-            "pDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\n" +
-            "eTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\n" +
-            "AAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\n" +
-            "HQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\n" +
-            "9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\n" +
-            "b2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\n" +
-            "b2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\n" +
-            "CCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\n" +
-            "MA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\n" +
-            "91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\n" +
-            "RJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\n" +
-            "DsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\n" +
-            "GIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\n" +
-            "LXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\n" +
-            "-----END CERTIFICATE-----\n";
-
-    public final static String GODADDY_ROOT_CRT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\n" +
-            "EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\n" +
-            "EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\n" +
-            "ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\n" +
-            "MDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\n" +
-            "EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\n" +
-            "CxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\n" +
-            "EypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\n" +
-            "MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\n" +
-            "BNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\n" +
-            "K/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\n" +
-            "cSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\n" +
-            "pDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\n" +
-            "eTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\n" +
-            "AAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\n" +
-            "HQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\n" +
-            "9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\n" +
-            "b2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\n" +
-            "b2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\n" +
-            "CCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\n" +
-            "MA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\n" +
-            "91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\n" +
-            "RJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\n" +
-            "DsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\n" +
-            "GIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\n" +
-            "LXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\n" +
+    public final static String GODADDY_CLASS_2_ROOT_CRT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIEADCCAuigAwIBAgIBADANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEh\n" +
+            "MB8GA1UEChMYVGhlIEdvIERhZGR5IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBE\n" +
+            "YWRkeSBDbGFzcyAyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA0MDYyOTE3\n" +
+            "MDYyMFoXDTM0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRo\n" +
+            "ZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3Mg\n" +
+            "MiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggEN\n" +
+            "ADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCA\n" +
+            "PVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6w\n" +
+            "wdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXi\n" +
+            "EqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMY\n" +
+            "avx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+\n" +
+            "YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjgcAwgb0wHQYDVR0OBBYEFNLE\n" +
+            "sNKR1EwRcbNhyz2h/t2oatTjMIGNBgNVHSMEgYUwgYKAFNLEsNKR1EwRcbNhyz2h\n" +
+            "/t2oatTjoWekZTBjMQswCQYDVQQGEwJVUzEhMB8GA1UEChMYVGhlIEdvIERhZGR5\n" +
+            "IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBEYWRkeSBDbGFzcyAyIENlcnRpZmlj\n" +
+            "YXRpb24gQXV0aG9yaXR5ggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQAD\n" +
+            "ggEBADJL87LKPpH8EsahB4yOd6AzBhRckB4Y9wimPQoZ+YeAEW5p5JYXMP80kWNy\n" +
+            "OO7MHAGjHZQopDH2esRU1/blMVgDoszOYtuURXO1v0XJJLXVggKtI3lpjbi2Tc7P\n" +
+            "TMozI+gciKqdi0FuFskg5YmezTvacPd+mSYgFFQlq25zheabIZ0KbIIOqPjCDPoQ\n" +
+            "HmyW74cNxA9hi63ugyuV+I6ShHI56yDqg+2DzZduCLzrTia2cyvk0/ZM/iZx4mER\n" +
+            "dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf\n" +
+            "ReYNnyicsbkqWletNw+vHX/bvZ8=\n" +
             "-----END CERTIFICATE-----";
 
-    public final static String FIDDLER_ROOT_CRT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIICnjCCAgegAwIBAgIQAOlcuB4VA5KNHpx2RQcMrzANBgkqhkiG9w0BAQUFADBq\n" +
-            "MSswKQYDVQQLDCJDcmVhdGVkIGJ5IGh0dHA6Ly93d3cuZmlkZGxlcjIuY29tMRgw\n" +
-            "FgYDVQQKDA9ET19OT1RfVFJVU1RfQkMxITAfBgNVBAMMGERPX05PVF9UUlVTVF9G\n" +
-            "aWRkbGVyUm9vdDAeFw0xMzEyMTIwMDAwMDBaFw0yMzEyMTkxMTI1NTRaMGoxKzAp\n" +
-            "BgNVBAsMIkNyZWF0ZWQgYnkgaHR0cDovL3d3dy5maWRkbGVyMi5jb20xGDAWBgNV\n" +
-            "BAoMD0RPX05PVF9UUlVTVF9CQzEhMB8GA1UEAwwYRE9fTk9UX1RSVVNUX0ZpZGRs\n" +
-            "ZXJSb290MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC6P47ffxB2xJFlYVEZ\n" +
-            "L4KSTORmxI21pUIb6jqkAEGYOeO+In5egCmroZuXbem1YYzTmgkmCelt6OTr0OLa\n" +
-            "ePCkdnxteUDMBs0DpcWutdJW9/9MNE90BfJ2WX1CA4zQx4zFZ9FRpYHntaIE8kf4\n" +
-            "bcts1+CE+VnI1fOPo0PsF6yudQIDAQABo0UwQzASBgNVHRMBAf8ECDAGAQH/AgEB\n" +
-            "MA4GA1UdDwEB/wQEAwICBDAdBgNVHQ4EFgQUouuoWsFXoOzyyW94lTD/apHuos8w\n" +
-            "DQYJKoZIhvcNAQEFBQADgYEAjOW9psxS4AeYgUcIhvNR5pd1BkuEwbdtgd8S0zgf\n" +
-            "jOmkkQNKHPikfOeJurA3jityX3+z9d2zSvtbLU7MYArb7hs5cibAyxalI6NlWSsg\n" +
-            "QGKwfeATxe0gReGYACTf2WIBa3ceQFhAYhyEUYJpDiZsJi8mZkeQMWH/ZanBnL/Q\n" +
-            "gZ4=\n" +
+    public final static String GODADDY_ROOT_G2_CRT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\n" +
+            "EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\n" +
+            "EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\n" +
+            "ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz\n" +
+            "NTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\n" +
+            "EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE\n" +
+            "AxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw\n" +
+            "DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD\n" +
+            "E6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH\n" +
+            "/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy\n" +
+            "DfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh\n" +
+            "GkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR\n" +
+            "tDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA\n" +
+            "AaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE\n" +
+            "FDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX\n" +
+            "WWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu\n" +
+            "9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr\n" +
+            "gIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo\n" +
+            "2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO\n" +
+            "LPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI\n" +
+            "4uJEvlz36hz1\n" +
+            "-----END CERTIFICATE-----";
+
+    public final static String LETS_ENCRYPTS_ROOT_X1_CRT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\n" +
+            "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n" +
+            "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\n" +
+            "WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\n" +
+            "ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\n" +
+            "MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\n" +
+            "h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n" +
+            "0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\n" +
+            "A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\n" +
+            "T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\n" +
+            "B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\n" +
+            "B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\n" +
+            "KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\n" +
+            "OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\n" +
+            "jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\n" +
+            "qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\n" +
+            "rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\n" +
+            "HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\n" +
+            "hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\n" +
+            "ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n" +
+            "3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\n" +
+            "NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\n" +
+            "ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\n" +
+            "TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\n" +
+            "jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\n" +
+            "oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n" +
+            "4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\n" +
+            "mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\n" +
+            "emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n" +
+            "-----END CERTIFICATE-----";
+
+    public final static String LETS_ENCRYPTS_ROOT_X2_SELF_SIGN_CRT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw\n" +
+            "CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg\n" +
+            "R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00\n" +
+            "MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT\n" +
+            "ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw\n" +
+            "EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW\n" +
+            "+1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9\n" +
+            "ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T\n" +
+            "AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI\n" +
+            "zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW\n" +
+            "tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1\n" +
+            "/q4AaOeMSQ+2b1tbFfLn\n" +
+            "-----END CERTIFICATE-----";
+
+    public final static String LETS_ENCRYPTS_ROOT_X2_CROSS_SIGN_CRT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIEYDCCAkigAwIBAgIQB55JKIY3b9QISMI/xjHkYzANBgkqhkiG9w0BAQsFADBP\n" +
+            "MQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFy\n" +
+            "Y2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMTAeFw0yMDA5MDQwMDAwMDBa\n" +
+            "Fw0yNTA5MTUxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5l\n" +
+            "dCBTZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgy\n" +
+            "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0H\n" +
+            "ttwW+1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7\n" +
+            "AlF9ItgKbppbd9/w+kHsOdx1ymgHDB/qo4HlMIHiMA4GA1UdDwEB/wQEAwIBBjAP\n" +
+            "BgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBR8Qpau3ktIO/qS+J6Mz22LqXI3lTAf\n" +
+            "BgNVHSMEGDAWgBR5tFnme7bl5AFzgAiIyBpY9umbbjAyBggrBgEFBQcBAQQmMCQw\n" +
+            "IgYIKwYBBQUHMAKGFmh0dHA6Ly94MS5pLmxlbmNyLm9yZy8wJwYDVR0fBCAwHjAc\n" +
+            "oBqgGIYWaHR0cDovL3gxLmMubGVuY3Iub3JnLzAiBgNVHSAEGzAZMAgGBmeBDAEC\n" +
+            "ATANBgsrBgEEAYLfEwEBATANBgkqhkiG9w0BAQsFAAOCAgEAG38lK5B6CHYAdxjh\n" +
+            "wy6KNkxBfr8XS+Mw11sMfpyWmG97sGjAJETM4vL80erb0p8B+RdNDJ1V/aWtbdIv\n" +
+            "P0tywC6uc8clFlfCPhWt4DHRCoSEbGJ4QjEiRhrtekC/lxaBRHfKbHtdIVwH8hGR\n" +
+            "Ib/hL8Lvbv0FIOS093nzLbs3KvDGsaysUfUfs1oeZs5YBxg4f3GpPIO617yCnpp2\n" +
+            "D56wKf3L84kHSBv+q5MuFCENX6+Ot1SrXQ7UW0xx0JLqPaM2m3wf4DtVudhTU8yD\n" +
+            "ZrtK3IEGABiL9LPXSLETQbnEtp7PLHeOQiALgH6fxatI27xvBI1sRikCDXCKHfES\n" +
+            "c7ZGJEKeKhcY46zHmMJyzG0tdm3dLCsmlqXPIQgb5dovy++fc5Ou+DZfR4+XKM6r\n" +
+            "4pgmmIv97igyIintTJUJxCD6B+GGLET2gUfA5GIy7R3YPEiIlsNekbave1mk7uOG\n" +
+            "nMeIWMooKmZVm4WAuR3YQCvJHBM8qevemcIWQPb1pK4qJWxSuscETLQyu/w4XKAM\n" +
+            "YXtX7HdOUM+vBqIPN4zhDtLTLxq9nHE+zOH40aijvQT2GcD5hq/1DhqqlWvvykdx\n" +
+            "S2McTZbbVSMKnQ+BdaDmQPVkRgNuzvpqfQbspDQGdNpT2Lm4xiN9qfgqLaSCpi4t\n" +
+            "EcrmzTFYeYXmchynn9NM0GbQp7s=\n" +
+            "-----END CERTIFICATE-----";
+
+    public final static String GODADDY_TLS_ROOT_R1_CRT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIFWTCCA0GgAwIBAgIRANpi/54mGbElekgJNo7o4/cwDQYJKoZIhvcNAQELBQAw\n" +
+            "RjELMAkGA1UEBhMCVVMxFDASBgNVBAoTC0dvRGFkZHkuY29tMSEwHwYDVQQDExhH\n" +
+            "b0RhZGR5IFRMUyBSb290IENBIC0gUjEwHhcNMjUwODI4MTIwMDAwWhcNNDAwODI0\n" +
+            "MTE1OTU5WjBGMQswCQYDVQQGEwJVUzEUMBIGA1UEChMLR29EYWRkeS5jb20xITAf\n" +
+            "BgNVBAMTGEdvRGFkZHkgVExTIFJvb3QgQ0EgLSBSMTCCAiIwDQYJKoZIhvcNAQEB\n" +
+            "BQADggIPADCCAgoCggIBAMLrcp3XnknkTvY9I1IzsQA8K/vp5TJRiYsCZWMitXxG\n" +
+            "H+yD1+dPuC5nVzu6BLlXWZ8f7E7cs7lGBUeygeb2CsrESx1uFtB8R3JR4UOAMNE/\n" +
+            "KrlYFwHBydF1JhcttMEEkojBqt9If+Ks8Go2Be4rIAj495yFzArAPc8Ax2kyGgqf\n" +
+            "9Sl0S1SUbxkuvNRomsb3uNg+rcSWg4zUVixQijIZm2AIBxNW9gzaghs6dnog6rgq\n" +
+            "wBYKk7WNhZOfATkq/GHU9glnmiiMMeFPK2kqo9YNWk17NzEYmrBp6ELJwMwhuupX\n" +
+            "LifmoOAL2axvkO1ci66WKBxPB5OPgy5WfdhYp7l2Az8d9MDKWCYwPTpRjwf41AgG\n" +
+            "KhrwMjEJ+H/tG+wu7vWH0Bk+Bfl2gBtNyGjvObGJHMgJusPASDbWThBaw4PrA6sK\n" +
+            "TNPaQCYtVCYi6h/JXB39P2ilTixeC9hiEFmPkwplgjf/t/7CvF6XoCRIFkU2vUYN\n" +
+            "5WQ9upLYRTMZIVrHOxHOcxevvbD2jSuIz2ZydWWdwSzoQb8g5/bmhfrXwLPlCAZh\n" +
+            "hx+E5ljM/OLlkaySoi35mGE4MVOfld94J7m11UeY76t43RIGW0HF7fwm556C3thd\n" +
+            "70RZ3KWwSiOBJQGzDMzjY+R53kJnUljPSlSqDemUE1fsG7evOPgrZSXc8rP2WTAx\n" +
+            "AgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MB0GA1Ud\n" +
+            "DgQWBBTsUhGVcHMZyN7KSEOXSxw1JCJDUDANBgkqhkiG9w0BAQsFAAOCAgEAndbU\n" +
+            "wF1KXURZgNLhfC0UkO0qBS2tHXhqJ2AGVMrOkX2+WFwPZ4jOqDTQoobcOXRBlE6O\n" +
+            "eLSGYquyTEW43gWHVy6+UKP1jnBLhpcaib56F5Wp8Fi3eZpT+3MojZEofMtZg7rG\n" +
+            "Jmn6vf1QLztm66JBb7uh1yVruHZupfT0TXZ8Sbpf8xVVWnq+owgVzTFsfSjWyBps\n" +
+            "5G9e/IWYfl6r9rmAPmPdo8LqxUmJXfjL06RlZ2K7HghBQgefEuBjUkSXFR73SyZH\n" +
+            "f8IR+CRbwjV0hmhn2NWDos1MB9TLKm/C8HQ49acBybtLmsTai+i+RT/N6UB1TNTw\n" +
+            "Ts+eZ42z5Danmw+KDO7JI6m/WrlDOuDkyRmY2TKI8vvEeKHfaBehGHUMEWQZe2d2\n" +
+            "AHFvmAonhB10aXUhjAbUMZs4SCo241iuz28FMoVCC6pa07l8A84IRbUfu9OMRkmm\n" +
+            "Ydmd5Pa4ggfkhtJwFxMbR/3bhsDi8tRwkgS6XNOixXK/azf9TA2RqyOsiiJFjffO\n" +
+            "xS4nnYkLtgzqf7hs+Qe3D5UDWUgJyx8AYiwKJIMDlLz+CO8yYIx+YMsKS8jHvclI\n" +
+            "X5DePkFKKNWCUz5x2wlfPbXUPhTjsKO2m3F6009Gf4bQgBL60rzBOuo1Wp6fSlDE\n" +
+            "b9J1nSdKq7qIj1IJ5icFCDhzV+P1LjVv77My5Rw=\n" +
             "-----END CERTIFICATE-----";
 
     //wait 5 seconds to trigger an immediate upload in the case where multiple trigger-messages are logged

--- a/android-core/src/main/java/com/mparticle/networking/NetworkOptionsManager.java
+++ b/android-core/src/main/java/com/mparticle/networking/NetworkOptionsManager.java
@@ -6,6 +6,7 @@ import com.mparticle.BuildConfig;
 import com.mparticle.internal.Constants;
 import com.mparticle.internal.MPUtility;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -60,13 +61,16 @@ public class NetworkOptionsManager {
         return defaultCertificates;
     }
 
-    private static List<Certificate> defaultCertificates = new LinkedList<Certificate>() {
+    private static final List<Certificate> defaultCertificates = Collections.unmodifiableList(new LinkedList<Certificate>() {
         {
-            add(Certificate.with("intca", Constants.GODADDY_INTERMEDIATE_CRT));
-            add(Certificate.with("rootca", Constants.GODADDY_ROOT_CRT));
-            add(Certificate.with("fiddlerroot", Constants.FIDDLER_ROOT_CRT));
+            add(Certificate.with("godaddy_root_g2", Constants.GODADDY_ROOT_G2_CRT));
+            add(Certificate.with("godaddy_tls_root_r1", Constants.GODADDY_TLS_ROOT_R1_CRT));
+            add(Certificate.with("godaddy_root_class2", Constants.GODADDY_CLASS_2_ROOT_CRT));
+            add(Certificate.with("lets_encrypt_root_x1", Constants.LETS_ENCRYPTS_ROOT_X1_CRT));
+            add(Certificate.with("lets_encrypt_root_x2_self", Constants.LETS_ENCRYPTS_ROOT_X2_SELF_SIGN_CRT));
+            add(Certificate.with("lets_encrypt_root_x2_cross", Constants.LETS_ENCRYPTS_ROOT_X2_CROSS_SIGN_CRT));
         }
-    };
+    });
 
     static String getDefaultUrl(Endpoint type) {
         switch (type) {

--- a/android-core/src/test/kotlin/com/mparticle/networking/NetworkOptionsManagerCertificateTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/networking/NetworkOptionsManagerCertificateTest.kt
@@ -1,0 +1,56 @@
+package com.mparticle.networking
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+
+class NetworkOptionsManagerCertificateTest {
+
+    // SHA-256 of the DER encoding, as published by each CA.
+    private val expectedFingerprints = mapOf(
+        "godaddy_root_g2" to "45140B3247EB9CC8C5B4F0D7B53091F73292089E6E5A63E2749DD3ACA9198EDA",
+        "godaddy_tls_root_r1" to "25CF3DA8E9B97ADDBF92543C2B82527C8A4E2CFF2062A6483040D4B64ACE719F",
+        "godaddy_root_class2" to "C3846BF24B9E93CA64274C0EC67C1ECC5E024FFCACD2D74019350E81FE546AE4",
+        "lets_encrypt_root_x1" to "96BCEC06264976F37460779ACF28C5A7CFE8A3C0AAE11A8FFCEE05C0BDDF08C6",
+        "lets_encrypt_root_x2_self" to "69729B8E15A86EFC177A57AFB7171DFC64ADD28C2FCA8CF1507E34453CCB1470",
+        "lets_encrypt_root_x2_cross" to "8B05B68CC659E5ED0FCB38F2C942FBFD200E6F2FF9F85D63C6994EF5E0B02701",
+    )
+
+    @Test
+    fun defaultCertificatesArePinnedRootsWithExpectedFingerprints() {
+        val pinned = NetworkOptionsManager.getDefaultCertificates()
+
+        assertEquals(expectedFingerprints.keys.toList(), pinned.map { it.alias })
+        for (certificate in pinned) {
+            assertEquals(
+                "fingerprint mismatch for ${certificate.alias}",
+                expectedFingerprints[certificate.alias],
+                fingerprintOf(parse(certificate.certificate)),
+            )
+        }
+    }
+
+    @Test
+    fun goDaddyR1RootIsTheSelfSignedRootNotTheCrossSignedVariant() {
+        val r1 = parse(
+            NetworkOptionsManager.getDefaultCertificates()
+                .single { it.alias == "godaddy_tls_root_r1" }
+                .certificate,
+        )
+
+        assertEquals(r1.subjectX500Principal, r1.issuerX500Principal)
+    }
+
+    private fun parse(pem: String): X509Certificate =
+        CertificateFactory.getInstance("X.509")
+            .generateCertificate(ByteArrayInputStream(pem.toByteArray(Charsets.US_ASCII)))
+            as X509Certificate
+
+    private fun fingerprintOf(certificate: X509Certificate): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(certificate.encoded)
+            .joinToString("") { "%02X".format(it.toInt() and 0xFF) }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
 
 allprojects {
     group = 'com.mparticle'
-    version = '5.55.9-SNAPSHOT'
+    version = '5.55.10-SNAPSHOT'
     if (project.hasProperty('isRelease') && project.isRelease) {
         version = version.toString().replace("-SNAPSHOT", "")
     }

--- a/kit-plugin/src/main/groovy/com/mparticle/kits/KitPlugin.groovy
+++ b/kit-plugin/src/main/groovy/com/mparticle/kits/KitPlugin.groovy
@@ -136,7 +136,7 @@ class KitPlugin implements Plugin<Project> {
                     username System.getenv('sonatypeUsername') ?: ""
                     password System.getenv('sonatypePassword') ?: ""
                 }
-                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                url = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
             }
 
             def signingKey = System.getenv("mavenSigningKeyId")

--- a/scripts/maven.gradle
+++ b/scripts/maven.gradle
@@ -96,11 +96,11 @@ afterEvaluate {
         }
         repositories {
             maven {
-                    credentials {
-                        username System.getenv('sonatypeUsername')
-                        password System.getenv('sonatypePassword')
-                    }
-                    url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                credentials {
+                    username System.getenv('sonatypeUsername')
+                    password System.getenv('sonatypePassword')
+                }
+                url = 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
             }
         }
     }


### PR DESCRIPTION
## Background
- GoDaddy has ended DV issuance under its G2 hierarchy. Endpoints are moving to leaves issued under `GoDaddy TLS Intermediate CA DV - R1v1`, chaining to `GoDaddy TLS Root CA - R1`.
- The 5.55.x line replaces the system trust store with its pinned set, whose only usable anchor is the Go Daddy G2 *intermediate* (`intca` and `rootca` are the same certificate). PKIX cannot build a path to R1, so config fetch — the SDK's first request — fails closed. Fixed on `main` in 5.58.0 (#504) and 6.0.3 (#766); this backports both.

## What Has Changed
- **Pinning.** The default set is now the same six roots as 6.0.4: Go Daddy Root CA - G2, **GoDaddy TLS Root CA - R1**, Go Daddy Class 2, ISRG Root X1, ISRG Root X2 (self-signed), ISRG Root X2 (cross-signed). Drops the G2 intermediate and `DO_NOT_TRUST_FiddlerRoot`, a debug MITM anchor that expired 2023-12-19. Adds a unit test asserting the alias set and every certificate's SHA-256.
- **This widens trust, deliberately.** 5.55.9 effectively trusted one CA; 5.55.10 trusts five, including Let's Encrypt roots it previously rejected. That is the upstream set, unchanged since 5.58.0. #504's `NetworkConnection.java` hunk is excluded — it flips custom `NetworkOptions` certificates from replacing the defaults to only adding to them, a semantics change this line does not need for R1.
- **Publishing.** Cherry-picks #594 (first shipped in v5.70.3) to repoint the deploy URL at the Central Portal OSSRH Staging API, and applies the same swap to `KitPlugin.groovy`, which #594 missed. `oss.sonatype.org` has been retired and now returns 404/402, so nothing on this branch — core or kits — could be published without this.
- Version bumped to 5.55.10 by hand: `release.config.js` is `branches: ["main"]`, so semantic-release will not run here.

## Screenshots/Video
- N/A — no visual changes.

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- Verified locally: 272 unit tests pass. A JVM harness replicating `NetworkConnection.getSocketFactory()` completed real TLS handshakes to R1-serving hosts using only these anchors; the 5.55.9 set fails those same hosts, and both sets still validate today's endpoints. The release AAR was unpacked to confirm the R1 root is present and the intermediate and Fiddler anchors are gone.
- Publishing 5.55.10 also needs the manual visibility POST added in #611 (shipped v5.79.2). It lives in `release.yml`, which does not run on this branch, so it is a runbook step rather than a code change here.
- Expect red CI, for reasons that predate this branch: `android-core/build.gradle` declares `androidx.core:core:[1.3.2, )`, which now resolves to a Kotlin 2.1 artifact this tree's Kotlin 1.8.0 cannot read, and `ktlintCheck` already fails on the base with 517 violations — none in files this PR modifies.
