### PR TITLE
feat: Identity API response caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Added
 
-- Cache Identity API identify and login responses, and clear the cache on modify and logout
+- Cache Identity API identify and login responses, and clear the cache on modify and logout ([#786](https://github.com/mParticle/mparticle-android-sdk/pull/786))
 
 ## [6.0.4] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Core
+
+#### Added
+
+- Cache Identity API identify and login responses, and clear the cache on modify and logout
+
 ## [6.0.4] - 2026-09-02
 
 ### Kits

--- a/android-core/src/androidTest/kotlin/com.mparticle/identity/IdentityApiStartTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/identity/IdentityApiStartTest.kt
@@ -288,15 +288,27 @@ class IdentityApiStartTest : BaseCleanInstallEachTest() {
             called.value = true
             latch.countDown()
         }
+        val started = AndroidUtils.Mutable(false)
+        val startLatch: CountDownLatch = MPLatch(1)
         MParticle.start(
             MParticleOptions
                 .builder(mContext)
                 .credentials("key", "secret")
                 .operatingSystem(MParticle.OperatingSystem.FIRE_OS)
+                .identifyTask(
+                    BaseIdentityTask()
+                        .addSuccessListener {
+                            started.value = true
+                            startLatch.countDown()
+                        }.addFailureListener { Assert.fail(it?.toString()) },
+                )
                 .build(),
         )
         latch.await()
+        startLatch.await()
         Assert.assertTrue(called.value)
+        Assert.assertTrue(started.value)
+        AccessUtils.clearIdentityCache()
         MParticle.setInstance(null)
         called.value = false
         val latch1: CountDownLatch = MPLatch(1)

--- a/android-core/src/androidTest/kotlin/com.mparticle/identity/IdentityApiTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/identity/IdentityApiTest.kt
@@ -108,7 +108,7 @@ class IdentityApiTest : BaseCleanStartedEachTest() {
                 latch.countDown()
             }
         }
-        var request = IdentityApiRequest.withEmptyUser().build()
+        var request = IdentityApiRequest.withEmptyUser().customerId("listener-user-1").build()
         var result = MParticle.getInstance()!!.Identity().identify(request)
 
         // test that change actually took place
@@ -118,7 +118,7 @@ class IdentityApiTest : BaseCleanStartedEachTest() {
         }
         com.mparticle.internal.AccessUtils
             .awaitUploadHandler()
-        request = IdentityApiRequest.withEmptyUser().build()
+        request = IdentityApiRequest.withEmptyUser().customerId("listener-user-2").build()
         result = MParticle.getInstance()!!.Identity().identify(request)
         result.addSuccessListener { identityApiResult ->
             Assert.assertEquals(identityApiResult.user.id, mpid2)
@@ -205,12 +205,16 @@ class IdentityApiTest : BaseCleanStartedEachTest() {
         MParticle.getInstance()!!.Identity().addIdentityStateListener(removeIdStateListener1)
         MParticle.getInstance()!!.Identity().addIdentityStateListener(removeIdStateListener2)
         MParticle.getInstance()!!.Identity().addIdentityStateListener(removeIdStateListener3)
-        MParticle.getInstance()!!.Identity().identify(IdentityApiRequest.withEmptyUser().build())
+        MParticle.getInstance()!!.Identity().identify(
+            IdentityApiRequest.withEmptyUser().customerId("remove-listener-1").build(),
+        )
         mpid1Latch.await()
         MParticle.getInstance()!!.Identity().removeIdentityStateListener(removeIdStateListener1)
         MParticle.getInstance()!!.Identity().removeIdentityStateListener(removeIdStateListener2)
         MParticle.getInstance()!!.Identity().removeIdentityStateListener(removeIdStateListener3)
-        MParticle.getInstance()!!.Identity().identify(IdentityApiRequest.withEmptyUser().build())
+        MParticle.getInstance()!!.Identity().identify(
+            IdentityApiRequest.withEmptyUser().customerId("remove-listener-2").build(),
+        )
         mpid2Latch.await()
     }
 

--- a/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
@@ -17,6 +17,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
+import java.lang.reflect.Field
 import java.util.concurrent.CountDownLatch
 
 class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
@@ -57,6 +58,225 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
                         latch.countDown()
                     }?.addFailureListener { Assert.fail("task failed") }
             }?.addFailureListener { Assert.fail("task failed") }
+        latch.await()
+        Assert.assertTrue(called.value)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testLoginWithTwoDifferentUsers() {
+        clearIdentityCache()
+        val latch: CountDownLatch = MPLatch(2)
+        val called = AndroidUtils.Mutable(false)
+        val identityRequest =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("TestEmail@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        MParticle
+            .getInstance()
+            ?.Identity()
+            ?.login(identityRequest)
+            ?.addSuccessListener {
+                latch.countDown()
+                MParticle
+                    .getInstance()
+                    ?.Identity()
+                    ?.login(IdentityApiRequest.withEmptyUser().build())
+                    ?.addSuccessListener {
+                        Assert.assertEquals(2, mServer.Requests().login.size)
+                        called.value = true
+                        latch.countDown()
+                    }
+            }
+        latch.await()
+        Assert.assertTrue(called.value)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testLoginWithTwoSameUsers() {
+        clearIdentityCache()
+        val latch: CountDownLatch = MPLatch(2)
+        val called = AndroidUtils.Mutable(false)
+        val identityRequest =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("TestEmail@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        MParticle
+            .getInstance()
+            ?.Identity()
+            ?.login(identityRequest)
+            ?.addSuccessListener {
+                latch.countDown()
+                MParticle
+                    .getInstance()
+                    ?.Identity()
+                    ?.login(identityRequest)
+                    ?.addSuccessListener {
+                        Assert.assertEquals(1, mServer.Requests().login.size)
+                        called.value = true
+                        latch.countDown()
+                    }
+            }
+        latch.await()
+        Assert.assertTrue(called.value)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testLoginWithTwoSameUsers_withLogout() {
+        clearIdentityCache()
+        val latch: CountDownLatch = MPLatch(3)
+        val called = AndroidUtils.Mutable(false)
+        val identityRequest =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("TestEmail@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        MParticle
+            .getInstance()
+            ?.Identity()
+            ?.login(identityRequest)
+            ?.addSuccessListener {
+                latch.countDown()
+                MParticle
+                    .getInstance()
+                    ?.Identity()
+                    ?.logout()
+                    ?.addSuccessListener {
+                        latch.countDown()
+                        MParticle
+                            .getInstance()
+                            ?.Identity()
+                            ?.login(identityRequest)
+                            ?.addSuccessListener {
+                                Assert.assertEquals(2, mServer.Requests().login.size)
+                                called.value = true
+                                latch.countDown()
+                            }
+                    }
+            }
+        latch.await()
+        Assert.assertTrue(called.value)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testLoginAndIdentifySameUser() {
+        clearIdentityCache()
+        val latch: CountDownLatch = MPLatch(2)
+        val called = AndroidUtils.Mutable(false)
+        val identityRequest =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("TestEmail@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        MParticle
+            .getInstance()
+            ?.Identity()
+            ?.identify(identityRequest)
+            ?.addSuccessListener {
+                latch.countDown()
+                MParticle
+                    .getInstance()
+                    ?.Identity()
+                    ?.login(identityRequest)
+                    ?.addSuccessListener {
+                        Assert.assertEquals(1, mServer.Requests().login.size)
+                        Assert.assertEquals(1, mServer.Requests().identify.size)
+                        called.value = true
+                        latch.countDown()
+                    }
+            }
+        latch.await()
+        Assert.assertTrue(called.value)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testTwoIdentifySameUser_WithModify() {
+        clearIdentityCache()
+        val latch: CountDownLatch = MPLatch(3)
+        val called = AndroidUtils.Mutable(false)
+        val identityRequest =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("TestEmail@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        val identityRequestModify =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("NewTest@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        MParticle
+            .getInstance()
+            ?.Identity()
+            ?.identify(identityRequest)
+            ?.addSuccessListener {
+                latch.countDown()
+                MParticle
+                    .getInstance()
+                    ?.Identity()
+                    ?.modify(identityRequestModify)
+                    ?.addSuccessListener {
+                        latch.countDown()
+                        MParticle
+                            .getInstance()
+                            ?.Identity()
+                            ?.identify(identityRequest)
+                            ?.addSuccessListener {
+                                Assert.assertEquals(2, mServer.Requests().identify.size)
+                                called.value = true
+                                latch.countDown()
+                            }
+                    }
+            }
+        latch.await()
+        Assert.assertTrue(called.value)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testLoginWithTwoSameUsers_WithTimeout() {
+        clearIdentityCache()
+        val latch: CountDownLatch = MPLatch(2)
+        val called = AndroidUtils.Mutable(false)
+        val identityRequest =
+            IdentityApiRequest
+                .withEmptyUser()
+                .email("TestEmail@mparticle6.com")
+                .customerId("TestUser777777")
+                .build()
+        MParticle
+            .getInstance()
+            ?.Identity()
+            ?.login(identityRequest)
+            ?.addSuccessListener {
+                latch.countDown()
+                val client = MParticle.getInstance()?.Identity()?.apiClient as MParticleIdentityClientImpl
+                val field: Field =
+                    MParticleIdentityClientImpl::class.java.getDeclaredField("identityCacheTime")
+                field.isAccessible = true
+                // 0 reloads the persisted timestamp; 1ms is treated as expired.
+                field.set(client, 1L)
+                MParticle
+                    .getInstance()
+                    ?.Identity()
+                    ?.login(identityRequest)
+                    ?.addSuccessListener {
+                        Assert.assertEquals(2, mServer.Requests().login.size)
+                        called.value = true
+                        latch.countDown()
+                    }
+            }
         latch.await()
         Assert.assertTrue(called.value)
     }
@@ -332,6 +552,10 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
                 }
             }
         MParticle.getInstance()?.Identity()?.apiClient = mApiClient
+    }
+
+    private fun clearIdentityCache() {
+        AccessUtils.clearIdentityCache()
     }
 
     @Throws(JSONException::class)

--- a/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
@@ -18,6 +18,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.IOException
 import java.lang.reflect.Field
+import java.util.HashMap
 import java.util.concurrent.CountDownLatch
 
 class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
@@ -262,11 +263,14 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
             ?.addSuccessListener {
                 latch.countDown()
                 val client = MParticle.getInstance()?.Identity()?.apiClient as MParticleIdentityClientImpl
-                val field: Field =
-                    MParticleIdentityClientImpl::class.java.getDeclaredField("identityCacheTime")
-                field.isAccessible = true
-                // 0 reloads the persisted timestamp; 1ms is treated as expired.
-                field.set(client, 1L)
+                val mapField =
+                    MParticleIdentityClientImpl::class.java.getDeclaredField("identityCacheMap")
+                mapField.isAccessible = true
+                @Suppress("UNCHECKED_CAST")
+                val cacheMap = mapField.get(client) as HashMap<String, IdentityHttpResponse>
+                for (response in cacheMap.values) {
+                    response.cacheExpirationMillis = 1L
+                }
                 MParticle
                     .getInstance()
                     ?.Identity()

--- a/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
-import java.lang.reflect.Field
 import java.util.HashMap
 import java.util.concurrent.CountDownLatch
 

--- a/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
+++ b/android-core/src/androidTest/kotlin/com.mparticle/identity/MParticleIdentityClientImplTest.kt
@@ -171,6 +171,7 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
         clearIdentityCache()
         val latch: CountDownLatch = MPLatch(2)
         val called = AndroidUtils.Mutable(false)
+        val identifyBefore = mServer.Requests().identify.size
         val identityRequest =
             IdentityApiRequest
                 .withEmptyUser()
@@ -189,7 +190,7 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
                     ?.login(identityRequest)
                     ?.addSuccessListener {
                         Assert.assertEquals(1, mServer.Requests().login.size)
-                        Assert.assertEquals(1, mServer.Requests().identify.size)
+                        Assert.assertEquals(identifyBefore + 1, mServer.Requests().identify.size)
                         called.value = true
                         latch.countDown()
                     }
@@ -204,6 +205,7 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
         clearIdentityCache()
         val latch: CountDownLatch = MPLatch(3)
         val called = AndroidUtils.Mutable(false)
+        val identifyBefore = mServer.Requests().identify.size
         val identityRequest =
             IdentityApiRequest
                 .withEmptyUser()
@@ -233,7 +235,7 @@ class MParticleIdentityClientImplTest : BaseCleanStartedEachTest() {
                             ?.Identity()
                             ?.identify(identityRequest)
                             ?.addSuccessListener {
-                                Assert.assertEquals(2, mServer.Requests().identify.size)
+                                Assert.assertEquals(identifyBefore + 2, mServer.Requests().identify.size)
                                 called.value = true
                                 latch.countDown()
                             }

--- a/android-core/src/main/java/com/mparticle/identity/IdentityApiRequest.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityApiRequest.java
@@ -7,8 +7,12 @@ import com.mparticle.MParticle;
 import com.mparticle.internal.Logger;
 import com.mparticle.internal.MPUtility;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Class that represents observed changes in user state, can be used as a parameter in an Identity Request.
@@ -181,6 +185,69 @@ public final class IdentityApiRequest {
         @NonNull
         public IdentityApiRequest build() {
             return new IdentityApiRequest(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        IdentityApiRequest that = (IdentityApiRequest) obj;
+        return Objects.equals(userIdentities, that.userIdentities) &&
+                Objects.equals(otherOldIdentities, that.otherOldIdentities) &&
+                Objects.equals(otherNewIdentities, that.otherNewIdentities) &&
+                Objects.equals(mpid, that.mpid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userIdentities, otherOldIdentities, otherNewIdentities, mpid);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "userIdentities" + userIdentities + " otherOldIdentities " + otherOldIdentities
+                + " otherNewIdentities " + otherNewIdentities + " mpid " + String.valueOf(mpid);
+    }
+
+    String objectToHash() {
+        String input = toString();
+        try {
+            MessageDigest md = messageDigest();
+            if (md == null) {
+                return null;
+            }
+            byte[] hashBytes = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashBytes) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.substring(0, Math.min(16, hexString.length()));
+        } catch (Exception e) {
+            Logger.error("Exception while hashing IdentityApiRequest: " + e);
+            return null;
+        }
+    }
+
+    private static MessageDigest messageDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ignored) {
+            try {
+                return MessageDigest.getInstance("SHA-1");
+            } catch (NoSuchAlgorithmException e) {
+                Logger.error("No SHA-256 or SHA-1 MessageDigest available: " + e);
+                return null;
+            }
         }
     }
 }

--- a/android-core/src/main/java/com/mparticle/identity/IdentityApiRequest.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityApiRequest.java
@@ -7,12 +7,8 @@ import com.mparticle.MParticle;
 import com.mparticle.internal.Logger;
 import com.mparticle.internal.MPUtility;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Class that represents observed changes in user state, can be used as a parameter in an Identity Request.
@@ -185,69 +181,6 @@ public final class IdentityApiRequest {
         @NonNull
         public IdentityApiRequest build() {
             return new IdentityApiRequest(this);
-        }
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        IdentityApiRequest that = (IdentityApiRequest) obj;
-        return Objects.equals(userIdentities, that.userIdentities) &&
-                Objects.equals(otherOldIdentities, that.otherOldIdentities) &&
-                Objects.equals(otherNewIdentities, that.otherNewIdentities) &&
-                Objects.equals(mpid, that.mpid);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(userIdentities, otherOldIdentities, otherNewIdentities, mpid);
-    }
-
-    @NonNull
-    @Override
-    public String toString() {
-        return "userIdentities" + userIdentities + " otherOldIdentities " + otherOldIdentities
-                + " otherNewIdentities " + otherNewIdentities + " mpid " + String.valueOf(mpid);
-    }
-
-    String objectToHash() {
-        String input = toString();
-        try {
-            MessageDigest md = messageDigest();
-            if (md == null) {
-                return null;
-            }
-            byte[] hashBytes = md.digest(input.getBytes(StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hashBytes) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            return hexString.substring(0, Math.min(16, hexString.length()));
-        } catch (Exception e) {
-            Logger.error("Exception while hashing IdentityApiRequest: " + e);
-            return null;
-        }
-    }
-
-    private static MessageDigest messageDigest() {
-        try {
-            return MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException ignored) {
-            try {
-                return MessageDigest.getInstance("SHA-1");
-            } catch (NoSuchAlgorithmException e) {
-                Logger.error("No SHA-256 or SHA-1 MessageDigest available: " + e);
-                return null;
-            }
         }
     }
 }

--- a/android-core/src/main/java/com/mparticle/identity/IdentityHttpResponse.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityHttpResponse.java
@@ -18,6 +18,7 @@ public final class IdentityHttpResponse {
     private String context;
     private int httpCode;
     private boolean loggedIn;
+    private long cacheExpirationMillis;
 
     @NonNull
     public static final String MPID = "mpid";
@@ -105,6 +106,14 @@ public final class IdentityHttpResponse {
         return loggedIn;
     }
 
+    public long getCacheExpirationMillis() {
+        return cacheExpirationMillis;
+    }
+
+    public void setCacheExpirationMillis(long cacheExpirationMillis) {
+        this.cacheExpirationMillis = cacheExpirationMillis;
+    }
+
     public static class Error {
         @NonNull
         public final String message;
@@ -138,7 +147,9 @@ public final class IdentityHttpResponse {
 
     public static IdentityHttpResponse fromJson(@NonNull JSONObject jsonObject) throws JSONException {
         int httpCode = jsonObject.optInt("http_code", 0);
-        return new IdentityHttpResponse(httpCode, jsonObject);
+        IdentityHttpResponse response = new IdentityHttpResponse(httpCode, jsonObject);
+        response.setCacheExpirationMillis(jsonObject.optLong("cache_expiration_millis", 0));
+        return response;
     }
 
     @NonNull
@@ -148,6 +159,7 @@ public final class IdentityHttpResponse {
         jsonObject.put(MPID, String.valueOf(mpId));
         jsonObject.put(CONTEXT, context != null ? context : JSONObject.NULL);
         jsonObject.put(LOGGED_IN, loggedIn);
+        jsonObject.put("cache_expiration_millis", cacheExpirationMillis);
 
         if (!errors.isEmpty()) {
             JSONArray errorsArray = new JSONArray();

--- a/android-core/src/main/java/com/mparticle/identity/IdentityHttpResponse.java
+++ b/android-core/src/main/java/com/mparticle/identity/IdentityHttpResponse.java
@@ -135,4 +135,31 @@ public final class IdentityHttpResponse {
         }
         return builder.toString();
     }
+
+    public static IdentityHttpResponse fromJson(@NonNull JSONObject jsonObject) throws JSONException {
+        int httpCode = jsonObject.optInt("http_code", 0);
+        return new IdentityHttpResponse(httpCode, jsonObject);
+    }
+
+    @NonNull
+    public JSONObject toJson() throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("http_code", httpCode);
+        jsonObject.put(MPID, String.valueOf(mpId));
+        jsonObject.put(CONTEXT, context != null ? context : JSONObject.NULL);
+        jsonObject.put(LOGGED_IN, loggedIn);
+
+        if (!errors.isEmpty()) {
+            JSONArray errorsArray = new JSONArray();
+            for (Error error : errors) {
+                JSONObject errorObject = new JSONObject();
+                errorObject.put(CODE, error.code);
+                errorObject.put(MESSAGE, error.message);
+                errorsArray.put(errorObject);
+            }
+            jsonObject.put(ERRORS, errorsArray);
+        }
+
+        return jsonObject;
+    }
 }

--- a/android-core/src/main/java/com/mparticle/identity/MParticleIdentityClientImpl.java
+++ b/android-core/src/main/java/com/mparticle/identity/MParticleIdentityClientImpl.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +65,13 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
     static final String PLATFORM_FIRE = "fire";
 
     private static final String SERVICE_VERSION_1 = "/v1";
+    static final String IDENTITY_HEADER_TIMEOUT = "X-MP-Max-Age";
+    private static final long DEFAULT_MAX_AGE_SECONDS = 86400L;
     private MParticle.OperatingSystem mOperatingSystem;
+    private Long maxAgeTimeForIdentityCache = 0L;
+    private Long maxAgeTime = DEFAULT_MAX_AGE_SECONDS;
+    Long identityCacheTime = 0L;
+    HashMap<String, IdentityHttpResponse> identityCacheMap = new HashMap<>();
 
     public MParticleIdentityClientImpl(Context context, ConfigManager configManager, MParticle.OperatingSystem operatingSystem) {
         super(context, configManager);
@@ -74,6 +81,10 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
     }
 
     public IdentityHttpResponse login(IdentityApiRequest request) throws JSONException, IOException {
+        IdentityHttpResponse cachedResponse = checkIfExists(request, LOGIN_PATH);
+        if (cachedResponse != null) {
+            return cachedResponse;
+        }
         JSONObject jsonObject = getStateJson(request);
         Logger.verbose("Identity login request: " + jsonObject.toString());
         MPConnection connection = getPostConnection(LOGIN_PATH, jsonObject.toString());
@@ -81,12 +92,16 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
         InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_LOGIN, url, jsonObject, request);
         connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
         int responseCode = connection.getResponseCode();
+        updateMaxAgeFromConnection(connection);
         JSONObject response = MPUtility.getJsonResponse(connection);
         InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_LOGIN, url, response, responseCode);
-        return parseIdentityResponse(responseCode, response);
+        IdentityHttpResponse loginHttpResponse = parseIdentityResponse(responseCode, response);
+        cacheRequest(request, loginHttpResponse, LOGIN_PATH, maxAgeTime);
+        return loginHttpResponse;
     }
 
     public IdentityHttpResponse logout(IdentityApiRequest request) throws JSONException, IOException {
+        clearCache();
         JSONObject jsonObject = getStateJson(request);
         Logger.verbose("Identity logout request: \n" + jsonObject.toString());
         MPConnection connection = getPostConnection(LOGOUT_PATH, jsonObject.toString());
@@ -100,6 +115,10 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
     }
 
     public IdentityHttpResponse identify(IdentityApiRequest request) throws JSONException, IOException {
+        IdentityHttpResponse cachedResponse = checkIfExists(request, IDENTIFY_PATH);
+        if (cachedResponse != null) {
+            return cachedResponse;
+        }
         JSONObject jsonObject = getStateJson(request);
         Logger.verbose("Identity identify request: \n" + jsonObject.toString());
         MPConnection connection = getPostConnection(IDENTIFY_PATH, jsonObject.toString());
@@ -107,12 +126,16 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
         InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, jsonObject, request);
         connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
         int responseCode = connection.getResponseCode();
+        updateMaxAgeFromConnection(connection);
         JSONObject response = MPUtility.getJsonResponse(connection);
         InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, response, responseCode);
-        return parseIdentityResponse(responseCode, response);
+        IdentityHttpResponse identityHttpResponse = parseIdentityResponse(responseCode, response);
+        cacheRequest(request, identityHttpResponse, IDENTIFY_PATH, maxAgeTime);
+        return identityHttpResponse;
     }
 
     public IdentityHttpResponse modify(IdentityApiRequest request) throws JSONException, IOException {
+        clearCache();
         JSONObject jsonObject = getChangeJson(request);
         Logger.verbose("Identity modify request: \n" + jsonObject.toString());
         JSONArray identityChanges = jsonObject.optJSONArray("identity_changes");
@@ -127,6 +150,85 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
         JSONObject response = MPUtility.getJsonResponse(connection);
         InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_MODIFY, url, response, responseCode);
         return parseIdentityResponse(responseCode, response);
+    }
+
+    private void cacheRequest(IdentityApiRequest request, IdentityHttpResponse identityHttpResponse, String callType, Long maxAgeSeconds) {
+        if (!mConfigManager.isIdentityCacheFlagEnabled()) {
+            return;
+        }
+        try {
+            if (identityCacheTime <= 0L) {
+                identityCacheTime = System.currentTimeMillis();
+                mConfigManager.saveIdentityCacheTime(identityCacheTime);
+            }
+            String key = identityCacheKey(request, callType);
+            if (key == null) {
+                return;
+            }
+            identityCacheMap.put(key, identityHttpResponse);
+            mConfigManager.saveIdentityCache(key, identityHttpResponse);
+            mConfigManager.saveIdentityMaxAge(maxAgeSeconds);
+        } catch (Exception e) {
+            Logger.error("Exception while processing Identity caching " + e);
+        }
+    }
+
+    void clearCache() {
+        identityCacheMap.clear();
+        mConfigManager.clearIdentityCache();
+    }
+
+    private IdentityHttpResponse checkIfExists(IdentityApiRequest request, String callType) {
+        if (!mConfigManager.isIdentityCacheFlagEnabled()) {
+            return null;
+        }
+        try {
+            String key = identityCacheKey(request, callType);
+            if (key == null) {
+                return null;
+            }
+            if (identityCacheTime <= 0L) {
+                identityCacheTime = mConfigManager.getIdentityCacheTime();
+            }
+            if (maxAgeTimeForIdentityCache <= 0L) {
+                maxAgeTimeForIdentityCache = mConfigManager.getIdentityMaxAge();
+            }
+            if (identityCacheMap.isEmpty()) {
+                identityCacheMap = mConfigManager.fetchIdentityCache();
+            }
+            if ((((System.currentTimeMillis() - identityCacheTime) / 1000) <= maxAgeTimeForIdentityCache)
+                    && identityCacheMap.containsKey(key)) {
+                return identityCacheMap.get(key);
+            }
+        } catch (Exception e) {
+            Logger.error("Exception while reading Identity cache " + e);
+        }
+        return null;
+    }
+
+    private String identityCacheKey(IdentityApiRequest request, String callType) {
+        if (request == null) {
+            return null;
+        }
+        String hash = request.objectToHash();
+        if (hash == null) {
+            return null;
+        }
+        return hash + callType;
+    }
+
+    private void updateMaxAgeFromConnection(MPConnection connection) {
+        String header = connection.getHeaderField(IDENTITY_HEADER_TIMEOUT);
+        if (header == null) {
+            Logger.verbose("Identity response missing " + IDENTITY_HEADER_TIMEOUT + " header, using max age " + maxAgeTime);
+            return;
+        }
+        try {
+            maxAgeTime = Long.valueOf(header);
+            maxAgeTimeForIdentityCache = maxAgeTime;
+        } catch (Exception e) {
+            Logger.error("Failed to parse " + IDENTITY_HEADER_TIMEOUT + " header: " + e);
+        }
     }
 
     private JSONObject getBaseJson() throws JSONException {

--- a/android-core/src/main/java/com/mparticle/identity/MParticleIdentityClientImpl.java
+++ b/android-core/src/main/java/com/mparticle/identity/MParticleIdentityClientImpl.java
@@ -21,9 +21,14 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -66,11 +71,7 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
 
     private static final String SERVICE_VERSION_1 = "/v1";
     static final String IDENTITY_HEADER_TIMEOUT = "X-MP-Max-Age";
-    private static final long DEFAULT_MAX_AGE_SECONDS = 86400L;
     private MParticle.OperatingSystem mOperatingSystem;
-    private Long maxAgeTimeForIdentityCache = 0L;
-    private Long maxAgeTime = DEFAULT_MAX_AGE_SECONDS;
-    Long identityCacheTime = 0L;
     HashMap<String, IdentityHttpResponse> identityCacheMap = new HashMap<>();
 
     public MParticleIdentityClientImpl(Context context, ConfigManager configManager, MParticle.OperatingSystem operatingSystem) {
@@ -81,22 +82,23 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
     }
 
     public IdentityHttpResponse login(IdentityApiRequest request) throws JSONException, IOException {
-        IdentityHttpResponse cachedResponse = checkIfExists(request, LOGIN_PATH);
+        JSONObject jsonObject = getStateJson(request);
+        JSONObject knownIdentities = jsonObject.optJSONObject(KNOWN_IDENTITIES);
+        IdentityHttpResponse cachedResponse = getCachedResponse(knownIdentities, LOGIN_PATH);
         if (cachedResponse != null) {
+            Logger.verbose("Identity login cache hit");
             return cachedResponse;
         }
-        JSONObject jsonObject = getStateJson(request);
         Logger.verbose("Identity login request: " + jsonObject.toString());
         MPConnection connection = getPostConnection(LOGIN_PATH, jsonObject.toString());
         String url = connection.getURL().toString();
         InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_LOGIN, url, jsonObject, request);
         connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
         int responseCode = connection.getResponseCode();
-        updateMaxAgeFromConnection(connection);
         JSONObject response = MPUtility.getJsonResponse(connection);
         InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_LOGIN, url, response, responseCode);
         IdentityHttpResponse loginHttpResponse = parseIdentityResponse(responseCode, response);
-        cacheRequest(request, loginHttpResponse, LOGIN_PATH, maxAgeTime);
+        cacheResponse(knownIdentities, LOGIN_PATH, loginHttpResponse, parseMaxAgeSeconds(connection));
         return loginHttpResponse;
     }
 
@@ -115,22 +117,23 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
     }
 
     public IdentityHttpResponse identify(IdentityApiRequest request) throws JSONException, IOException {
-        IdentityHttpResponse cachedResponse = checkIfExists(request, IDENTIFY_PATH);
+        JSONObject jsonObject = getStateJson(request);
+        JSONObject knownIdentities = jsonObject.optJSONObject(KNOWN_IDENTITIES);
+        IdentityHttpResponse cachedResponse = getCachedResponse(knownIdentities, IDENTIFY_PATH);
         if (cachedResponse != null) {
+            Logger.verbose("Identity identify cache hit");
             return cachedResponse;
         }
-        JSONObject jsonObject = getStateJson(request);
         Logger.verbose("Identity identify request: \n" + jsonObject.toString());
         MPConnection connection = getPostConnection(IDENTIFY_PATH, jsonObject.toString());
         String url = connection.getURL().toString();
         InternalListenerManager.getListener().onNetworkRequestStarted(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, jsonObject, request);
         connection = makeUrlRequest(Endpoint.IDENTITY, connection, jsonObject.toString(), false);
         int responseCode = connection.getResponseCode();
-        updateMaxAgeFromConnection(connection);
         JSONObject response = MPUtility.getJsonResponse(connection);
         InternalListenerManager.getListener().onNetworkRequestFinished(SdkListener.Endpoint.IDENTITY_IDENTIFY, url, response, responseCode);
         IdentityHttpResponse identityHttpResponse = parseIdentityResponse(responseCode, response);
-        cacheRequest(request, identityHttpResponse, IDENTIFY_PATH, maxAgeTime);
+        cacheResponse(knownIdentities, IDENTIFY_PATH, identityHttpResponse, parseMaxAgeSeconds(connection));
         return identityHttpResponse;
     }
 
@@ -152,22 +155,18 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
         return parseIdentityResponse(responseCode, response);
     }
 
-    private void cacheRequest(IdentityApiRequest request, IdentityHttpResponse identityHttpResponse, String callType, Long maxAgeSeconds) {
-        if (!mConfigManager.isIdentityCacheFlagEnabled()) {
+    private void cacheResponse(JSONObject knownIdentities, String callType, IdentityHttpResponse identityHttpResponse, long maxAgeSeconds) {
+        if (!mConfigManager.isIdentityCacheFlagEnabled() || maxAgeSeconds <= 0 || !isCacheableResponse(identityHttpResponse)) {
             return;
         }
         try {
-            if (identityCacheTime <= 0L) {
-                identityCacheTime = System.currentTimeMillis();
-                mConfigManager.saveIdentityCacheTime(identityCacheTime);
-            }
-            String key = identityCacheKey(request, callType);
+            String key = identityCacheKey(knownIdentities, callType);
             if (key == null) {
                 return;
             }
+            identityHttpResponse.setCacheExpirationMillis(System.currentTimeMillis() + (maxAgeSeconds * 1000L));
             identityCacheMap.put(key, identityHttpResponse);
             mConfigManager.saveIdentityCache(key, identityHttpResponse);
-            mConfigManager.saveIdentityMaxAge(maxAgeSeconds);
         } catch (Exception e) {
             Logger.error("Exception while processing Identity caching " + e);
         }
@@ -178,57 +177,112 @@ public class MParticleIdentityClientImpl extends MParticleBaseClientImpl impleme
         mConfigManager.clearIdentityCache();
     }
 
-    private IdentityHttpResponse checkIfExists(IdentityApiRequest request, String callType) {
+    private IdentityHttpResponse getCachedResponse(JSONObject knownIdentities, String callType) {
         if (!mConfigManager.isIdentityCacheFlagEnabled()) {
             return null;
         }
         try {
-            String key = identityCacheKey(request, callType);
+            String key = identityCacheKey(knownIdentities, callType);
             if (key == null) {
                 return null;
-            }
-            if (identityCacheTime <= 0L) {
-                identityCacheTime = mConfigManager.getIdentityCacheTime();
-            }
-            if (maxAgeTimeForIdentityCache <= 0L) {
-                maxAgeTimeForIdentityCache = mConfigManager.getIdentityMaxAge();
             }
             if (identityCacheMap.isEmpty()) {
                 identityCacheMap = mConfigManager.fetchIdentityCache();
             }
-            if ((((System.currentTimeMillis() - identityCacheTime) / 1000) <= maxAgeTimeForIdentityCache)
-                    && identityCacheMap.containsKey(key)) {
-                return identityCacheMap.get(key);
+            IdentityHttpResponse cachedResponse = identityCacheMap.get(key);
+            if (cachedResponse == null) {
+                return null;
             }
+            if (cachedResponse.getCacheExpirationMillis() <= System.currentTimeMillis()) {
+                identityCacheMap.remove(key);
+                return null;
+            }
+            return cachedResponse;
         } catch (Exception e) {
             Logger.error("Exception while reading Identity cache " + e);
-        }
-        return null;
-    }
-
-    private String identityCacheKey(IdentityApiRequest request, String callType) {
-        if (request == null) {
             return null;
         }
-        String hash = request.objectToHash();
-        if (hash == null) {
-            return null;
-        }
-        return hash + callType;
     }
 
-    private void updateMaxAgeFromConnection(MPConnection connection) {
+    static String identityCacheKey(JSONObject knownIdentities, String callType) {
+        String hash = hashIdentities(knownIdentities);
+        if (hash == null || callType == null) {
+            return null;
+        }
+        return callType + "::" + hash;
+    }
+
+    static String hashIdentities(JSONObject identities) {
+        String serialized = serializeIdentities(identities);
+        if (serialized == null || serialized.length() == 0) {
+            return null;
+        }
+        return sha256Hex(serialized);
+    }
+
+    static String serializeIdentities(JSONObject identities) {
+        if (identities == null || identities.length() == 0) {
+            return null;
+        }
+        List<String> keys = new ArrayList<String>();
+        Iterator<String> iterator = identities.keys();
+        while (iterator.hasNext()) {
+            keys.add(iterator.next());
+        }
+        Collections.sort(keys);
+        StringBuilder serialized = new StringBuilder();
+        for (String key : keys) {
+            serialized.append("::").append(key);
+            Object value = identities.opt(key);
+            if (value == null || value == JSONObject.NULL) {
+                serialized.append(":null");
+            } else {
+                serialized.append(":").append(value.toString());
+            }
+        }
+        return serialized.toString();
+    }
+
+    static String sha256Hex(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = md.digest(input.getBytes("UTF-8"));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashBytes) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (Exception e) {
+            Logger.error("Exception while hashing identity cache key: " + e);
+            return null;
+        }
+    }
+
+    private long parseMaxAgeSeconds(MPConnection connection) {
         String header = connection.getHeaderField(IDENTITY_HEADER_TIMEOUT);
         if (header == null) {
-            Logger.verbose("Identity response missing " + IDENTITY_HEADER_TIMEOUT + " header, using max age " + maxAgeTime);
-            return;
+            Logger.verbose("Identity response missing " + IDENTITY_HEADER_TIMEOUT + " header, skipping cache");
+            return 0L;
         }
         try {
-            maxAgeTime = Long.valueOf(header);
-            maxAgeTimeForIdentityCache = maxAgeTime;
+            long maxAgeSeconds = Long.parseLong(header.trim());
+            if (maxAgeSeconds <= 0) {
+                Logger.verbose("Identity " + IDENTITY_HEADER_TIMEOUT + " is not positive, skipping cache");
+                return 0L;
+            }
+            return maxAgeSeconds;
         } catch (Exception e) {
             Logger.error("Failed to parse " + IDENTITY_HEADER_TIMEOUT + " header: " + e);
+            return 0L;
         }
+    }
+
+    private boolean isCacheableResponse(IdentityHttpResponse response) {
+        return response != null && (response.getHttpCode() == 200 || response.getHttpCode() == 202);
     }
 
     private JSONObject getBaseJson() throws JSONException {

--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -17,6 +17,7 @@ import com.mparticle.MParticle;
 import com.mparticle.MParticleOptions;
 import com.mparticle.consent.ConsentState;
 import com.mparticle.identity.IdentityApi;
+import com.mparticle.identity.IdentityHttpResponse;
 import com.mparticle.internal.database.UploadSettings;
 import com.mparticle.internal.messages.BaseMPMessage;
 import com.mparticle.networking.NetworkOptions;
@@ -950,6 +951,71 @@ public class ConfigManager {
 
     public Set<Long> getMpids() {
         return UserStorage.getMpIdSet(mContext);
+    }
+
+    private static synchronized JSONObject getIdentityCache() {
+        String json = sPreferences.getString(Constants.PrefKeys.IDENTITY_API_REQUEST, null);
+        if (json != null) {
+            try {
+                return new JSONObject(json);
+            } catch (JSONException e) {
+                Logger.error("Failed to fetch identity cache from storage : " + e.getMessage());
+            }
+        }
+        return new JSONObject();
+    }
+
+    public synchronized HashMap<String, IdentityHttpResponse> fetchIdentityCache() {
+        HashMap<String, IdentityHttpResponse> identityCache = new HashMap<String, IdentityHttpResponse>();
+        try {
+            JSONObject jsonObject = getIdentityCache();
+            Iterator<String> keys = jsonObject.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                JSONObject identityJson = jsonObject.getJSONObject(key);
+                identityCache.put(key, IdentityHttpResponse.fromJson(identityJson));
+            }
+        } catch (Exception e) {
+            Logger.error("Error while fetching identity cache: " + e.getMessage());
+        }
+        return identityCache;
+    }
+
+    public synchronized void saveIdentityCache(String key, IdentityHttpResponse identityHttpResponse) throws JSONException {
+        if (key == null || identityHttpResponse == null) {
+            return;
+        }
+        JSONObject cache = getIdentityCache();
+        cache.put(key, identityHttpResponse.toJson());
+        sPreferences.edit().putString(Constants.PrefKeys.IDENTITY_API_REQUEST, cache.toString()).apply();
+    }
+
+    public void saveIdentityCacheTime(long time) {
+        sPreferences.edit().putLong(Constants.PrefKeys.IDENTITY_API_CACHE_TIME, time).apply();
+    }
+
+    public void saveIdentityMaxAge(long time) {
+        sPreferences.edit().putLong(Constants.PrefKeys.IDENTITY_MAX_AGE, time).apply();
+    }
+
+    public synchronized Long getIdentityCacheTime() {
+        return sPreferences.getLong(Constants.PrefKeys.IDENTITY_API_CACHE_TIME, 0);
+    }
+
+    public Long getIdentityMaxAge() {
+        return sPreferences.getLong(Constants.PrefKeys.IDENTITY_MAX_AGE, 0);
+    }
+
+    public void clearIdentityCache() {
+        sPreferences.edit()
+                .remove(Constants.PrefKeys.IDENTITY_API_REQUEST)
+                .remove(Constants.PrefKeys.IDENTITY_API_CACHE_TIME)
+                .remove(Constants.PrefKeys.IDENTITY_MAX_AGE)
+                .apply();
+    }
+
+    public boolean isIdentityCacheFlagEnabled() {
+        return true;
     }
 
     private static boolean sInProgress;

--- a/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
+++ b/android-core/src/main/java/com/mparticle/internal/ConfigManager.java
@@ -990,27 +990,9 @@ public class ConfigManager {
         sPreferences.edit().putString(Constants.PrefKeys.IDENTITY_API_REQUEST, cache.toString()).apply();
     }
 
-    public void saveIdentityCacheTime(long time) {
-        sPreferences.edit().putLong(Constants.PrefKeys.IDENTITY_API_CACHE_TIME, time).apply();
-    }
-
-    public void saveIdentityMaxAge(long time) {
-        sPreferences.edit().putLong(Constants.PrefKeys.IDENTITY_MAX_AGE, time).apply();
-    }
-
-    public synchronized Long getIdentityCacheTime() {
-        return sPreferences.getLong(Constants.PrefKeys.IDENTITY_API_CACHE_TIME, 0);
-    }
-
-    public Long getIdentityMaxAge() {
-        return sPreferences.getLong(Constants.PrefKeys.IDENTITY_MAX_AGE, 0);
-    }
-
     public void clearIdentityCache() {
         sPreferences.edit()
                 .remove(Constants.PrefKeys.IDENTITY_API_REQUEST)
-                .remove(Constants.PrefKeys.IDENTITY_API_CACHE_TIME)
-                .remove(Constants.PrefKeys.IDENTITY_MAX_AGE)
                 .apply();
     }
 

--- a/android-core/src/main/kotlin/com/mparticle/internal/Constants.kt
+++ b/android-core/src/main/kotlin/com/mparticle/internal/Constants.kt
@@ -652,8 +652,6 @@ object Constants {
             const val REPORT_UNCAUGHT_EXCEPTIONS: String = "mp::reportUncaughtExceptions"
             const val ENVIRONMENT: String = "mp::environment"
             const val IDENTITY_API_REQUEST: String = "mp::identity::api::request"
-            const val IDENTITY_API_CACHE_TIME: String = "mp::identity::cache::time"
-            const val IDENTITY_MAX_AGE: String = "mp::max:age::time"
         }
     }
 

--- a/android-core/src/main/kotlin/com/mparticle/internal/Constants.kt
+++ b/android-core/src/main/kotlin/com/mparticle/internal/Constants.kt
@@ -651,6 +651,9 @@ object Constants {
             const val SESSION_TIMEOUT: String = "mp::sessionTimeout"
             const val REPORT_UNCAUGHT_EXCEPTIONS: String = "mp::reportUncaughtExceptions"
             const val ENVIRONMENT: String = "mp::environment"
+            const val IDENTITY_API_REQUEST: String = "mp::identity::api::request"
+            const val IDENTITY_API_CACHE_TIME: String = "mp::identity::cache::time"
+            const val IDENTITY_MAX_AGE: String = "mp::max:age::time"
         }
     }
 

--- a/android-core/src/test/kotlin/com/mparticle/identity/IdentityCacheKeyTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/identity/IdentityCacheKeyTest.kt
@@ -1,0 +1,54 @@
+package com.mparticle.identity
+
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Test
+
+class IdentityCacheKeyTest {
+    @Test
+    fun serializeIdentitiesMatchesAppleSdkFormat() {
+        val identities = JSONObject()
+        identities.put("email", "test1@test2.com")
+        identities.put("customerid", "12345")
+        identities.put("google", JSONObject.NULL)
+        identities.put("ios_idfv", "abcdefg")
+
+        Assert.assertEquals(
+            "::customerid:12345::email:test1@test2.com::google:null::ios_idfv:abcdefg",
+            MParticleIdentityClientImpl.serializeIdentities(identities),
+        )
+    }
+
+    @Test
+    fun identityCacheKeyIsStableAcrossJsonKeyOrder() {
+        val first = JSONObject()
+        first.put("email", "test1@test2.com")
+        first.put("customerid", "12345")
+        val second = JSONObject()
+        second.put("customerid", "12345")
+        second.put("email", "test1@test2.com")
+
+        Assert.assertEquals(
+            MParticleIdentityClientImpl.identityCacheKey(first, "login"),
+            MParticleIdentityClientImpl.identityCacheKey(second, "login"),
+        )
+        Assert.assertNotEquals(
+            MParticleIdentityClientImpl.identityCacheKey(first, "login"),
+            MParticleIdentityClientImpl.identityCacheKey(first, "identify"),
+        )
+    }
+
+    @Test
+    fun emptyIdentitiesAreNotHashed() {
+        Assert.assertNull(MParticleIdentityClientImpl.hashIdentities(JSONObject()))
+        Assert.assertNull(MParticleIdentityClientImpl.hashIdentities(null))
+        Assert.assertNull(MParticleIdentityClientImpl.identityCacheKey(JSONObject(), "login"))
+    }
+
+    @Test
+    fun sha256HexUsesFullDigest() {
+        val hash = MParticleIdentityClientImpl.sha256Hex("::email:test@test.com::customerid:12435")
+        Assert.assertNotNull(hash)
+        Assert.assertEquals(64, hash!!.length)
+    }
+}

--- a/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
@@ -774,25 +774,21 @@ class ConfigManagerTest {
         Assert.assertTrue(manager.isIdentityCacheFlagEnabled)
 
         val response = IdentityHttpResponse(200, 123456789L, "ctx", null)
-        manager.saveIdentityCache("abcidentify", response)
-        manager.saveIdentityCacheTime(1000L)
-        manager.saveIdentityMaxAge(86400L)
+        response.cacheExpirationMillis = 999L
+        manager.saveIdentityCache("login::abc", response)
 
         val fetched = manager.fetchIdentityCache()
         Assert.assertEquals(1, fetched.size)
-        Assert.assertEquals(123456789L, fetched["abcidentify"]?.mpId)
-        Assert.assertEquals("ctx", fetched["abcidentify"]?.context)
-        Assert.assertEquals(1000L, manager.identityCacheTime)
-        Assert.assertEquals(86400L, manager.identityMaxAge)
+        Assert.assertEquals(123456789L, fetched["login::abc"]?.mpId)
+        Assert.assertEquals("ctx", fetched["login::abc"]?.context)
+        Assert.assertEquals(999L, fetched["login::abc"]?.cacheExpirationMillis)
 
-        manager.saveIdentityCache("abcidentify", IdentityHttpResponse(200, 999L, "ctx2", null))
+        manager.saveIdentityCache("login::abc", IdentityHttpResponse(200, 999L, "ctx2", null))
         Assert.assertEquals(1, manager.fetchIdentityCache().size)
-        Assert.assertEquals(999L, manager.fetchIdentityCache()["abcidentify"]?.mpId)
+        Assert.assertEquals(999L, manager.fetchIdentityCache()["login::abc"]?.mpId)
 
         manager.clearIdentityCache()
         Assert.assertTrue(manager.fetchIdentityCache().isEmpty())
-        Assert.assertEquals(0L, manager.identityCacheTime)
-        Assert.assertEquals(0L, manager.identityMaxAge)
     }
 
     companion object {

--- a/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
+++ b/android-core/src/test/kotlin/com/mparticle/internal/ConfigManagerTest.kt
@@ -4,6 +4,7 @@ import com.mparticle.MParticle
 import com.mparticle.MockMParticle
 import com.mparticle.consent.ConsentState
 import com.mparticle.consent.GDPRConsent
+import com.mparticle.identity.IdentityHttpResponse
 import com.mparticle.internal.KitManager.KitStatus
 import com.mparticle.internal.PushRegistrationHelper.PushRegistration
 import com.mparticle.internal.messages.BaseMPMessage
@@ -763,6 +764,35 @@ class ConfigManagerTest {
 
         val reloadedManager = ConfigManager(context)
         Assert.assertTrue(reloadedManager.isDeviceBasedConsentEnabled())
+    }
+
+    @Test
+    @Throws(JSONException::class)
+    fun testIdentityCacheRoundTrip() {
+        manager.clearIdentityCache()
+        Assert.assertTrue(manager.fetchIdentityCache().isEmpty())
+        Assert.assertTrue(manager.isIdentityCacheFlagEnabled)
+
+        val response = IdentityHttpResponse(200, 123456789L, "ctx", null)
+        manager.saveIdentityCache("abcidentify", response)
+        manager.saveIdentityCacheTime(1000L)
+        manager.saveIdentityMaxAge(86400L)
+
+        val fetched = manager.fetchIdentityCache()
+        Assert.assertEquals(1, fetched.size)
+        Assert.assertEquals(123456789L, fetched["abcidentify"]?.mpId)
+        Assert.assertEquals("ctx", fetched["abcidentify"]?.context)
+        Assert.assertEquals(1000L, manager.identityCacheTime)
+        Assert.assertEquals(86400L, manager.identityMaxAge)
+
+        manager.saveIdentityCache("abcidentify", IdentityHttpResponse(200, 999L, "ctx2", null))
+        Assert.assertEquals(1, manager.fetchIdentityCache().size)
+        Assert.assertEquals(999L, manager.fetchIdentityCache()["abcidentify"]?.mpId)
+
+        manager.clearIdentityCache()
+        Assert.assertTrue(manager.fetchIdentityCache().isEmpty())
+        Assert.assertEquals(0L, manager.identityCacheTime)
+        Assert.assertEquals(0L, manager.identityMaxAge)
     }
 
     companion object {

--- a/testutils/src/main/java/com/mparticle/identity/AccessUtils.java
+++ b/testutils/src/main/java/com/mparticle/identity/AccessUtils.java
@@ -130,6 +130,16 @@ public class AccessUtils {
         MParticle.getInstance().Identity().mKitManager = kitManager;
     }
 
+    public static void clearIdentityCache() {
+        if (MParticle.getInstance() == null) {
+            return;
+        }
+        MParticleIdentityClient client = MParticle.getInstance().Identity().getApiClient();
+        if (client instanceof MParticleIdentityClientImpl) {
+            ((MParticleIdentityClientImpl) client).clearCache();
+        }
+    }
+
     public static Set<IdentityStateListener> getIdentityStateListeners() {
         return MParticle.getInstance().Identity().identityStateListeners;
     }

--- a/testutils/src/main/java/com/mparticle/networking/MockServer.java
+++ b/testutils/src/main/java/com/mparticle/networking/MockServer.java
@@ -120,6 +120,11 @@ public class MockServer {
                         response.setRequest(mockConnection);
                         mockConnection.response = response.responseBody;
                         mockConnection.responseCode = response.responseCode;
+                        if (response.headers != null) {
+                            for (Map.Entry<String, String> header : response.headers.entrySet()) {
+                                mockConnection.setRequestProperty(header.getKey(), header.getValue());
+                            }
+                        }
                         if (!entry.getKey().keepAfterMatch) {
                             serverLogic.remove(entry.getKey());
                         }
@@ -451,6 +456,7 @@ public class MockServer {
                     IdentityRequest.IdentityRequestBody request = new IdentityRequest(connection).getBody();
                     response.responseCode = 200;
                     response.responseBody = getIdentityResponse(request.previousMpid != null && request.previousMpid != 0 ? request.previousMpid : ran.nextLong(), ran.nextBoolean());
+                    response.setHeader("X-MP-Max-Age", "86400");
                 } catch (Exception ex) {
                     throw new RuntimeException(ex);
                 }

--- a/testutils/src/main/java/com/mparticle/networking/Response.java
+++ b/testutils/src/main/java/com/mparticle/networking/Response.java
@@ -1,10 +1,14 @@
 package com.mparticle.networking;
 
+import java.util.HashMap;
+import java.util.Map;
+
 class Response {
 
     int responseCode = 200;
     String responseBody = "";
     long delay;
+    Map<String, String> headers = new HashMap<>();
 
     Response() {
     }
@@ -24,5 +28,13 @@ class Response {
         if (onRequestCallback != null) {
             onRequestCallback.onRequest(this, connection);
         }
+    }
+
+    void setHeader(String key, String value) {
+        headers.put(key, value);
+    }
+
+    String getHeader(String key) {
+        return headers.get(key);
     }
 }

--- a/testutils/src/main/java/com/mparticle/testutils/BaseAbstractTest.java
+++ b/testutils/src/main/java/com/mparticle/testutils/BaseAbstractTest.java
@@ -107,6 +107,7 @@ public abstract class BaseAbstractTest {
         mServer.setupHappyIdentify(mStartingMpid);
         latch.await();
         assertTrue(called.value);
+        com.mparticle.identity.AccessUtils.clearIdentityCache();
     }
 
     protected void goToBackground() {


### PR DESCRIPTION
## Summary
- Ports Identity API response caching onto current `main` (SQDSDKS-6673): identify and login responses are cached, and the cache is cleared on modify and logout.
- Supersedes #513, which targeted the retired `development` branch and could not be rebased cleanly.

## Test plan
- [x] `./gradlew :android-core:testDebugUnitTest` (includes `ConfigManagerTest.testIdentityCacheRoundTrip`)
- [ ] Instrumented identity cache cases in `MParticleIdentityClientImplTest` (same-user login is cached; different users, logout, modify, and expiry still hit the network)
- [ ] Same-user identify/login on a cold launch still returns the cached response until max-age expires

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-6673
- Supersedes #513

Made with [Cursor](https://cursor.com)