### PR TITLE
ci: extend Dependabot to kit directories with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: gradle
-    directory: "/"
+    # Root monorepo plus standalone kit Gradle projects. Kits live at kits/*/*
+    # (e.g. kits/rokt/rokt); deeper paths like example apps are excluded.
+    directories:
+      - "/"
+      - "/kits/*/*"
     schedule:
       interval: daily
     labels: ["dependabot"]
     open-pull-requests-limit: 10
+    groups:
+      shared-gradle-dependencies:
+        patterns:
+          - "*"
+        group-by: dependency-name
     ignore:
       - dependency-name: "com.mparticle:android-core"
       - dependency-name: "com.google.firebase:firebase-messaging"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Dependabot previously scanned only the root Gradle project (`directory: "/"`). Standalone kit projects under `kits/*/*` each have their own `settings.gradle.kts` and are built with `-p kits/...`, so they were outside Dependabot's scope. The recent coroutines bump (#794) updated `ext.coroutines_version` in the root `build.gradle` but left hardcoded versions in kits such as `kits/rokt/rokt/build.gradle`.

## What Has Changed

Updated `.github/dependabot.yml` to:

- Replace `directory: "/"` with `directories` covering the root monorepo and all kit Gradle projects via `/kits/*/*`
- Add a `shared-gradle-dependencies` group with `group-by: dependency-name` so the same Maven dependency is bumped in one PR across root and kits

The `/kits/*/*` glob matches the two-level kit layout (e.g. `kits/rokt/rokt`) and excludes deeper paths such as example apps.

## Screenshots/Video

N/A — configuration-only change.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Grouping is by exact dependency name (`group:artifact`), not Maven groupId. Related artifacts such as `kotlinx-coroutines-android`, `kotlinx-coroutines-core`, and `kotlinx-coroutines-test` may still appear in separate PRs.
- If kits pin incompatible versions of the same dependency (e.g. Kotlin `2.1.20` vs `2.2.20`), Dependabot may open separate PRs per its cross-directory grouping rules.
- Existing `ignore` entries and the github-actions update entry are unchanged.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A

Made with [Cursor](https://cursor.com)