### PR TITLE
ci: measure the Rokt kit against a Compose reference app

### DIFF
--- a/.github/scripts/render_size_report.py
+++ b/.github/scripts/render_size_report.py
@@ -10,6 +10,8 @@ Options:
                              shows this stack's cost over stack BASE rather than over the
                              empty baseline. Repeatable; order is preserved.
   --marker TEXT              HTML comment used to find and replace the sticky PR comment.
+  --baseline-note TEXT       Sentence describing what the baseline app is. Per-workflow rather
+                             than fixed, because the fixtures do not share a baseline.
   --footnote TEXT            Trailing line naming what was measured, so a comment left behind
                              by a later push is visibly stale rather than passing as current.
 
@@ -105,13 +107,22 @@ def status(base, head, stacks):
 
 
 def parse_args(argv):
-    stacks, marker, paths, footnote = [], "<!-- sdk-size-report -->", [], ""
+    stacks, marker, paths, footnote, baseline_note = (
+        [],
+        "<!-- sdk-size-report -->",
+        [],
+        "",
+        "",
+    )
     index = 0
     while index < len(argv):
         arg = argv[index]
         if arg == "--footnote":
             index += 1
             footnote = argv[index]
+        elif arg == "--baseline-note":
+            index += 1
+            baseline_note = argv[index]
         elif arg == "--stack":
             index += 1
             parts = argv[index].split(":")
@@ -124,11 +135,11 @@ def parse_args(argv):
         else:
             paths.append(arg)
         index += 1
-    return stacks, marker, paths, footnote
+    return stacks, marker, paths, footnote, baseline_note
 
 
 def main(argv):
-    stacks, marker, paths, footnote = parse_args(argv)
+    stacks, marker, paths, footnote, baseline_note = parse_args(argv)
     if len(paths) != 2 or not stacks:
         print(__doc__, file=sys.stderr)
         return 2
@@ -138,8 +149,10 @@ def main(argv):
         marker,
         "## 📦 SDK Size Impact Report",
         "",
-        "APK size a minimal app pays for the SDK, on a minified release build.",
+        "What the SDK adds to a minified release APK.",
     ]
+    if baseline_note:
+        parts += ["", baseline_note]
     labels = {name: label for name, label, _ in stacks}
     for stack, label, marginal_base in stacks:
         marginal_label = labels.get(marginal_base, marginal_base)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -305,6 +305,7 @@ jobs:
           head/.github/scripts/render_size_report.py \
             --marker "${COMMENT_IDENTIFIER}" \
             --footnote "${FOOTNOTE}" \
+            --baseline-note "Measured against an empty baseline app. Unlike the Rokt kit, android-core ships no Compose and no resources, so there is nothing here that a host app would already provide." \
             --stack 'core:mParticle Core SDK' \
             "${RUNNER_TEMP}/base.json" "${RUNNER_TEMP}/head.json" > "${RUNNER_TEMP}/size-report.md"
           cat "${RUNNER_TEMP}/size-report.md" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/rokt-size-report.yml
+++ b/.github/workflows/rokt-size-report.yml
@@ -108,6 +108,7 @@ jobs:
           head/.github/scripts/render_size_report.py \
             --marker "${COMMENT_IDENTIFIER}" \
             --footnote "${FOOTNOTE}" \
+            --baseline-note "Measured against a Compose + Material3 reference app, so these are the costs on top of an app that already ships Compose. The reference app's dependencies are a documented convention, not a measured average: see \`size-report-rokt/README.md\`." \
             --stack 'kit:mParticle Core + Rokt kit' \
             --stack 'sdkplus:Rokt SDK+ umbrella (adds the payment extension):kit' \
             "${RUNNER_TEMP}/base.json" "${RUNNER_TEMP}/head.json" > "${RUNNER_TEMP}/size-report.md"

--- a/scripts/rokt-size-report.sh
+++ b/scripts/rokt-size-report.sh
@@ -106,7 +106,9 @@ dex_bytes() { unzip -l "$1" | awk '$4 ~ /\.dex$/ { s += $1 } END { print s + 0 }
 # A fixture that silently stops linking the kit or the payment extension still produces a
 # perfectly valid APK, and the report would present that as a large size *saving*. Fail closed
 # instead: the workflow leaves the JSON empty and the comment reads "not measured".
-MAX_BASELINE_BYTES=$((128 * 1024))
+# Floors are set well below the figures actually observed (baseline 1.24 MB, kit +2.09 MB,
+# payment extension +5.46 MB), so they catch a collapse rather than tracking normal drift.
+MIN_BASELINE_BYTES=$((768 * 1024))
 MIN_KIT_OVER_BASELINE_BYTES=$((1024 * 1024))
 MIN_SDKPLUS_OVER_KIT_BYTES=$((1024 * 1024))
 
@@ -114,9 +116,13 @@ assert_plausible() {
     local baseline="$1" kit="$2" sdkplus="$3"
     local ok=true
 
-    if ((baseline > MAX_BASELINE_BYTES)); then
-        log "IMPLAUSIBLE: baseline APK is ${baseline} bytes, expected under ${MAX_BASELINE_BYTES}."
-        log "  The baseline flavor should depend on nothing -- check its dependencies."
+    # The baseline is a Compose + Material3 reference app. If R8 shrinks Compose out of it --
+    # because the reference screen stopped being reachable -- the baseline collapses towards an
+    # empty APK and every delta silently reverts to charging the kit for Compose.
+    if ((baseline < MIN_BASELINE_BYTES)); then
+        log "IMPLAUSIBLE: baseline APK is ${baseline} bytes, expected at least ${MIN_BASELINE_BYTES}."
+        log "  R8 has probably shrunk Compose out of the reference app -- check that"
+        log "  ReferenceAppActivity is still declared in the manifest and still renders."
         ok=false
     fi
     if ((kit - baseline < MIN_KIT_OVER_BASELINE_BYTES)); then

--- a/size-report-rokt/README.md
+++ b/size-report-rokt/README.md
@@ -1,0 +1,54 @@
+# Rokt SDK+ size report fixture
+
+Measures what the Rokt kit, and the `com.rokt:rokt-sdk-plus` umbrella (which adds the payment
+extension), add to a minified release APK. Results are posted to pull requests by
+`.github/workflows/rokt-size-report.yml`.
+
+This is a standalone Gradle build with its own wrapper and AGP, modelled on
+`kits/rokt/rokt/example/example-kotlin`. It has to be: the kit plugin wires kits to module
+coordinates rather than projects, and the Rokt SDK needs a newer AGP than the shared multi-kit
+build, so the umbrella can only be measured against published artifacts. `scripts/rokt-size-report.sh`
+publishes the chain to mavenLocal and then builds this fixture against it.
+
+Three flavours of one throwaway app, differing only in dependencies so that one
+`assembleRelease` produces every APK under one AGP/R8:
+
+| Flavour    | Dependencies                       | Yields                                        |
+| ---------- | ---------------------------------- | --------------------------------------------- |
+| `baseline` | the reference app                  | the floor                                     |
+| `kit`      | `+ com.mparticle:android-rokt-kit` | `kit - baseline` = Core + kit + Rokt SDK      |
+| `sdkplus`  | `+ com.rokt:rokt-sdk-plus`         | `sdkplus - kit` = the payment extension alone |
+
+## The reference app
+
+The baseline is a small Jetpack Compose + Material3 screen, not an empty app. The Rokt kit is
+Compose-based, so an empty baseline charged it for Compose that almost every partner app already
+ships — around 1.2 MB of the reported figure.
+
+**This dependency set is a convention, not a measured average.** Nobody surveyed real partner
+apps. Treat the number as "what the kit costs an app that looks roughly like this", and do not
+quote it to a partner as a typical or average figure.
+
+- `androidx.compose:compose-bom` — `ui`, `material3`
+- `androidx.activity:activity-compose`
+- `androidx.lifecycle:lifecycle-runtime-compose`
+- `androidx.appcompat:appcompat`
+- `androidx.core:core-ktx`
+
+The per-pull-request check in `size-report` deliberately keeps an **empty** baseline instead:
+`android-core` ships no Compose and no resources, so there is nothing a host app would already
+provide. The two numbers are produced by different builds and are not comparable with each other.
+
+`ReferenceAppActivity` has to keep rendering real Compose. If it stops being reachable, R8
+shrinks Compose out of the baseline, the baseline collapses towards an empty app, and every delta
+silently reverts to charging the kit for Compose. `scripts/rokt-size-report.sh` asserts the
+baseline stays above 768 KB to catch exactly that.
+
+## Running it locally
+
+```bash
+scripts/rokt-size-report.sh .    # publishes the chain, builds, prints one line of JSON
+```
+
+`--skip-build` measures APKs that are already built. Expect the publish chain to take a few
+minutes: it is three sequential Gradle invocations before this fixture is built at all.

--- a/size-report-rokt/build.gradle
+++ b/size-report-rokt/build.gradle
@@ -1,6 +1,10 @@
 plugins {
     id 'com.android.application' version '8.9.1'
     id 'org.jetbrains.kotlin.android' version '2.1.20'
+    // Module-level, not per-flavor: the Compose compiler cannot be scoped to a flavor, and it
+    // does not need to be -- it is compile-time only and contributes nothing to a flavor with
+    // no @Composable code. Version must track the Kotlin version above.
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.1.20'
 }
 
 // Standalone build, modelled on kits/rokt/rokt/example/example-kotlin: the Rokt SDK requires a
@@ -10,7 +14,7 @@ plugins {
 // Three flavors of one throwaway app, all built by this one toolchain so the deltas are
 // comparable:
 //
-//   baseline -> nothing                          the floor
+//   baseline -> the reference app alone          the floor
 //   kit      -> com.mparticle:android-rokt-kit    Core + kit-base + Rokt kit + Rokt SDK
 //   sdkplus  -> com.rokt:rokt-sdk-plus            the above plus the payment extension, so
 //                                                 sdkplus - kit is the payment extension alone
@@ -81,10 +85,25 @@ android {
     }
 
     lint { checkReleaseBuilds false }
-    buildFeatures { buildConfig false }
+    buildFeatures {
+        buildConfig false
+        compose true
+    }
 }
 
 dependencies {
+    // The reference app, shared by every flavor. Anything here is paid for by the baseline too,
+    // so it drops out of the deltas -- which is the point: a partner already ships this. The Rokt
+    // kit is Compose-based, so an empty baseline charged it for Compose the host already has.
+    // This set is a convention, not a measured average: see README.md.
+    implementation platform('androidx.compose:compose-bom:2026.05.01')
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'androidx.activity:activity-compose:1.10.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.8.7'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.material3:material3'
+
     // Transitively provides android-core, android-kit-base and com.rokt:roktsdk.
     kitImplementation "com.mparticle:android-rokt-kit:${mparticleVersion}"
     // Transitively provides android-core, android-rokt-kit, com.rokt:roktsdk and

--- a/size-report-rokt/src/main/AndroidManifest.xml
+++ b/size-report-rokt/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:label="size-report-rokt" />
+    <application android:label="size-report-rokt">
+        <!-- Declared so aapt's generated keep rules make it an R8 root; without that the whole
+             reference app is dead code and Compose is shrunk out of the baseline. -->
+        <activity
+            android:name=".ReferenceAppActivity"
+            android:exported="true" />
+    </application>
 </manifest>

--- a/size-report-rokt/src/main/java/com/mparticle/sizereport/ReferenceAppActivity.kt
+++ b/size-report-rokt/src/main/java/com/mparticle/sizereport/ReferenceAppActivity.kt
@@ -1,0 +1,65 @@
+package com.mparticle.sizereport
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * The reference app every flavor shares: a small Compose + Material3 screen standing in for the
+ * partner app the SDK is dropped into.
+ *
+ * It has to actually render -- theme, layout, list, state -- or R8 strips Compose out of the
+ * baseline, the baseline collapses back to an empty app, and every delta silently reverts to
+ * charging the SDK for Compose. `measure_size.sh` asserts the baseline stays large enough to
+ * prove that has not happened.
+ */
+class ReferenceAppActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                ReferenceScreen()
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReferenceScreen() {
+    var count by remember { mutableStateOf(0) }
+    val items = remember { List(20) { "Item ${it + 1}" } }
+
+    Scaffold(topBar = { TopAppBar(title = { Text("Reference app") }) }) { padding ->
+        Column(Modifier.padding(padding)) {
+            Button(onClick = { count++ }) {
+                Text("Tapped $count")
+            }
+            LazyColumn {
+                items(items) { item ->
+                    Card(Modifier.padding(8.dp)) {
+                        Text(item, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Follow-up to #798. A reviewer on the sibling Rokt SDK change asked for a "typical app size impact" — a figure for an app **already using Compose** — rather than the cost to an empty app.
- That applies here too: the Rokt kit is Compose-based, so the umbrella check's empty baseline charged it for Jetpack Compose that almost every partner app already ships. The reported figure was a bare-app upper bound rather than what an integrator actually pays.

## What Has Changed

**`size-report-rokt` (the umbrella check):** the baseline flavour is now a small Compose + Material3 app instead of an empty one, shared by every flavour, so each flavour differs from the baseline only by its SDK layer.

| Flavour | Dependencies | Yields |
|---|---|---|
| `baseline` | the reference app | the floor |
| `kit` | `+ com.mparticle:android-rokt-kit` | `kit - baseline` = Core + kit + Rokt SDK |
| `sdkplus` | `+ com.rokt:rokt-sdk-plus` | `sdkplus - kit` = the payment extension alone |

**The measured effect:**

| | Empty baseline (before) | Compose baseline (now) |
|---|---|---|
| mParticle Core + Rokt kit | 3.29 MB | **2.09 MB** |
| Payment extension, on top of the kit | 5.46 MB | 5.46 MB |

So ~1.2 MB of the previous figure was Compose a host app already provides. The payment extension did not move, which is the expected result — Stripe is not shared with the host.

**`size-report` (the per-PR Core check) deliberately keeps its empty baseline.** `android-core` ships no Compose and no `res/` at all, so there is nothing here that a host app would already provide; a Compose baseline would cost build time and change nothing. Both reports now state which baseline they used, since they are produced by different builds and are **not comparable with each other**.

**On scoping the Compose compiler:** it cannot be scoped to a flavour — `org.jetbrains.kotlin.plugin.compose` and `buildFeatures.compose` are module-level. It does not need to be, either: the compiler is compile-time only and contributes nothing to a flavour with no `@Composable` code. So it is applied module-wide while the dependencies stay per-flavour. No restructuring, no extra flavours, no extra builds.

**Also in this PR:**

- `size-report-rokt/README.md` records the reference app's dependency set.
- Thresholds retuned around the measured figures, and the umbrella baseline check is now a **floor** rather than a ceiling (see below).

## Screenshots/Video

- Rendered locally from real measurements of this branch:

```
### mParticle Core + Rokt kit

| Metric | Target branch | This PR | Change |
|---|---|---|---|
| APK size | 2.09 MB | 2.09 MB | 0 bytes |
| Download size | 2.08 MB | 2.08 MB | 0 bytes |
| Dex bytes | 5.38 MB | 5.38 MB | 0 bytes |

### Rokt SDK+ umbrella (adds the payment extension)

| Metric | Target branch | This PR | Change | On top of mParticle Core + Rokt kit |
|---|---|---|---|---|
| APK size | 7.55 MB | 7.55 MB | 0 bytes | +5.46 MB |
| Download size | 7.43 MB | 7.43 MB | 0 bytes | +5.35 MB |
| Dex bytes | 10.70 MB | 10.70 MB | 0 bytes | +5.32 MB |
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

Three judgement calls worth a reviewer's attention:

- **The reference app's dependency set is a convention, not a survey.** Nobody sampled real partner apps. The README says so plainly and the report labels it rather than calling it "typical" or "average", so 2.09 MB does not get quoted to a partner as a measured average. If the team wants a different dependency set, it is a one-block change — and every reported number moves with it.
- **The bare-app upper bound is gone** for the umbrella. Retaining it would mean a fourth flavour and a third table. I left it out as over-engineering, but it is cheap to add back.
- **The umbrella baseline threshold is now a floor, not a ceiling.** If `ReferenceAppActivity` ever stops being reachable, R8 shrinks Compose out of the baseline, the baseline collapses towards an empty app, and every delta silently reverts to charging the kit for Compose — the report would look correct and be wrong. The first run after the change caught its own stale ceiling and failed closed, which is the behaviour working as intended.

Other notes:

- **No fabricated delta on this PR.** The workflow copies the head revision's fixture into the base checkout, so both sides are measured with the new baseline.
- **R8 + Compose + Material3 had never run in this standalone build.** It needed no additional ProGuard rules — Compose ships its own consumer rules — but it was verified rather than assumed.
- **Local validation:** `trunk check` clean; `./gradlew test lint` green; both measure scripts ran end to end, including the three-publish umbrella chain.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- N/A
